### PR TITLE
Edits to Provisioning section

### DIFF
--- a/_source/docs/guides/oan_guidance.md
+++ b/_source/docs/guides/oan_guidance.md
@@ -48,20 +48,20 @@ Already part of the Okta App Network but looking for a more “go-to-market” p
 
 ## Provisioning
 
-Single sign-on is just one aspect of federation. First, an account for the user must be created to grant access to your application. In order to “automate” this process, your application should expose APIs to manage the account lifecycle that account creation, user profile updates, authorization settings (such as groups or roles), account deactivation, etc.
+Single sign-on is just one aspect of federation. First, an account for the user must be created to grant access to your application. In order to “automate” this process, your application should expose APIs to manage the account lifecycle such as user account creation, profile updates, authorization settings (such as groups or roles), account deactivation, etc.
 
 While many ISVs use proprietary APIs, Okta recommends that you implement your API using the [Simple Cloud Identity Management protocol](http://www.simplecloud.info/) (SCIM) which supports all of the key features needed in provisioning.
 
 
 ### Provisioning: Building an Integration with Okta
 
-With the new Cloud Provisioning Connector (CPC) Program, you can now build and support a provisioning integration between your application and Okta. At a high level, the CPC program let’s you choose between two technical approaches for building the integration, each with it’s own advantages:
+With the new Cloud Provisioning Connector (CPC) Program, you can now build and support a provisioning integration between your application and Okta, and make it easily available to customers via the Okta Application Network. At a high level, the CPC program let’s you choose between two technical approaches for building the integration, each with it’s own advantages:
 
 | | **Java Connector** | **SCIM**
 -------- | ----------- | --------
-**What is it?**  | Connector written in Java that takes Okta provisioning signals and translates them into your service’s User API. The Connector is built and managed by the ISV (you) and hosted in the Okta service. Typical development effort is ~1-3 man-weeks. | Okta's SCIM 1.1/2.0 Client will interface directly with compatible SCIM 1.1/2.0 Servers. The integration is just a template that is configured. No coding required.
+**What is it?**  | The Java SDK lets you write Java code that takes Okta provisioning signals and translates them into your service’s User API. This connector code is written and supported by the ISV (you) and hosted in the Okta service to complete the integration. Typical development effort is ~1-3 man-weeks. | Okta's SCIM 1.1/2.0 Client will interface directly with compatible SCIM 1.1/2.0 Servers. The integration is completed with a few configurations, such as the endpoint address and authentication method. No coding required.
 **Who is it designed for?** | ISVs with an existing proprietary API for user operations. You want maximum flexibility and do not plan on supporting the SCIM standard. | ISVs that: a) currently support the SCIM standard; b) plan to support the SCIM standard; c) don’t already have proprietary APIs for user operations.
-**How do I get started?** |Email <oan@okta.com> and express interest in developing using Java Connector. We’ll share the SDK and additional program details. **Note: We are only accepting a limited number of ISV partners into the Java Connector program to start.** Please try to share some details on customer demand and urgency (e.g. # of joint customers that would benefit, deployment deadlines) in your email. | Okta support for SCIM is coming in March 2016. If you are interested in being part of the SCIM Beta reply to <oan@okta.com> and we’ll add you to the list. We’ll reach back out with additional SCIM documentation and SCIM Beta details by March 2016.
+**How do I get started?** |Email <oan@okta.com> and express interest in developing using Java SDK. We’ll share the SDK and additional program details. **Note: We are only accepting a limited number of ISV partners into the Java SDK program to start.** Please try to share some details on customer demand and urgency (e.g. # of joint customers that would benefit, deployment deadlines) in your email. | Okta support for SCIM is coming in March 2016. If you are interested in being part of the SCIM Beta reply to <oan@okta.com> and we’ll add you to the list. We’ll reach back out with additional SCIM documentation and SCIM Beta details by March 2016.
 
 For more details, see the [Cloud Provisioning Connector Program Overview](https://www.okta.com/sites/default/files/cloud_provisioning_connector_program_overview_v1.pdf).
 


### PR DESCRIPTION
Rename "Java Connector" to "Java SDK", which is the official terminology. Update descriptions to be clearer.