### PR TITLE
move platform RN to dev site

### DIFF
--- a/_source/_data/docs.yml
+++ b/_source/_data/docs.yml
@@ -1,3 +1,10 @@
+# -- Platform Release Notes
+- section: platform-release-notes/platform-release-notes.html
+  slug: Platform Release Notes
+  title: Platform Release Notes
+  pages:
+    - platform-relesae-notes
+
 # -- APIS
 - section: api/getting_started
   slug: api

--- a/_source/_includes/docs_nav.html
+++ b/_source/_includes/docs_nav.html
@@ -1,13 +1,16 @@
 {% assign section = page.url %}
-	<a {% if section contains "/api/" endif %} class="on" {% endif %} href="/docs/api/getting_started/design_principles.html">
+<a {% if section contains "/platform-release-notes/" endif %} class="on" {% endif %} href="/docs/platform-release-notes/platform-release-notes.html">
+		Platform Release Notes
+	</a>
+<a {% if section contains "/api/" endif %} class="on" {% endif %} href="/docs/api/getting_started/design_principles.html">
 		API
 	</a>
-	<a {% if section contains "/guides/" endif %} class="on" {% endif %} href="/docs/guides/saml_guidance.html">
+<a {% if section contains "/guides/" endif %} class="on" {% endif %} href="/docs/guides/saml_guidance.html">
 		Guides
 	</a>
-	<a {% if section contains "/examples/" endif %} class="on" {% endif %} href="/docs/examples/session_cookie.html">
+<a {% if section contains "/examples/" endif %} class="on" {% endif %} href="/docs/examples/session_cookie.html">
 		Examples
 	</a>
-	<a {% if section contains "/sdk/" endif %} class="on" {% endif %} href="/docs/sdk/core/api.html">
+<a {% if section contains "/sdk/" endif %} class="on" {% endif %} href="/docs/sdk/core/api.html">
 		SDKs
 	</a>

--- a/_source/_includes/footer.html
+++ b/_source/_includes/footer.html
@@ -31,6 +31,7 @@ a.async=true;a.type="text/javascript";b.parentNode.insertBefore(a,b)}, 1);
 		<ul>
 			<li><a href="http://www.okta.com" target="_blank">Okta.com</a></li>
 			<li><a href="/blog">Blog</a></li>
+			<li><a href="{{ "docs/platform-release-notes/platform-release-notes.html" | prepend: site.baseurl }}">Platform Release Notes</a></li>
 			<li><a href="{{ "terms/" | prepend: site.baseurl }}">Terms &amp; Conditions</a></li>
 			<li><a href="{{ "privacy/" | prepend: site.baseurl }}">Privacy Policy</a></li>
 			<li><a href="http://okta.com/developer/contact/">Contact Sales</a></li>

--- a/_source/_includes/header.html
+++ b/_source/_includes/header.html
@@ -5,6 +5,7 @@
 		<nav id="primary-nav" class="site-nav loaded">
 			<ul>
 				<li><a href="{{ "product/" | prepend: site.baseurl }}">Product</a></li>
+				<li><a href="{{ "docs/platform-release-notes/platform-release-notes.html" | prepend: site.baseurl }}">Platform Release Notes</a></li>
 				<li><a href="{{ "docs/api/getting_started/design_principles.html" | prepend: site.baseurl }}">Docs</a></li>
 				<li><a href="{{ "discussion/" | prepend: site.baseurl }}">Discussion</a></li>
 				<li class="has-dropdown"><a href="#">Support</a>

--- a/_source/docs/platform-release-notes/platform-release-notes.md
+++ b/_source/docs/platform-release-notes/platform-release-notes.md
@@ -1,0 +1,35 @@
+---
+layout: docs_page
+title: Platform Changes Available Wednesday, June 22, 2016
+---
+
+The Okta Platform adds new features and changes existing features to improve your experience, as well as fixing bugs.
+Features also move from Beta to Early Access to General Availability, and more rarely, are removed after end-of-life notifications.
+Okta platform changes delivered since the last Platform Release Note are listed here.
+
+## New Platform Feature: Limit on Size of Groups Claim
+    
+To protect against arbitrarily large numbers of groups matching the group filter, the group claim has a limit of 100. 
+If more than 100 groups match the filter, then the request fails.
+
+* For more information about configuring an app for OpenID Connect, including group claims, see [Using OpenID Connect](). 
+* For more information about group claims in the API, see [Scope-dependent claims](/docs/api/resources/oidc.html#scope-dependent-claims-not-always-returned).
+
+## Bugs Fixed
+
+The following issues are fixed:
+
+* OKTA-89624 – Base schema attributes for OpenID Connect without default mappings weren't included in ID token claims.
+* OKTA-89867 – Creating a new user and adding that user to a group with the same create request via the API failed, which was a problem for group-scoped User Admins creating users.
+* OKTA-90593 – The Group property <em>lastMembershipUpdated</em> wasn't updated when adding or removing users from an Active Directory group using scheduled import.
+* OKTA-90898 – Updating credentials failed when using the Apps API for custom apps.
+* OKTA-91066 – System log messages related to OpenID Connect didn't contain scopes.
+
+## Looking for Product Release Notes?
+
+For changes that affect the Okta user interface, see the [Release Notes Knowledge Hub](https://support.okta.com/help/articles/Knowledge_Article/Release-Notes-Knowledge-Hub).
+
+## Earlier Release Notes
+
+* [Platform Release Notes for the week ending Wednesday, June 15](platform-release-notes2016-24.html)
+* [Platform Release Notes for the week ending Wednesday, June 8](platform-release-notes2016-23.html)

--- a/_source/docs/platform-release-notes/platform-release-notes2016-23.md
+++ b/_source/docs/platform-release-notes/platform-release-notes2016-23.md
@@ -1,0 +1,33 @@
+---
+layout: docs_page
+title: Platform Release Notes June 8, 2016
+---
+
+Platform changes available after Wednesday, June 8, 2016
+
+The Okta Platform adds new features and changes existing features to improve your experience, as well as fixing bugs.
+Features also move from Beta to Early Access to General Availability, and more rarely, are removed after end-of-life notifications.
+All Okta platform changes are listed here. For product changes, see the Okta Product Release Notes.
+
+<!-- ## New Platform Feature -->
+
+### Looking for Product New Features?
+
+For changes that appear in the Okta user interface, see the [Release Notes Knowledge Hub](https://support.okta.com/help/articles/Knowledge_Article/Release-Notes-Knowledge-Hub).
+
+<!-- ## Enhancements -->
+
+<!-- ## Feature Status Changes -->
+
+## Bugs Fixed
+
+* OKTA-73691 – HTML tags were incorrectly allowed in POST and PUT requests to `/api/v1/idps/`.
+* OKTA-90218 – Requests to `/oauth2/v1/authorize` failed if they included a state value with special characters.
+* OKTA-91074 – Requests to `/oauth2/v1/introspect` incorrectly included scopesList.
+* OKTA-91441 – The Users API incorrectly returned an error when updating login. 
+
+## Return to Current Release Notes
+
+[Current Platform Release Notes](platform-release-notes.html)
+
+<!-- Platform Release Notes: 2016.23 -->

--- a/_source/docs/platform-release-notes/platform-release-notes2016-24.md
+++ b/_source/docs/platform-release-notes/platform-release-notes2016-24.md
@@ -1,0 +1,44 @@
+---
+layout: docs_page
+title: Platform Release Notes June 15, 2016
+---
+
+Platform changes available after Wednesday, June 15, 2016
+
+The Okta Platform adds new features and changes existing features to improve your experience, as well as fixing bugs.
+Features also move from Beta to Early Access to General Availability, and more rarely, are removed after end-of-life notifications.
+All Okta platform changes are listed here. For product changes, see the Okta Product Release Notes.
+
+## New Platform Feature
+
+### New Version of Okta Sign-In Widget
+Version 1.3.3 of the Okta Sign-In Widget, and version 1.0.2 of okta-auth-js are available for Preview orgs. For more information, see Okta Sign-In Widget.
+
+### Policy API
+The Links object, _links, is available in the Policy object. For more information, see Links Object.
+
+### Improved Error Descriptions
+The error descriptions related to OAuth provide more helpful information about invalid clients for OpenID Connect flows. 
+
+### Disable Automatic Key Rotation
+If you need to disable automatic key rotation for an OpenID Connect flow, you can do so in General Settings section under the General tab for an app, and then use the /oauth2/v1/keys endpoint to fetch public keys for your app. For more information, see OpenID Connect.
+
+
+### Looking for Product New Features?
+
+For changes that appear in the Okta user interface, see the [Release Notes Knowledge Hub](https://support.okta.com/help/articles/Knowledge_Article/Release-Notes-Knowledge-Hub).
+
+<!-- ## Enhancements -->
+
+<!-- ## Feature Status Changes -->
+
+## Bugs Fixed
+
+* OKTA-69173 – The <em>helpURL</em> for <em>vpn</em> wasn't returned even though it had been set previously in a request to `/api/v1/apps`.
+
+## Return to Current Release Notes
+
+[Current Platform Release Notes](platform-release-notes.html)
+
+<!-- Platform Release Notes: 2016.24 -->
+


### PR DESCRIPTION
There's one bug: for some reason, the headings under the title aren't being displayed in the table of contents. I'm not sure what's wrong--they were showing up at one point...?! Because the RN are short, I don't think this is a showstopping bug.

https://oktainc.atlassian.net/browse/OKTA-91805