### PR TITLE
Include prerequisites in getting started steps

### DIFF
--- a/_source/docs/guides/pysaml2.md
+++ b/_source/docs/guides/pysaml2.md
@@ -69,6 +69,17 @@ section wuse the "Identity Provider metadata" link from the
 section above to configure {{ page.saml_library }}. After completing
 the following steps, you will have a working example of connecting Okta to a sample {{ page.programming_language }} application using {{ page.saml_library }}.
 
+0.  Install platform-dependent prerequisites:
+    
+    For Mac OS X:
+    ~~~ shell
+    brew install libffi libxmlsec1
+    ~~~
+
+    For RHEL:
+    ~~~ shell
+    sudo yum install libffi-devel xmlsec1 xmlsec1-openssl
+    ~~~
 
 1.  Download the example application for {{ page.programming_language }}:
 


### PR DESCRIPTION
On my OS X workstation I found that following the listed steps presented me with the following error:

```
saml2.sigver.SigverError
SigverError: Can't find ['xmlsec1']
```

That problem was remedied by running `brew install libxmlsec1`, but as a complete SAML neophyte it was not obvious that the `xmlsec1` PySAML could not find was a missing system-level dependency.