### PR TITLE
Fixed response for call to change a user's creds provider to FEDERATION

### DIFF
--- a/_source/docs/api/resources/users.md
+++ b/_source/docs/api/resources/users.md
@@ -2167,7 +2167,7 @@ Generates a one-time token (OTT) that can be used to reset a user's password.  T
 
 This operation will transition the user to the status of `RECOVERY` and the user will not be able to login or initiate a forgot password flow until they complete the reset flow.
 
-**Note:** You can also use this API to convert a user with the Okta Credential Provider to a use a Federated Provider. After this conversion, the user cannot directly sign in with password. The second example demonstrate this usage.
+**Note:** You can also use this API to convert a user with the Okta Credential Provider to a use a Federated Provider. After this conversion, the user cannot directly sign in with password. The second example demonstrates this usage.
 
 ##### Request Parameters
 {:.api .api-request .api-request-params}
@@ -2226,9 +2226,7 @@ curl -v -X POST \
 {:.api .api-response .api-response-example}
 
 ~~~json
-{
-  "resetPasswordUrl": "https://your-domain.okta.com/reset_password/XE6wE17zmphl3KqAPFxO"
-}
+{}
 ~~~
 
 ### Expire Password


### PR DESCRIPTION
Based on my testing, the response doesn't include the password reset URL - it simply sends back an empty JSON :

`schandra$ curl -s -H "Authorization: SSWS <removed>"  -H "Accept: application/json"  -H "Content-Type: application/json"  -X POST "https://schandra.okta.com/api/v1/users/:uid/lifecycle/reset_password?provider=FEDERATION&sendEmail=false"
{}
schandra$`