### PR TITLE
Updated authn.md

### DIFF
--- a/_source/docs/api/resources/authn.md
+++ b/_source/docs/api/resources/authn.md
@@ -1688,7 +1688,7 @@ curl -v -X POST \
 -d '{
   "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
   "factorType": "token:software:totp",
-  "provider": "OKTA"
+  "provider": "GOOGLE"
 }' "https://${org}.okta.com/api/v1/authn/factors"
 ~~~
 


### PR DESCRIPTION
Replaced typo ("OKTA" to "GOOGLE" provider type in Enroll Google Authenticator Factor" section)