### PR TITLE
Switched typekit to async mode

### DIFF
--- a/_source/_includes/head.html
+++ b/_source/_includes/head.html
@@ -28,7 +28,7 @@
 	{% if layout.js %}<script type="text/javascript" defer="defer" src="{{ "assets/js/" | prepend: site.baseurl | append: layout.js }}.js"></script>{% endif %}
 	<!-- TypeKit -->
 	<script src="//use.typekit.net/pls8pog.js"></script>
-	<script>try{Typekit.load();}catch(e){}</script>
+	<script>try{Typekit.load({async:true});}catch(e){}</script>
 	<!-- GA -->
 	<script>
 		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Typekit was doing blocking on load, this makes it async so other things can load. Initial tests show a 20-25% speed up in load times.

Ref:  http://blog.typekit.com/2015/08/04/new-embed-code-for-asynchronous-font-loading/