### PR TITLE
Adds more documentation about the requirement for the state and nonce parameters

### DIFF
--- a/_source/docs/api/resources/oidc.md
+++ b/_source/docs/api/resources/oidc.md
@@ -107,7 +107,7 @@ Claims in the payload are independent of scope (always returned) or dependent on
 | auth_time | The time the end-user was authenticated, represented in Unix time (seconds).   | Integer    | 1311280970     |
 | amr     | JSON array of strings that are identifiers for [authentication methods](http://self-issued.info/docs/draft-jones-oauth-amr-values-00.html) used in the authentication.   | Array    | [ "pwd", "mfa", "otp", "kba", "sms", "swk", "hwk" ]     |
 | idp     | The id of the Identity Provider that the user authenticated to Okta with. (Used for Social Auth and Inbound SAML). If it was Okta, the value would be the OrgId.  | String    | "00ok1u7AsAkrwdZL3z0g3"    |
-| nonce     |  Value used to associate a Client session with an ID Token, and to mitigate replay attacks. This is only returned if <em>nonce</em> was present in the request that generated the ID Token.    |  String   | "n-0S6_WzA2Mj"  |
+| nonce     |  Value used to associate a Client session with an ID Token, and to mitigate replay attacks. |  String   | "n-0S6_WzA2Mj"  |
 | at_hash     | The base64URL-encoded first 128-bits of the SHA-256 hash of the Access Token. This is only returned if an Access Token is also returned with an ID Token.  | String    | "MTIzNDU2Nzg5MDEyMzQ1Ng"     |
 | c_hash  | The base64URL-encoded first 128-bits of the SHA-256 hash of the authorization code. This is only returned if an authorization code is also returned with the id_token. | String |    |
            
@@ -442,7 +442,7 @@ Clients MUST validate the ID token in the Token Response in the following manner
 2. Verify that the `aud` (audience) claim contains the `client_id` of your application.
 3. Verify the signature of the ID token according to [JWS](https://tools.ietf.org/html/rfc7515) using the algorithm specified in the JWT `alg` header parameter. Use the public keys provided by Okta via the [Discovery Document](#openid-discovery-document).
 4. Verify that the expiry time (from the `exp` claim) has not already passed.
-5. If a `nonce` value was sent in the Authentication Request, a `nonce` claim MUST be present and its value checked to verify that it is the same value as the one that was sent in the Authentication Request. The client should check the nonce value for replay attacks.
+5. A `nonce` claim MUST be present and its value checked to verify that it is the same value as the one that was sent in the Authentication Request. The client should check the nonce value for replay attacks.
 6. The client SHOULD check the `auth_time` claim value and request re-authentication using the `prompt=login` parameter if it determines too much time has elapsed since the last End-User authentication.
 
 Step 3 involves downloading the public JWKS from Okta (specified by the `jwks_uri` attribute in the [discovery document](#opendid-discovery-document)). The result of this call is a [JSON Web Key](https://tools.ietf.org/html/rfc7517) set.

--- a/_source/docs/api/resources/social_authentication.md
+++ b/_source/docs/api/resources/social_authentication.md
@@ -104,9 +104,17 @@ Advantages of using Okta Social Authentication include:
         After adding the `scope` and `response_type` parameters to
         your URL, it should look something like this:
         `https://example.okta.com/oauth2/v1/authorize?idp=0oa0bcde12fghiJkl3m4&client_id=AbcDE0fGHI1jk2LM34no&scope=openid%20email%20profile&response_type=id_token`
-    
-    3.  Add a `redirect_url` GET parameter to the Social Auth "Login
-        URL".
+    3.  Add the `state` and `nonce` GET parameters to the Social Auth Login URL.
+
+        The `state` parameter is a string that will be returned in the response which should be used to protect against cross-site request forgery (CSRF).
+        The `nonce` parameter is a string that will be included in the returned ID Token and should be used to associate a client session with an ID Token, and to mitigate replay attacks.
+
+        After adding the `scope` and `nonce` parameters to your URL it should look something like this:
+        `https://example.okta.com/oauth2/v1/authorize?idp=0oa0bcde12fghiJkl3m4&client_id=AbcDE0fGHI1jk2LM34no&scope=openid%20email%20profile&response_type=id_token&state=someState&nonce=someNonce`
+
+        To learn more about Okta's requirements for these parameters see the [Authorize Endpoint Parameter Details](/docs/api/resources/oidc.html#parameter-details).
+
+    4.  Add a `redirect_url` GET parameter to the Social Auth "Login URL".
         
         The last required GET parameter you need to add to your URL is
         the `redirect_url` parameter. The value of this GET parameter is
@@ -116,10 +124,10 @@ Advantages of using Okta Social Authentication include:
         
         After adding the `redirect_url` GET parameter to 
         your URL, it should look something like this:
-        `https://example.okta.com/oauth2/v1/authorize?idp=0oa0bcde12fghiJkl3m4&client_id=AbcDE0fGHI1jk2LM34no&scope=openid%20email%20profile&response_type=id_token&redirect_uri=https://app.example.com/social_auth`
+        `https://example.okta.com/oauth2/v1/authorize?idp=0oa0bcde12fghiJkl3m4&client_id=AbcDE0fGHI1jk2LM34no&scope=openid%20email%20profile&response_type=id_token&state=someState&nonce=someNonce&redirect_uri=https://app.example.com/social_auth`
         or, if you are logging your user into Okta, might look
         something like this:
-        `https://example.okta.com/oauth2/v1/authorize?idp=0oa0bcde12fghiJkl3m4&client_id=AbcDE0fGHI1jk2LM34no&scope=openid%20email%20profile&response_type=id_token&redirect_uri=https://example.okta.com`
+        `https://example.okta.com/oauth2/v1/authorize?idp=0oa0bcde12fghiJkl3m4&client_id=AbcDE0fGHI1jk2LM34no&scope=openid%20email%20profile&response_type=id_token&state=someState&nonce=someNonce&redirect_uri=https://example.okta.com`
     
 8.  Add the Social Auth Login URL to the page where you want to
     enable Social Auth.


### PR DESCRIPTION
- More fully note that the `nonce` parameter is now required.

- Add documentation to social-auth that reflects `nonce` and `state` being required.

Resolves: OKTA-89262

@federations-okta 
@mystiberry-okta 