### PR TITLE
okta-97071 doc update

### DIFF
--- a/_source/docs/api/resources/oauth2.md
+++ b/_source/docs/api/resources/oauth2.md
@@ -439,9 +439,11 @@ Content-Type: application/json;charset=UTF-8
 
 <span class="api-uri-template api-uri-get"><span class="api-label">POST</span> /oauth2/v1/introspect</span>
 
-The API takes an Access Token, Refresh Token, or [ID Token](oidc.html#id-token) and returns whether it is active or not. 
+The API takes an Access Token or Refresh Token, and returns a boolean indicating whether it is active or not. 
 If the token is active, additional data about the token is also returned. If the token is invalid, expired, or revoked, it is considered inactive. 
 An implicit client can only introspect its own tokens, while a confidential client may inspect all access tokens.
+
+> Note; [ID Tokens](oidc.html#id-token) are also valid, however, they are usually validated on the service provider or app side of a flow.
 
 #### Request Parameters
 


### PR DESCRIPTION
Clarify that while ID Tokens are valid at introspection endpoint, Accces Tokens and Refresh Tokens are the intended uses.

@raphaellondner-okta  or @tthompson-okta , this section is missing request and response examples. Not sure I'm set up to create them, but if you supply the examples, I'll happily add them. Long term, will get set up properly so I can do these simple tasks.