### PR TITLE
Doc for 41919, 42149, and 49637

### DIFF
--- a/docs/api/rest/authn.md
+++ b/docs/api/rest/authn.md
@@ -378,6 +378,8 @@ deviceToken | A globally unique ID identifying the device of the user           
 
 You must always pass the same `deviceToken` for a user's device with every authentication request for **per-device** or **per-session** Sign-On Policy factor challenges.  If the `deviceToken` is absent or does not match the previous `deviceToken`, the user will still be challenged everytime instead of **per-device** or **per-session**.  It is recommend that you generate a UUID or GUID for each client and persist the `deviceToken` as a persistent cookie or HTML5 localStorage item scoped to your web application's origin.  The max length for `deviceToken` is 32 characters.
 
+> If you pass a device token, the factor verification is remembered to avoid additional MFA prompts when using the same device, unless the the organizational MFA policy requires an MFA challenge every time. The policy ultimately determines whether a user is challenged or not.
+
 #### Response Parameters
 {:.api .api-response .api-response-params}
 
@@ -1499,6 +1501,8 @@ Parameter    | Description                                         | Param Type 
 fid          | `id` of factor returned from enrollment             | URL        | String   | TRUE     |
 stateToken   | [state token](#state-token) for current transaction | Body       | String   | TRUE     |
 answer       | answer to security question                         | Body       | String   | TRUE     |
+
+> The factor verification is remembered to avoid additional MFA prompts when using the same [device token](#device-token). Even if the device is remembered, the organizational MFA policy can require an MFA challenge every time. The policy ultimately determines whether a user is challenged or not.
 
 ##### Response Parameters
 {:.api .api-response .api-response-params}

--- a/docs/api/rest/sessions.md
+++ b/docs/api/rest/sessions.md
@@ -65,6 +65,7 @@ cookieTokenUrl | URL for a a transparent 1x1 pixel image which contains a one-ti
 Creates a new session for a [user](users.html).
 
 - [Create Session with One-Time Token](#create-session-with-one-time-token)
+- [Create Session with Session Token](#create-session-with-session-token)
 - [Create Session with Embed Image URL](#create-session-with-embed-image-url)
 
 ##### Request Parameters
@@ -114,6 +115,52 @@ curl -v -H "Authorization: SSWS yourtoken" \
 ~~~
 
 Invalid credentials will return a `401 Unauthorized` status code.
+
+~~~ ruby
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+
+{
+    "errorCode": "E0000004",
+    "errorSummary": "Authentication failed",
+    "errorLink": "E0000004",
+    "errorId": "oaeVCVElsluRpii8PP4GeLYxA",
+    "errorCauses": []
+}
+~~~
+
+#### Create Session with Session Token
+{:.api .api-operation}
+
+Uses a [`sessionToken`](authn.html#session-token) created by the Auth API to set a session cookie in the user's browser.
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~ ruby
+curl -v -H "Authorization: SSWS yourtoken" \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-X POST "https://your-subdomain.okta.com/api/v1/sessions?additionalFields=cookieToken" \
+-d \
+'{
+  "sessionToken": "00Fpzf4en68pCXTsMjcX8JPMctzN2Wiw4LDOBL_9pz"
+}'
+~~~
+
+##### Response Example
+{:.api .api-response .api-response-example}
+
+~~~ json
+{
+  "id": "000rWcxHV-lQUOzBhLJLYTl0Q",
+  "userId": "00uld5QRRGEMJSSQJCUB",
+  "mfaActive": false,
+  "cookieToken": "00hbM-dbQNhKUtQY2lAl34Y0O9sHicFECHiTg3Ccv4"
+}
+~~~
+
+Invalid session tokens will return a `401 Unauthorized` status code.
 
 ~~~ ruby
 HTTP/1.1 401 Unauthorized


### PR DESCRIPTION
@tthompson-okta @lboyette-okta @croche-okta @stsai-okta @hoanguyen-okta @karlmcguinness-okta 

Authn.md contains changes for OKTA-42149 and OKTA-49367. Trevor suggested not documenting the rememberDevice paramater, as it is being deprecated. Instead, the doc is for 49367 that describes the default remembed behavior.

Sessions.md contains changes for OKTA-41919 about using a sessionToken created by the Auth API to create a session with the Sessions API.