### PR TITLE
Add beta OIDC Playground tab

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
+    activesupport (4.2.7)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -18,9 +18,10 @@ GEM
     execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.13)
+    ffi (1.9.14)
     gemoji (2.1.0)
-    github-pages (86)
+    github-pages (89)
+      activesupport (= 4.2.7)
       github-pages-health-check (= 1.1.0)
       jekyll (= 3.1.6)
       jekyll-coffeescript (= 1.0.1)
@@ -29,11 +30,11 @@ GEM
       jekyll-github-metadata (= 2.0.2)
       jekyll-mentions (= 1.1.3)
       jekyll-paginate (= 1.1.0)
-      jekyll-redirect-from (= 0.10.0)
+      jekyll-redirect-from (= 0.11.0)
       jekyll-sass-converter (= 1.3.0)
       jekyll-seo-tag (= 2.0.0)
       jekyll-sitemap (= 0.10.0)
-      jemoji (= 0.6.2)
+      jemoji (= 0.7.0)
       kramdown (= 1.11.1)
       liquid (= 3.0.6)
       listen (= 3.0.6)
@@ -46,8 +47,8 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 1.4)
       typhoeus (~> 0.7)
-    html-pipeline (2.4.1)
-      activesupport (>= 2, < 5)
+    html-pipeline (2.4.2)
+      activesupport (>= 2)
       nokogiri (>= 1.4)
     i18n (0.7.0)
     jekyll (3.1.6)
@@ -71,16 +72,17 @@ GEM
       html-pipeline (~> 2.3)
       jekyll (~> 3.0)
     jekyll-paginate (1.1.0)
-    jekyll-redirect-from (0.10.0)
+    jekyll-redirect-from (0.11.0)
       jekyll (>= 2.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
     jekyll-seo-tag (2.0.0)
       jekyll (~> 3.1)
     jekyll-sitemap (0.10.0)
-    jekyll-watch (1.4.0)
+    jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    jemoji (0.6.2)
+    jemoji (0.7.0)
+      activesupport (~> 4.0)
       gemoji (~> 2.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
@@ -122,7 +124,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (= 86)
+  github-pages (= 89)
   json
 
 BUNDLED WITH

--- a/_source/_includes/docs_nav.html
+++ b/_source/_includes/docs_nav.html
@@ -14,3 +14,6 @@
 <a {% if section contains "/sdk/" endif %} class="on" {% endif %} href="/docs/sdk/core/api.html">
 		SDKs
 	</a>
+<a class="beta" href="/oidc_playground/index.html?beta=true">
+		OIDC Playground
+	</a>

--- a/_source/oidc_playground/index.md
+++ b/_source/oidc_playground/index.md
@@ -1,0 +1,7 @@
+---
+layout: docs_page
+---
+
+<html>
+<div>Hello World!</div>
+</html>


### PR DESCRIPTION
OKTA-96681

Doesn't behave super nicely since most links remove the beta=true query param but you can see the tab if you are in beta mode:

![image](https://cloud.githubusercontent.com/assets/13244399/17349190/ae57c032-58d0-11e6-920d-bca52ea96594.png)
![image](https://cloud.githubusercontent.com/assets/13244399/17349197/b69efed6-58d0-11e6-8f55-1835ddee25be.png)


@mystiberry-okta 
@federations-okta 