### PR TITLE
Update authn.md

### DIFF
--- a/_source/docs/api/resources/authn.md
+++ b/_source/docs/api/resources/authn.md
@@ -1240,9 +1240,9 @@ HTTP/1.1 403 Forbidden
 Content-Type: application/json
 
 {
-  "errorCode": "E0000080",
-  "errorSummary": "The password does meet the complexity requirements of the current password policy.",
-  "errorLink": "E0000080",
+  "errorCode": "E0000014",
+  "errorSummary": "Update of credentials failed",
+  "errorLink": "E0000014",
   "errorId": "oaeuNNAquYEQkWFnUVG86Abbw",
   "errorCauses": [
     {


### PR DESCRIPTION
Faulty information given in this file. Error code E0000080 does not exist! Instead of that, the change password api returns a e0000014 error when updating the password failes if its not strong enough according to the security policy rules configured.