### PR TITLE
Re-order SAML guidance, add link to SimpleSAMLphp.

### DIFF
--- a/_source/_data/docs.yml
+++ b/_source/_data/docs.yml
@@ -7,10 +7,11 @@
     - saml_guidance
     - oan_guidance
     - okta_mobile_connect
-    - spring_security_saml
-    - pysaml2
     - add_mfa
     - setting_up_a_saml_application_in_okta
+    - spring_security_saml
+    - pysaml2
+    - simplesamlphp
 
 # -- APIS
 - section: api/getting_started


### PR DESCRIPTION
The SimpleSAMLphp guidance has been available on the website for a while without being part of the navigation. Customers are asking for the guidance so I think we should add it to the sidebar. @benjaminwesson-okta 