### PR TITLE
Add links to .NET and Python SDKs for the Okta API

### DIFF
--- a/_source/_code/dotnet/powershell.md
+++ b/_source/_code/dotnet/powershell.md
@@ -1,0 +1,5 @@
+---
+title: Okta API PowerShell SDK
+excerpt: PowerShell bindings for the Okta API. <a href="https://github.com/okta/oktasdk-csharp/tree/master/Okta.Core.Automation/">Get started now</a>.
+github_url: https://github.com/okta/oktasdk-csharp
+---

--- a/_source/_code/dotnet/sdk.md
+++ b/_source/_code/dotnet/sdk.md
@@ -1,0 +1,5 @@
+---
+title: Okta API .NET SDK
+excerpt: .NET bindings for the Okta API. <a href="/docs/sdk/core/csharp_api_sdk/html/6af60b57-62fa-477c-a899-e2f21286c53d.htm/">Get started now</a>.
+github_url: https://github.com/okta/oktasdk-csharp
+---

--- a/_source/_code/python/sdk.md
+++ b/_source/_code/python/sdk.md
@@ -1,0 +1,5 @@
+---
+title: Okta API Python SDK
+excerpt: Python bindings for the Okta API. <a href="/docs/sdk/core/python_api_sdk/">Documentation here</a>.
+github_url: https://github.com/okta/oktasdk-python
+---


### PR DESCRIPTION
@raphaellondner-okta could you review the updates before we go live?

Here are what the changes would look like if they were to go live:

<img width="678" alt="_net___okta_developer" src="https://cloud.githubusercontent.com/assets/8584286/18803125/3b216dca-81a2-11e6-813f-4f1d084069d8.png">

<img width="678" alt="python___okta_developer" src="https://cloud.githubusercontent.com/assets/8584286/18803108/2750ec3a-81a2-11e6-833f-0d98690dd26c.png">
