### PR TITLE
36881 cb toc updates

### DIFF
--- a/_source/_includes/sidebar.html
+++ b/_source/_includes/sidebar.html
@@ -1,6 +1,18 @@
-        <aside class="Sidebar">
-        <h2 class="Sidebar-location Sidebar-toggle h6">HTTP Verbs</h3>
-           <div class="Sidebar-close Sidebar-toggle"></div>
+<aside class="Sidebar">
+	
+    <div class="Sidebar-toggle MenuToggle">
+		<svg width="28px" height="28px" viewBox="0 0 28 28" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+		    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+		        <circle class="MenuToggle-circle" stroke="#000000" cx="14" cy="14" r="13.5"></circle>
+		        <rect class="MenuToggle-line1" fill="#000000" x="5.5" y="8" width="17" height="2"></rect>
+		        <rect class="MenuToggle-line2" fill="#000000" x="5.5" y="13" width="17" height="2"></rect>
+		        <rect class="MenuToggle-line3" fill="#000000" x="5.5" y="13" width="17" height="2"></rect>
+		        <rect class="MenuToggle-line4" fill="#000000" x="5.5" y="18" width="17" height="2"></rect>
+		    </g>
+		</svg>
+
+    </div>
+    
 	   <div>
 	     <h3 class="Sidebar-title">Use Cases</h3>
 	     <ul class="Sidebar-nav">

--- a/_source/_sass/okta/components/_Header.scss
+++ b/_source/_sass/okta/components/_Header.scss
@@ -12,7 +12,7 @@
 	nav {
 		width: 100%;
 		height: 100px;
-		padding: 40px 20px;
+		padding: 40px 0;
 
 		ul {
 			float: right;
@@ -157,7 +157,7 @@
 	.logo {
 		display: inline-block;
 		top: 30px;
-		left: 30px;
+		left: 40px;
 		position: absolute;
 
 		a {
@@ -198,7 +198,7 @@
 		#mobile-nav {
 			display: block;
 			position: absolute;
-			right: 25px;
+			right: 40px;
 			top: 25px;
 
 			#mobile-search {

--- a/_source/_sass/okta/components/_MenuToggle.scss
+++ b/_source/_sass/okta/components/_MenuToggle.scss
@@ -1,0 +1,55 @@
+.MenuToggle {
+	cursor: pointer;
+	display: block;
+	height: 28px;
+	position: relative;
+	width: 28px;
+	
+	> svg {
+		//@include transition(opacity normal, transform normal);
+		display: block;
+		height: 28px;
+		width: 28px;
+	}
+	
+	&-circle {
+		//@include transition(stroke normal);
+		stroke: get-color('default');
+	}
+	
+	&-line1,
+	&-line2,
+	&-line3,
+	&-line4 {
+		//@include transition(fill normal, opacity normal, transform normal);
+		fill: get-color('default');
+		transform-origin: center;
+	}
+	
+	.is-active > & > svg,
+	&.is-active > svg {
+		transform: rotate(90deg);
+	}
+	
+	.is-active > & &-line1,
+	&.is-active &-line1 {
+		opacity: 0;
+		transform: translate(0, 5px);
+	}
+	
+	.is-active > & &-line2,	
+	&.is-active &-line2 {
+		transform: rotateZ(-45deg);
+	}
+	
+	.is-active > & &-line3,	
+	&.is-active &-line3 {
+		transform: rotateZ(45deg);
+	}
+	
+	.is-active > & &-line4,
+	&.is-active &-line4 {
+		opacity: 0;
+		transform: translate(0, -5px);
+	}
+}

--- a/_source/_sass/okta/components/_PageContent.scss
+++ b/_source/_sass/okta/components/_PageContent.scss
@@ -14,7 +14,7 @@
 	}
 	
 	&-main {
-		@include padding(0 large large);
+		@include padding(0 large);
 		flex-grow: 1;
 		overflow: auto;
 		
@@ -710,7 +710,7 @@
 		padding-left: get-spacing('medium');
 		
 		&-main {
-			@include padding(large medium);
+			@include padding(0 medium);
 		}
 	}
 }

--- a/_source/_sass/okta/components/_PageContent.scss
+++ b/_source/_sass/okta/components/_PageContent.scss
@@ -1,12 +1,20 @@
 .PageContent {
 	@extend %Wrap;
+	@include padding(large 0);
+	box-sizing: border-box;
 	display: flex;
 	max-width: $site-width + get-spacing('medium') * 2;
-	padding: 0;
+	overflow: hidden;
+	position: relative;
 	width: 100%;
+	z-index: 10;
+	
+	&.has-tableOfContents {
+		padding-right: 240px;
+	}
 	
 	&-main {
-		@include padding(large);
+		@include padding(0 large large);
 		flex-grow: 1;
 		overflow: auto;
 		
@@ -697,13 +705,25 @@
 	}
 }
 
-@include media("<=medium") {
+@include media('<medium') {
 	.PageContent {
-		display: block;
-
+		padding-left: get-spacing('medium');
+		
 		&-main {
-			@include padding(medium small);
-			flex-grow: 1;
+			@include padding(large medium);
+		}
+	}
+}
+
+@include media('<small') {
+	.PageContent {
+		&.has-tableOfContents {
+			flex-direction: column;
+			padding-right: 0;
+		}
+		
+		&.has-tableOfContents &-main {
+			width: 100%;
 		}
 	}
 }

--- a/_source/_sass/okta/components/_Sidebar.scss
+++ b/_source/_sass/okta/components/_Sidebar.scss
@@ -1,6 +1,7 @@
 .Sidebar {
 	@include padding(large medium);
 	background: get-color('gray-lightest');
+	margin: get-spacing('-large') 0;
 	min-width: 280px;
 	position: relative;
 	width: 320px;
@@ -75,8 +76,8 @@
 			}
 		}
 	}
-
-	&-location {
+	
+	&-toggle {
 		display: none;
 	}
 }
@@ -84,56 +85,33 @@
 
 @include media("<=medium") {
 	.Sidebar {
-		@include padding(x-small small x-small 0);
-		background: get-color('white');
-		min-width: 100%;
-		position: relative;
-		clear:both;
-		width: 100%;
-		height: auto;
-		border-bottom: solid 3px get-color('gray-light');
-		z-index: 100;
-		position: relative;
-
-		&-close {
-			@include transition(normal transform);
-			background: url('#{$asset-path}/img/icons/close.svg') no-repeat center;
-			cursor: pointer;
-			position: absolute;
-			width: 22px;
-			height: 22px;
-			z-index: 3;
-			right: get-spacing('small');
-			top: 14px;
-		}
-
-		&-location {
-			@include margin(0 small);
-			color: get-color('blue-bright');
+		@include transition(transform normal);
+		bottom: 0;
+		left: 0;
+		margin-top: 0;
+		position: fixed;
+		transform: translateX(-320px);
+		top: 100px;
+		z-index: 20;
+		
+		&-toggle {
 			display: block;
-			cursor: pointer;
-		}
-
-		h3,
-		ul {
-			display: none;
-		}
-
-		&-active {
-			@include padding(small);
-			
-			h3,
-			ul {
-				display: block;
-			}
+			height: 28px;
+			position: fixed;
+			right: get-spacing('-medium');
+			top: get-spacing('large') + 8;
+			transform: translate(50%, 0);
+			width: 28px;
 		}
 		
-		&-active &-close {
-			transform: rotate(180deg);
+		&.is-active {
+			transform: translateX(0);
 		}
 		
-		&-active &-location {
-			display: none;
+		&.is-active &-toggle {
+			right: get-spacing('medium');
+			top: get-spacing('medium');
+			transform: translate(50%, -50%);
 		}
 	}
 }

--- a/_source/_sass/okta/components/_TableOfContents.scss
+++ b/_source/_sass/okta/components/_TableOfContents.scss
@@ -1,29 +1,21 @@
 .TableOfContents {
+	@include padding(large medium large 0);
 	@include transition(transform normal);
 	align-self: flex-start;
+	bottom: 0;
 	left: calc(50% + #{$site-width * 0.5 - 200});
-	padding-left: get-spacing('small');
+	overflow: auto;
 	position: fixed;
-	top: 100px + get-spacing('large');
-	width: 200px;
+	top: 100px;
+	width: 200px + get-spacing('medium');
 	z-index: 1000;
-	
-	&:before {
-		background: get-color('gray-light');
-		bottom: get-spacing('large');
-		content: '';
-		display: block;
-		left: 0;
-		position: absolute;
-		top: get-spacing('large');
-		width: 1px;
-	}
 	
 	&-indicator {
 		@include transition(height normal, transform normal);
 		background: get-color('blue-bright');
 		height: (get-spacing('xx-small') * 2) + 20;
 		left: 0;
+		margin-top: 25px + get-spacing('large');
 		position: absolute;
 		top: 0;
 		width: 1px;
@@ -47,9 +39,7 @@
 	}
 
 	.is-level1 {
-		background: get-color('white');
 		font-weight: bold;
-		margin-left: get-spacing('-small');
 		padding-top: get-spacing('small');
 		
 		&:nth-child(2) {
@@ -57,16 +47,40 @@
 		}
 	}
 	
+	.is-level2 {
+		padding-left: get-spacing('small');
+	}
+	
+	.is-level3 {
+		padding-left: get-spacing('small') * 2;
+		
+		&:before {
+			left: get-spacing('small');
+		}
+	}
+	
 	.is-level4 {
-		margin-left: get-spacing('small');
+		padding-left: get-spacing('small') * 3;
+		
+		&:before {
+			left: get-spacing('small') * 2;
+		}
 	}
 	
 	.is-level5 {
-		margin-left: get-spacing('small') * 2;
+		padding-left: get-spacing('small') * 4;
+		
+		&:before {
+			left: get-spacing('small') * 3;
+		}
 	}
 	
 	.is-level6 {
-		margin-left: get-spacing('small') * 3;
+		padding-left: get-spacing('small') * 5;
+		
+		&:before {
+			left: get-spacing('small') * 4;
+		}
 	}
 
 	.is-level2,
@@ -74,6 +88,7 @@
 	.is-level4,
 	.is-level5,
 	.is-level6 {
+		border-left: 1px solid get-color('gray-light');
 		cursor: pointer;
 	}
 	
@@ -81,8 +96,6 @@
 	.is-level4,
 	.is-level5,
 	.is-level6 {
-		padding-left: get-spacing('small');
-		
 		&:before {
 			@include transition(border normal);
 			border: 1px solid get-color('gray-medium');
@@ -90,7 +103,6 @@
 			content: '';
 			display: block;
 			height: 6px;
-			left: 0;
 			position: absolute;
 			top: get-spacing('xx-small') + 6;
 			width: 6px;
@@ -109,7 +121,7 @@
 @include media('<1360px') {
 	.TableOfContents {
 		left: inherit;
-		right: get-spacing('medium');
+		right: 0;
 	}
 }
 

--- a/_source/_sass/okta/components/_TableOfContents.scss
+++ b/_source/_sass/okta/components/_TableOfContents.scss
@@ -1,0 +1,156 @@
+.TableOfContents {
+	@include transition(transform normal);
+	align-self: flex-start;
+	left: calc(50% + #{$site-width * 0.5 - 200});
+	padding-left: get-spacing('small');
+	position: fixed;
+	top: 100px + get-spacing('large');
+	width: 200px;
+	z-index: 1000;
+	
+	&:before {
+		background: get-color('gray-light');
+		bottom: get-spacing('large');
+		content: '';
+		display: block;
+		left: 0;
+		position: absolute;
+		top: get-spacing('large');
+		width: 1px;
+	}
+	
+	&-indicator {
+		@include transition(height normal, transform normal);
+		background: get-color('blue-bright');
+		height: (get-spacing('xx-small') * 2) + 20;
+		left: 0;
+		position: absolute;
+		top: 0;
+		width: 1px;
+		z-index: 10;
+	}
+	
+	&-item {
+		@include font-size('small');
+		@include padding(xx-small 0);
+		@include transition(color normal);
+		display: block;
+		line-height: 20px;
+		position: relative;
+		
+		&,
+		&:active
+		&:hover {
+			@include color('default');
+			text-decoration: none;
+		}
+	}
+
+	.is-level1 {
+		background: get-color('white');
+		font-weight: bold;
+		margin-left: get-spacing('-small');
+		padding-top: get-spacing('small');
+		
+		&:nth-child(2) {
+			padding-top: 0;
+		}
+	}
+	
+	.is-level4 {
+		margin-left: get-spacing('small');
+	}
+	
+	.is-level5 {
+		margin-left: get-spacing('small') * 2;
+	}
+	
+	.is-level6 {
+		margin-left: get-spacing('small') * 3;
+	}
+
+	.is-level2,
+	.is-level3,
+	.is-level4,
+	.is-level5,
+	.is-level6 {
+		cursor: pointer;
+	}
+	
+	.is-level3,
+	.is-level4,
+	.is-level5,
+	.is-level6 {
+		padding-left: get-spacing('small');
+		
+		&:before {
+			@include transition(border normal);
+			border: 1px solid get-color('gray-medium');
+			border-radius: 100%;
+			content: '';
+			display: block;
+			height: 6px;
+			left: 0;
+			position: absolute;
+			top: get-spacing('xx-small') + 6;
+			width: 6px;
+		}
+	}
+	
+	.is-active {
+		@include color('blue-bright');
+		
+		&:before {
+			border-color: get-color('blue-bright');
+		}
+	}
+}
+
+@include media('<1360px') {
+	.TableOfContents {
+		left: inherit;
+		right: get-spacing('medium');
+	}
+}
+
+@include media('<small') {
+	.TableOfContents {
+		@include padding(8px medium 0);
+		order: -1;
+		position: static;
+		width: 100%;
+		z-index: 10;
+		
+		&:before {
+			display: none;
+		}
+		
+		&-indicator {
+			display: none;
+		}
+		
+		.is-level1 {
+			margin-left: 0;
+			margin-top: 8px;
+		}
+		
+		.is-level4,
+		.is-level5,
+		.is-level6 {
+			display: none;
+		}
+		
+		.is-level1,
+		:last-child {
+			border-bottom: 1px solid get-color('gray-light');
+		}
+		
+		.is-active {
+			@include color('default');
+			
+			&:before {
+				border-color: get-color('gray-medium');
+			}
+		}
+	}
+}

--- a/_source/assets/css/okta.scss
+++ b/_source/assets/css/okta.scss
@@ -20,6 +20,7 @@
 	'okta/components/ProductSection.scss',
 	'okta/components/Header.scss',
 	'okta/components/PageContent.scss',
+	'okta/components/MenuToggle',
 	'okta/components/misc.scss',
 	'okta/components/Sidebar.scss',
 	'okta/components/Forms.scss',
@@ -27,6 +28,7 @@
 	'okta/components/Hero.scss',
 	'okta/components/SideBySidePromo.scss',
 	'okta/components/IconTiles.scss',
+	'okta/components/TableOfContents',
 	
 	'okta/global/fontawesome',
 	'okta/global/fontello',

--- a/_source/assets/js/docs.js
+++ b/_source/assets/js/docs.js
@@ -48,4 +48,179 @@ $(function() {
 			$('html,body').scrollTop(target.offset().top - fixedNavHeight);
 		}
 	};
+	
+	
+	$(document).ready(function() {
+		
+		var offset     = 140;
+		var headerData = [];
+		
+		var $window    = $(window);
+		var $body      = $('html, body');
+		var $footer    = $('.footer');
+		var $header    = $('#header');
+		var $page      = $('.PageContent');
+		var $sidebar   = $('.Sidebar');
+		var $content   = $('.PageContent-main');
+		var $headers   = [];
+		var $toc       = $('<div>').addClass('TableOfContents').appendTo($page);
+		var $tocItems  = [];
+		var $indicator = $('<div>').addClass('TableOfContents-indicator').appendTo($toc);
+		
+		var buildTOC = function() {
+			
+			var $items   = $('h1, h2, h3, h4, h5, h6', $content);
+			var pageEle  = $page[0];
+			var pageRect = pageEle.getBoundingClientRect();
+			
+			$.each($items, function(index, value) {
+				
+				var $this = $items.eq(index);
+				var level = $this.prop('tagName').substr(1, 2);
+				var text = $this.text();
+				var thisEle = $this[0];
+				var thisRect = thisEle.getBoundingClientRect();
+				var sectionHeight = 0;
+				var $menuItem;
+				
+				if (index < $items.length - 1) {
+					var nextEle = $items.eq(index + 1)[0];
+					var nextRect = nextEle.getBoundingClientRect();
+					sectionHeight = nextRect.top - thisRect.top;
+				} else {
+					sectionHeight = pageRect.bottom - thisRect.top;
+				}
+				
+				if (level == 1) {
+					$menuItem = $('<div>');
+				} else {
+					$menuItem = $('<a>').attr('href', '#' + $this.attr('id'));
+				}
+				
+				$menuItem
+					.data('level', level)
+					.addClass('TableOfContents-item')
+					.addClass('is-level' + level)
+					.text(text);
+				
+				$toc.append($menuItem);
+				
+				if (level > 1) {
+					$menuItem.on('click', goToSection.bind($this[0]));
+					
+					if ($headers.length) {
+						$headers = $headers.add($this);
+						$tocItems = $tocItems.add($menuItem);
+					} else {
+						$headers = $this;
+						$tocItems = $menuItem;
+					}
+				}
+				
+				headerData.push({
+					'headerEle': $this[0],
+					'menuItemEle': $menuItem[0],
+					'height': sectionHeight
+				});
+				
+			});
+			
+		};
+		
+		var init = function() {
+			$page.addClass('has-tableOfContents');
+		};
+		
+		var goToSection = function() {
+			$body.animate({
+				scrollTop: $(this).offset().top - offset
+			});
+		};
+		
+		var onScroll = function() {
+			
+			var sectionOffset = 0;
+			
+			for (var i = 0; i < headerData.length; i++) {
+				var ele = headerData[i].headerEle;
+				var rect = ele.getBoundingClientRect();
+				
+				if (rect.top >= offset) {
+					setActiveItem(i);
+					break;
+				}
+				
+				sectionOffset += headerData[i].height;
+			}
+			
+		};
+		
+		var setActiveItem = function(i) {
+			
+			var $activeItem = $($tocItems[i]);
+			var nextClasses = [];
+			
+			for (var i = $activeItem.data('level'); i > 0; i--) {
+				nextClasses.push('.is-level' + i);
+			}
+			
+			var $nextItem = $activeItem.nextAll(nextClasses.join(', ')).eq(0);
+			
+			var firstEle = $tocItems[0];
+			var firstRect = firstEle.getBoundingClientRect();
+			
+			var activeEle = $activeItem[0];
+			var activeRect = activeEle.getBoundingClientRect();
+			
+			var tocEle = $toc[0];
+			var tocRect = tocEle.getBoundingClientRect();
+			
+			var tocOffset = activeRect.top - tocRect.top;
+			var maxOffset = (tocRect.bottom - tocRect.top) - ($window.height() - $header.outerHeight() - $footer.outerHeight() - 120);
+			
+			if (tocOffset > maxOffset) {
+				tocOffset = maxOffset;
+			}
+			
+			var nextEle;
+			var nextRect;
+			var scale;
+			var marginTop = 0;
+			var indicatorOffset = (activeRect.top - firstRect.top);
+			
+			if ($nextItem.length) {
+				nextEle = $nextItem[0];
+				nextRect = nextEle.getBoundingClientRect();
+				scale = (nextRect.top - activeRect.top);
+			} else {
+				scale = (activeRect.bottom - activeRect.top);
+			}
+			
+			if ($('.is-level1:nth-child(2)', $toc).length == 1) {
+				marginTop = 25;
+			}
+			
+			$indicator.css({
+				'height': scale + 'px',
+				'marginTop': marginTop,
+				'transform': 'translate(0, ' + indicatorOffset + 'px)'
+			});
+			
+			$tocItems.removeClass('is-active');
+			$activeItem.addClass('is-active');
+			
+			$toc.css({
+				transform: 'translateY(-' + tocOffset + 'px)'
+			});
+			
+		};
+		
+		$(window).on('scroll', onScroll);
+		$(window).on('resize', onScroll);
+		
+		buildTOC();
+		init();
+		onScroll();
+		
+	});
 }());

--- a/assets/js/okta.js
+++ b/assets/js/okta.js
@@ -1,2 +1,224 @@
-!function e(t,a,n){function o(r,s){if(!a[r]){if(!t[r]){var c="function"==typeof require&&require;if(!s&&c)return c(r,!0);if(i)return i(r,!0);var l=new Error("Cannot find module '"+r+"'");throw l.code="MODULE_NOT_FOUND",l}var d=a[r]={exports:{}};t[r][0].call(d.exports,function(e){var a=t[r][1][e];return o(a?a:e)},d,d.exports,e,t,a,n)}return a[r].exports}for(var i="function"==typeof require&&require,r=0;r<n.length;r++)o(n[r]);return o}({1:[function(e,t,a){!function(e){e.fn.extend({fbTabber:function(t){var a=t;return this.each(function(){var t=0,n=e("a",this),o=n.eq(0),i=n.eq(0);n.each(function(){e(this).data("index",++t)}),n.click(function(t){t.preventDefault(),i=o,o=e(this),i!==o&&(n.removeClass("active"),e(this).addClass("active"),"function"==typeof a.onClick&&a.onClick(o,i))})})}})}(jQuery)},{}],2:[function(e,t,a){!function(e){}(jQuery)},{}],3:[function(e,t,a){!function(e){e("#cors-test").delegate(":button","click",function(t){t.preventDefault();var a=e("#input-orgUrl").val();0!==a.indexOf("http://")&&0!==a.indexOf("https://")&&(a="https://"+a),e.ajax({url:a+"/api/v1/users/me",type:"GET",accept:"application/json",xhrFields:{withCredentials:!0}}).done(function(t){var a=_.template(e("#template-profile").html(),{user:t});e("#cors-test-result").html(a)}).fail(function(t,a,n){var o,i;switch(t.status){case 0:o="Cross-Origin Request Blocked",i="You must explictly add this site ("+window.location.origin+") to the list of allowed websites in your Okta Admin Dashboard";break;case 403:o=t.responseJSON.errorSummary,i="Please login to your Okta organization before running the test";break;default:o=t.responseJSON?t.responseJSON.errorSummary:t.statusText}e("#cors-test-result").html(e("<div>",{"class":"alert alert-danger",html:"<strong>"+o+":</strong> "+i||""}))})})}(jQuery)},{}],4:[function(e,t,a){!function(e){e(".mobile-toggle").click(function(){return e("body").toggleClass("mobile-nav-active"),!1}),e("#top-nav .SearchIcon").on("click",function(t){e(this).parent().toggleClass("search-active"),e("#top-nav #q").focus()}),e("#top-nav .has-dropdown > a").on("click",function(t){t.preventDefault(),t.stopPropagation(),e(this).parent().toggleClass("dropdown-active")}),e(".Sidebar-toggle").on("click",function(t){t.stopPropagation(),e(this).parent().toggleClass("Sidebar-active")}),e("#top-nav .has-dropdown > .dropdown-window, #top-nav #q, .Sidebar h2").on("click",function(e){e.preventDefault(),e.stopPropagation()}),e("#top-nav .has-dropdown > .dropdown-window a, #top-nav .SearchIcon, .Sidebar a").on("click",function(e){e.stopPropagation()}),e(window).bind("click",function(){e("#top-nav .has-dropdown").removeClass("dropdown-active"),e("#top-nav.search-active").removeClass("search-active")}),e("header, .Sidebar").bind("click",function(){e(".Sidebar.Sidebar-active").removeClass("Sidebar-active")})}(jQuery)},{}],5:[function(e,t,a){!function(e){var t=e("html[class*=ie]").length>0;e(".tabber").each(function(){e(this).fbTabber({onClick:function(a,n){var o=n.data("index"),i=a.data("index"),r=e(n.attr("href")),s=e(a.attr("href"));t||(r.removeClass("fadeInLeft").removeClass("fadeInRight").removeClass("fadeOutLeft").removeClass("fadeOutRight").removeClass("animated"),s.removeClass("fadeInLeft").removeClass("fadeInRight").removeClass("fadeOutLeft").removeClass("fadeOutRight").removeClass("animated")),r.css({display:"block",position:"relative",zIndex:5}),s.css({display:"block",position:"relative",zIndex:10}),t||(i>o?(s.addClass("fadeInRight"),r.addClass("fadeOutLeft")):i<o&&(s.addClass("fadeInLeft"),r.addClass("fadeOutRight")),s.addClass("animated"),r.addClass("animated")),t&&r.css({display:"none"})}})})}(jQuery)},{}]},{},[1,2,3,4,5]);
-//# sourceMappingURL=master.js.map
+//Tabber
+(function($)  {
+	
+	$.fn.extend({
+		
+		fbTabber: function(_options) {
+			
+			var options = _options;
+		
+			return this.each(function() {
+				
+				var index = 0;
+				var $tabs = $("a", this);
+				var $currentTab = $tabs.eq(0);
+				var $previousTab = $tabs.eq(0);
+				
+				$tabs.each(function() {
+					
+					$(this).data("index", ++index);
+					
+				});
+			
+				$tabs.click(function(e) {
+					
+					e.preventDefault();
+			
+					$previousTab = $currentTab;
+					$currentTab = $(this);
+			
+					if ($previousTab !== $currentTab) {
+						
+						$tabs.removeClass("active");
+						$(this).addClass("active");
+						
+						if (typeof options.onClick === "function") {
+							
+							options.onClick($currentTab, $previousTab);
+							
+						}
+						
+					}
+			
+				});
+				
+			});
+		
+		}
+		
+	});
+	
+})(jQuery);
+
+
+
+// Forms
+(function($) {
+
+    $('#cors-test').delegate(':button', "click", function(e) {
+        e.preventDefault();
+        var orgUrl = $('#input-orgUrl').val();
+        if (orgUrl.indexOf('http://') !== 0 && orgUrl.indexOf('https://') !== 0) {
+            orgUrl = 'https://' + orgUrl;
+        }
+
+        $.ajax({
+            url: orgUrl + '/api/v1/users/me',
+            type: 'GET',
+            accept: 'application/json',
+            xhrFields: { withCredentials: true }
+        }).done(function(data) {
+            var output = _.template($('#template-profile').html(), { user: data });
+            $('#cors-test-result').html(output);
+        }).fail(function(xhr, textStatus, error) {
+            var title, message;
+            switch (xhr.status) {
+                case 0 :
+                    title = 'Cross-Origin Request Blocked';
+                    message = 'You must explictly add this site (' + window.location.origin + ') to the list of allowed websites in your Okta Admin Dashboard';
+                    break;
+                case 403 :
+                    title = xhr.responseJSON.errorSummary;
+                    message = 'Please login to your Okta organization before running the test';
+                    break;
+                default :
+                    title = xhr.responseJSON ? xhr.responseJSON.errorSummary : xhr.statusText;
+                    break;
+            }
+            $('#cors-test-result').html($('<div>', {
+                'class': 'alert alert-danger',
+                'html': '<strong>' + title + ':</strong> ' + message || ''
+            }));
+        });
+    });
+
+})(jQuery);
+
+
+
+// Navigation
+(function($) {
+
+    // Mobile Nav Open
+    $(".mobile-toggle").click(function () {
+        $('body').toggleClass('mobile-nav-active');
+        return false;
+    });
+
+    // Search Open
+    $("#top-nav .SearchIcon").on('click', function(e){
+        $(this).parent().toggleClass("search-active");
+        $('#top-nav #q').focus();
+    });
+
+    // Support Dropdown Nav Open
+    $("#top-nav .has-dropdown > a").on("click", function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        $(this).parent().toggleClass("dropdown-active");
+    });
+
+    // Mobile Sidebar Open/Close
+    $(".Sidebar-toggle").on("click", function(e){
+        e.stopPropagation();
+        $(this).parent().toggleClass("is-active");
+    });
+
+    $("#top-nav .has-dropdown > .dropdown-window, #top-nav #q, .Sidebar h2").on("click", function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+    });
+
+    $("#top-nav .has-dropdown > .dropdown-window a, #top-nav .SearchIcon, .Sidebar a").on("click", function(e) {
+        e.stopPropagation();
+    });
+
+    $(window).bind("click", function() {
+        $("#top-nav .has-dropdown").removeClass("dropdown-active");
+        $("#top-nav.search-active").removeClass("search-active");
+    });
+
+    $('header, .Sidebar').bind("click", function() {
+        $(".Sidebar.is-active").removeClass("is-active");
+    });
+
+})(jQuery);
+
+
+
+// Product
+;(function($) {
+
+	var _isIE = ($("html[class*=ie]").length > 0);
+
+	$('.tabber').each(function() {
+		
+		$(this).fbTabber({	
+			onClick: function($current, $previous) {
+		
+				var prevIndex = $previous.data("index");
+				var currentIndex = $current.data("index");
+		
+				var $prevTarget = $($previous.attr("href"));
+				var $currentTarget = $($current.attr("href"));
+		
+				if (!_isIE)
+				{
+					$prevTarget
+					.removeClass("fadeInLeft")
+					.removeClass("fadeInRight")
+					.removeClass("fadeOutLeft")
+					.removeClass("fadeOutRight")
+					.removeClass("animated");
+		
+					$currentTarget
+					.removeClass("fadeInLeft")
+					.removeClass("fadeInRight")
+					.removeClass("fadeOutLeft")
+					.removeClass("fadeOutRight")
+					.removeClass("animated");
+				}
+		
+				$prevTarget.css({
+					display: "block",
+					position: "relative",
+					zIndex: 5
+				});
+		
+				$currentTarget.css({
+					display: "block",
+					position: "relative",
+					zIndex: 10
+				});
+		
+				if (!_isIE)
+				{
+					if (currentIndex > prevIndex)
+					{
+						$currentTarget.addClass("fadeInRight");
+						$prevTarget.addClass("fadeOutLeft");
+					}
+					else if (currentIndex < prevIndex)
+					{
+						$currentTarget.addClass("fadeInLeft");
+						$prevTarget.addClass("fadeOutRight");
+					}
+		
+					$currentTarget.addClass("animated");
+					$prevTarget.addClass("animated");
+				}
+		
+				if (_isIE)
+				{
+					$prevTarget.css({
+						display: "none"
+					});
+				}
+		
+			}
+		});
+	
+	});
+
+})(jQuery);


### PR DESCRIPTION
Hi Joël,

These are the CSS & JS changes for the responsive ToC as outlined. There are a few caveats:

1. On pages with extra large ToCs, there will be some lag in loading. It won't block page load, but will just won't load the ToC immediately. Ex. /docs/api/resources/authn.html
2. If an h1 is not on the page, it won't be added to the toc as detailed in the provided spec. Fix is just to add an h1 to that specific page Ex. /use_cases/integrate_with_okta/
3. I saw a few doc pages that were not using the `docs_page` layout and as a result do not load the docs.js file. This is where the new ToC code is located, so those will need to be updated. I did not make changes to any of these content pages myself. Ex. /use_cases/authentication/
4. As the site is built in jekyll, it doesn't really afford the possiblity to have css transitions between the pages in the left nav. That said, there is a class `.is-active` that can be added to any of the links in the left nav for the requisite highlight. I didn't adjust any of the generated / static content here in the sidebar.

Let me know if there's anything else we can address.

Thanks,
Cody Baker
Flickerbox