### PR TITLE
Update _PageContent.scss

### DIFF
--- a/_source/_sass/okta/components/_PageContent.scss
+++ b/_source/_sass/okta/components/_PageContent.scss
@@ -134,15 +134,16 @@
 		}
 	
 		code, kbd, pre, samp, pre code {
-			font-size: 11px;
+			font-size: 14px;
 		}
 		code {
 			border-radius: 2px;
 			white-space: normal;
 			padding: 0;
 			background: transparent;
-			color: get-color('blue-bright');
-			font-size: 12px;
+			color: #333333;
+			font-size: 14px;
+			font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 		}
 	
 		blockquote code,
@@ -158,7 +159,7 @@
 			color: #333333;
 			word-break: break-all;
 			word-wrap: break-word;
-			background-color: get-color('gray-lightest');
+			background-color: #f0f0f0;
 			border-radius: 4px;
 			white-space: pre;
 			overflow: auto;
@@ -596,70 +597,78 @@
 		}
 	
 		/* -------------------------- PYGMENTS */
-	
-		.hll  { background-color: #ffffcc; }
-		.c    { color: #999988; font-style: italic; } /* Comment */
-		.err  { color: #a61717; background-color: #e3d2d2; } /* Error */
-		.k    { color: #FF7640; } /* Keyword */
-		.o    { color: #000000; } /* Operator */
-		.cm   { color: #999988; font-style: italic; } /* Comment.Multiline */
-		.cp   { color: #999999; font-style: italic; } /* Comment.Preproc */
-		.c1   { color: #999988; font-style: italic; } /* Comment.Single */
-		.cs   { color: #999999; font-style: italic; } /* Comment.Special */
-		.gd   { color: #000000; background-color: #ffdddd; } /* Generic.Deleted */
-		.ge   { color: #000000; font-style: italic; } /* Generic.Emph */
-		.gr   { color: #aa0000; } /* Generic.Error */
-		.gh   { color: #999999; } /* Generic.Heading */
-		.gi   { color: #000000; background-color: #ddffdd; } /* Generic.Inserted */
-		.go   { color: #888888 }  /* Generic.Output */
-		.gp   { color: #555555 }  /* Generic.Prompt */
-		.gs   { }                 /* Generic.Strong */
-		.gu   { color: #aaaaaa; } /* Generic.Subheading */
-		.gt   { color: #aa0000; } /* Generic.Traceback */
-		.k    { color: #FF7640  } /* Keyword */
-		.kc   { color: #FF7640  } /* Keyword.Constant */
-		.kd   { color: #FF7640  } /* Keyword.Declaration */
-		.kn   { color: #FF7640  } /* Keyword.Namespace */
-		.kp   { color: #FF7640  } /* Keyword.Pseudo */
-		.kr   { color: #FF7640  } /* Keyword.Reserved */
-		.kt   { color: #FF7640  } /* Keyword.Type */
-		.m    { color: #FF7640; } /* Literal.Number */
-		.s    { color: #1C6297; } /* Literal.String */
-		.na   { color: #5691BF; } /* Name.Attribute */
-		.nb   { color: #0086B3; } /* Name.Builtin */
-		.nc   { color: #445588; } /* Name.Class */
-		.no   { color: #008080; } /* Name.Constant */
-		.nd   { color: #3c5d5d; } /* Name.Decorator */
-		.ni   { color: #800080; } /* Name.Entity */
-		.ne   { color: #FFB149; } /* Name.Exception */
-		.nf   { color: #0086B3; } /* Name.Function */
-		.nl   { color: get-color('blue-bright'); } /* Name.Label */
-		.nn   { color: #555555; } /* Name.Namespace */
-		.nt   { color: #456;    } /* Name.Tag */
-		.nv   { color: #FFB149; } /* Name.Variable */
-		.ow   { color: #000000; } /* Operator.Word */
-		.p    { color: #456; }
-		.w    { color: #bbbbbb; } /* Text.Whitespace */
-		.mf   { color: #009999; } /* Literal.Number.Float */
-		.mh   { color: #009999; } /* Literal.Number.Hex */
-		.mi   { color: #009999; } /* Literal.Number.Integer */
-		.mo   { color: #009999; } /* Literal.Number.Oct */
-		.sb   { color: #d01040; } /* Literal.String.Backtick */
-		.sc   { color: #d01040; } /* Literal.String.Char */
-		.sd   { color: #d01040; } /* Literal.String.Doc */
-		.s2   { color: get-color('blue-bright'); } /* Literal.String.Double */
-		.se   { color: get-color('blue-bright'); } /* Literal.String.Escape */
-		.sh   { color: get-color('blue-bright'); } /* Literal.String.Heredoc */
-		.si   { color: #d01040; } /* Literal.String.Interpol */
-		.sx   { color: #d01040; } /* Literal.String.Other */
-		.sr   { color: #009926; } /* Literal.String.Regex */
-		.s1   { color: #40BF99; } /* Literal.String.Single */
-		.ss   { color: #990073; } /* Literal.String.Symbol */
-		.bp   { color: #999999; } /* Name.Builtin.Pseudo */
-		.vc   { color: #008080; } /* Name.Variable.Class */
-		.vg   { color: #008080; } /* Name.Variable.Global */
-		.vi   { color: #008080; } /* Name.Variable.Instance */
-		.il   { color: #009999; } /* Literal.Number.Integer.Long */
+		
+		.highlight pre { color: #333333; background-color: #f0f0f0; } /* Base Style */
+		.highlight .p { color: #333333; background-color: #f0f0f0; } /* Punctuation */
+		.highlight .err { color: #333333; background-color: #f0f0f0; } /* Error */
+		.highlight .n { color: #006399; background-color: #f0f0f0; } /* Base Style */
+		.highlight .na { color: #006399; background-color: #f0f0f0; } /* Name Attribute */
+		.highlight .nb { color: #006399; background-color: #f0f0f0; } /* Name Builtin */
+		.highlight .nc { color: #006399; background-color: #f0f0f0; } /* Name Class */
+		.highlight .no { color: #006399; background-color: #f0f0f0; } /* Name Constant */
+		.highlight .nd { color: #006399; background-color: #f0f0f0; } /* Name Decorator */
+		.highlight .ni { color: #006399; background-color: #f0f0f0; } /* Name Entity */
+		.highlight .ne { color: #006399; background-color: #f0f0f0; } /* Name Exception */
+		.highlight .nf { color: #006399; background-color: #f0f0f0; } /* Name Function */
+		.highlight .nl { color: #006399; background-color: #f0f0f0; } /* Name Label */
+		.highlight .nn { color: #009468; background-color: #f0f0f0; } /* Name Namespace */
+		.highlight .nx { color: #006399; background-color: #f0f0f0; } /* Name Other */
+		.highlight .py { color: #006399; background-color: #f0f0f0; } /* Name Property */
+		.highlight .nt { color: #006399; background-color: #f0f0f0; } /* Name Tag */
+		.highlight .nv { color: #006399; background-color: #f0f0f0; } /* Name Variable */
+		.highlight .vc { color: #006399; background-color: #f0f0f0; } /* Name Variable Class */
+		.highlight .vg { color: #006399; background-color: #f0f0f0; } /* Name Variable Global */
+		.highlight .vi { color: #006399; background-color: #f0f0f0; } /* Name Variable Instance */
+		.highlight .bp { color: #006399; background-color: #f0f0f0; } /* Name Builtin Pseudo */
+		.highlight .g { color: #333333; background-color: #f0f0f0; } /* Base Style */
+		.highlight .gd { color: #333333; background-color: #f0f0f0; } /*  */
+		.highlight .o { color: #333333; background-color: #f0f0f0; } /* Base Style */
+		.highlight .ow { color: #009468; background-color: #f0f0f0; } /* Operator Word */
+		.highlight .c { color: #aaaaaa; background-color: #f0f0f0; font-style: italic; }/* Base Style */
+		.highlight .cm { color: #aaaaaa; background-color: #f0f0f0; font-style: italic; } /* Comment Multiline */
+		.highlight .cp { color: #aaaaaa; background-color: #f0f0f0; font-style: italic; } /* Comment Preproc */
+		.highlight .c1 { color: #aaaaaa; background-color: #f0f0f0; font-style: italic; } /* Comment Single */
+		.highlight .cs { color: #aaaaaa; background-color: #f0f0f0; font-style: italic; } /* Comment Special */
+		.highlight .k { color: #009468; background-color: #f0f0f0; } /* Base Style */
+		.highlight .kc { color: #009468; background-color: #f0f0f0; } /* Keyword Constant */
+		.highlight .kd { color: #009468; background-color: #f0f0f0; } /* Keyword Declaration */
+		.highlight .kn { color: #009468; background-color: #f0f0f0; } /* Keyword Namespace */
+		.highlight .kp { color: #009468; background-color: #f0f0f0; } /* Keyword Pseudo */
+		.highlight .kr { color: #009468; background-color: #f0f0f0; } /* Keyword Reserved */
+		.highlight .kt { color: #009468; background-color: #f0f0f0; } /* Keyword Type */
+		.highlight .l { color: #333333; background-color: #f0f0f0; } /* Base Style */
+		.highlight .ld { color: #990f69; background-color: #f0f0f0; } /* Literal Date */
+		.highlight .m { color: #990f69; background-color: #f0f0f0; } /* Literal Number */
+		.highlight .mf { color: #990f69; background-color: #f0f0f0; } /* Literal Number Float */
+		.highlight .mh { color: #990f69; background-color: #f0f0f0; } /* Literal Number Hex */
+		.highlight .mi { color: #990f69; background-color: #f0f0f0; } /* Literal Number Integer */
+		.highlight .mo { color: #990f69; background-color: #f0f0f0; } /* Literal Number Oct */
+		.highlight .il { color: #990f69; background-color: #f0f0f0; } /* Literal Number Integer Long */
+		.highlight .s { color: #bf3600; background-color: #f0f0f0; } /* Literal String */
+		.highlight .sb { color: #bf3600; background-color: #f0f0f0; } /* Literal String Backtick */
+		.highlight .sc { color: #bf3600; background-color: #f0f0f0; } /* Literal String Char */
+		.highlight .sd { color: #bf3600; background-color: #f0f0f0; } /* Literal String Doc */
+		.highlight .s2 { color: #bf3600; background-color: #f0f0f0; } /* Literal String Double */
+		.highlight .se { color: #990f69; background-color: #f0f0f0; } /* Literal String Escape */
+		.highlight .sh { color: #bf3600; background-color: #f0f0f0; } /* Literal String Heredoc */
+		.highlight .si { color: #bf3600; background-color: #f0f0f0; } /* Literal String Interpol */
+		.highlight .sx { color: #bf3600; background-color: #f0f0f0; } /* Literal String Other */
+		.highlight .sr { color: #990f69; background-color: #f0f0f0; } /* Literal String Regex */
+		.highlight .s1 { color: #bf3600; background-color: #f0f0f0; } /* Literal String Single */
+		.highlight .ss { color: #bf3600; background-color: #f0f0f0; } /* Literal String Symbol */
+		.highlight .g { color: #333333; background-color: #f0f0f0; } /* Base Style */
+		.highlight .gd { color: #333333; background-color: #f0f0f0; } /* Generic Deleted */
+		.highlight .ge { color: #333333; background-color: #f0f0f0; } /* Generic Emph */
+		.highlight .gr { color: #333333; background-color: #f0f0f0; } /* Generic Error */
+		.highlight .gh { color: #333333; background-color: #f0f0f0; } /* Generic Heading */
+		.highlight .gi { color: #333333; background-color: #f0f0f0; } /* Generic Inserted */
+		.highlight .go { color: #333333; background-color: #f0f0f0; } /* Generic Output */
+		.highlight .gp { color: #333333; background-color: #f0f0f0; } /* Generic Prompt */
+		.highlight .gs { color: #333333; background-color: #f0f0f0; } /* Generic Strong */
+		.highlight .gu { color: #333333; background-color: #f0f0f0; } /* Generic Subheading */
+		.highlight .gt { color: #333333; background-color: #f0f0f0; } /* Generic Traceback */
+		.highlight .x { color: #333333; background-color: #f0f0f0; } /* Other */
+		.highlight .w { color: #333333; background-color: #f0f0f0; } /* Text Whitespace */
 	
 		#scroll-top-button {
 			position: fixed;


### PR DESCRIPTION
Made changes to:

- Create more contrast between code background and page background.
- Increase text size of code.
- Create a new color palette based on Okta blue and green which is high contrast, and contains relatively few categories.
- Implement the color palette consistently across Pygment's various classes.