### PR TITLE
Fixing broken links to the "Setting up a SAML application in Okta" example page

### DIFF
--- a/_source/docs/guides/pysaml2.md
+++ b/_source/docs/guides/pysaml2.md
@@ -40,7 +40,7 @@ Before you can configure your application and {{ page.saml_library }} set up an
 Okta "[chiclet](https://support.okta.com/articles/Knowledge_Article/27838096-Okta-Terminology)" (application icon) that enables an Okta user to sign in to your to your application with SAML and {{ page.saml_library }}.
 
 To set up Okta to connect to your application, follow the
-[setting up a SAML application in Okta](setting_up_a_saml_application_in_okta.html)
+[setting up a SAML application in Okta](../examples/setting_up_a_saml_application_in_okta.html)
 guide. As noted in the instructions, there are two steps to change:
 
 * *In step \#6*: Use ***{{ page.chiclet_name }}*** instead of ***Example SAML application*** .
@@ -96,7 +96,7 @@ the following steps, you will have a working example of connecting Okta to a sam
 
 5.  Be sure to replace the contents of `{metdata-url}` with the link
     that you copied in step \#10 of the
-    "[Setting up a SAML application in Okta](setting_up_a_saml_application_in_okta.html)"
+    "[Setting up a SAML application in Okta](../examples/setting_up_a_saml_application_in_okta.html)"
     instructions that you followed above!
 
     Note: The contents of `{metadata-url}` should look similar to: `https://example.oktapreview.com/app/a0b1c2deFGHIJKLMNOPQ/sso/saml/metadata`

--- a/docs/guides/pysaml2.html
+++ b/docs/guides/pysaml2.html
@@ -1879,7 +1879,7 @@ section titled “Configuring PySAML2 to work with Okta.”</p>
 Okta “<a href="https://support.okta.com/articles/Knowledge_Article/27838096-Okta-Terminology">chiclet</a>” (application icon) that enables an Okta user to sign in to your to your application with SAML and PySAML2.</p>
 
 <p>To set up Okta to connect to your application, follow the
-<a href="setting_up_a_saml_application_in_okta.html">setting up a SAML application in Okta</a>
+<a href="../examples/setting_up_a_saml_application_in_okta.html">setting up a SAML application in Okta</a>
 guide. As noted in the instructions, there are two steps to change:</p>
 
 <ul>
@@ -1955,7 +1955,7 @@ the following steps, you will have a working example of connecting Okta to a sam
   <li>
     <p>Be sure to replace the contents of <code>{metdata-url}</code> with the link
 that you copied in step #10 of the
-“<a href="setting_up_a_saml_application_in_okta.html">Setting up a SAML application in Okta</a>”
+“<a href="../examples/setting_up_a_saml_application_in_okta.html">Setting up a SAML application in Okta</a>”
 instructions that you followed above!</p>
 
     <p>Note: The contents of <code>{metadata-url}</code> should look similar to: <code>https://example.oktapreview.com/app/a0b1c2deFGHIJKLMNOPQ/sso/saml/metadata</code></p>


### PR DESCRIPTION
This uses relative paths to fix the broken links. If you prefer absolute links it can be changed.