### PR TITLE
Update docs with information on `updatePhone` and available factors list

### DIFF
--- a/_source/docs/api/resources/authn.md
+++ b/_source/docs/api/resources/authn.md
@@ -1315,6 +1315,8 @@ stateToken  | [state token](#state-token) for current transaction               
 factorType  | type of factor                                                                | Body        | [Factor Type](factors.html#factor-type)                      | TRUE     |
 provider    | factor provider                                                               | Body        | [Provider Type](factors.html#provider-type)                  | TRUE     |
 profile     | profile of a [supported factor](factors.html#supported-factors-for-providers) | Body        | [Factor Profile Object](factors.html#factor-profile-object)  | TRUE     |
+updatePhone | Set this to `true` to force enrollment of a new phone token.                  | Query       | Boolean                                                      | FALSE    | FALSE
+
 
 #### Response Parameters
 {:.api .api-response .api-response-params}
@@ -1468,6 +1470,30 @@ curl -v -X POST \
     ]
   }
 }
+~~~
+
+#### Force Enrollment of an Okta SMS Factor
+{:.api .api-operation}
+
+If the user configured a phone number for account recovery, that phone number must match the phone number used for a SMS factor.
+
+This behavior can be overridden by setting the `updatePhone` Query parameter to `true`.
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-d '{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
+  "factorType": "sms",
+  "provider": "OKTA",
+  "profile": {
+    "phoneNumber": "+1-415-555-1337"
+  }
+}' "https://${org}.okta.com/api/v1/authn/factors?updatePhone=true"
 ~~~
 
 #### Enroll Okta Verify TOTP Factor

--- a/_source/docs/api/resources/factors.md
+++ b/_source/docs/api/resources/factors.md
@@ -368,6 +368,28 @@ Specifies the status of a factor verification attempt
 | `ERROR`                | Unexpected server error occurred verifying factor.                                                                                  |
 |------------------------+-------------------------------------------------------------------------------------------------------------------------------------|
 
+#### SMS Object
+
+Specifies the status of an existing phone number. This object will be included as an embedded resource if a user has a verified phone number that has not yet been configured for MFA.
+
+|---------------+---------------------------------------------------+---------------------------------+----------+--------+----------|-----------|-----------+------------|
+| Property      | Description                                       | DataType                        | Nullable | Unique | Readonly | MinLength | MaxLength | Validation |
+| ------------- | ------------------------------------------------- | ------------------------------- | -------- | ------ | -------- | --------- | --------- | ---------- |
+| profile       | The profile for a `sms` factor.                   | [SMS Profile](#sms-profile)     | FALSE    | FALSE  | TRUE     |           |           |            |
+|---------------+---------------------------------------------------+---------------------------------+----------+--------+----------|-----------|-----------+------------|
+
+~~~json
+{
+  "phones": [{
+    "id": "abc0de1f2ghijkLMn3o4",
+    "profile": {
+      "phoneNumber": "+14155551212"
+    },
+    "status": "ACTIVE"
+  }]
+}
+~~~
+
 ## Factor Operations
 
 ### Get Factor
@@ -703,6 +725,18 @@ curl -v -X GET \
           ]
         }
       }
+    },
+    "status": "NOT_SETUP",
+    "_embedded": {
+      "phones": [
+        {
+          "id": "abc0de1f2ghijkLMn3o4",
+          "profile": {
+            "phoneNumber": "+14155551212"
+          },
+          "status": "ACTIVE"
+        }
+      ]
     }
   },
   {


### PR DESCRIPTION
Update API documentation to document the `updatePhone` query param for `POST /authn/factors`. Also show pre-registered phone number in the available factors list
