### PR TITLE
Tweaks to document order and re-direct changes

### DIFF
--- a/_source/_docs/api/getting_started/api_test_client.md
+++ b/_source/_docs/api/getting_started/api_test_client.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 1
 title: API Test Client
 redirect_from: "/docs/getting_started/api_test_client.html"
 ---

--- a/_source/_docs/api/getting_started/design_principles.md
+++ b/_source/_docs/api/getting_started/design_principles.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 4
 title: Design Principles
 redirect_from: "/docs/getting_started/design_principles.html"
 ---

--- a/_source/_docs/api/getting_started/enabling_cors.md
+++ b/_source/_docs/api/getting_started/enabling_cors.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 3
 title: Enabling CORS
 redirect_from: "/docs/getting_started/enabling_cors.html"
 scripts:

--- a/_source/_docs/api/getting_started/getting_a_token.md
+++ b/_source/_docs/api/getting_started/getting_a_token.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 2
 title: Getting a Token
 redirect_from: "/docs/getting_started/getting_a_token.html"
 ---

--- a/_source/_docs/api/getting_started/index.md
+++ b/_source/_docs/api/getting_started/index.md
@@ -1,4 +1,4 @@
 ---
 layout: docs_page
-redirect_to: "/docs/api/getting_started/design_principles.html"
+redirect_to: "/docs/api/getting_started/api_test_client.html"
 ---

--- a/_source/_docs/index.md
+++ b/_source/_docs/index.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: "/docs/api/getting_started/design_principles.html"
+redirect_to: "/documentation"
 ---

--- a/_source/_includes/sidebar.html
+++ b/_source/_includes/sidebar.html
@@ -4,7 +4,7 @@
 	   <div>
 	     <h3 class="Sidebar-title">Use Cases</h3>
 	     <ul class="Sidebar-nav">
-	       {% assign documents = site.use_cases %}
+	       {% assign documents = site.use_cases | sort: 'weight' %}
 	       {% for document in documents %}
 	       {% unless document.id contains '/index' %}
                  {% continue %}
@@ -27,7 +27,7 @@
 		 </a>
 		 {% if page.id contains "docs/api/getting_started" %}
 		 <ul>
-		   {% assign docs = site.docs %}
+		   {% assign docs = site.docs | sort: 'weight' %}
 		   {% for doc in docs %}
 		     {% unless doc.id contains "docs/api/getting_started" %}{% continue %}{% endunless %}
 		     {% if doc.id contains "/index" %}{% continue %}{% endif %}

--- a/_source/_reference/api_reference.md
+++ b/_source/_reference/api_reference.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 2
 title: API Reference
 link: /docs/api/resources/authn.html
 excerpt: Documentation for all available Okta REST API endpoints. Includes sample requests and responses.

--- a/_source/_reference/error_codes/index.md
+++ b/_source/_reference/error_codes/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 3
 title: Error Codes
 excerpt: Information about the errors that the Okta API returns.
 redirect_from:

--- a/_source/_reference/getting_started.md
+++ b/_source/_reference/getting_started.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 1
 title: Getting started with the Okta API
 link: /docs/api/getting_started/
 excerpt: Understand the basics of the Okta API. Includes details on design principles, error codes and CORS to help you quickly get started.

--- a/_source/_reference/okta_expression_language/index.md
+++ b/_source/_reference/okta_expression_language/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 4
 title: Okta Expression Language
 excerpt: The features and syntax of Okta's Expression Language which can be used throughout the Okta Admin Console and API.
 redirect_from:

--- a/_source/_reference/release_notes.md
+++ b/_source/_reference/release_notes.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 5
 title: Release Notes
 link: /docs/platform-release-notes/platform-release-notes.html
 excerpt: Information on the changes and updates in the Okta platform.

--- a/_source/_use_cases/authentication/index.md
+++ b/_source/_use_cases/authentication/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 1
 title: Authentication
 excerpt: Overview of the various ways Okta can be used to authenticate users depending on your needs.
 ---

--- a/_source/_use_cases/integrate_with_okta/index.md
+++ b/_source/_use_cases/integrate_with_okta/index.md
@@ -1,6 +1,7 @@
 ---
 layout: docs_page
 title: Integrate with Okta
+weight: 3
 excerpt: Make your app enterprise-ready and connect with thousands of customers via the Okta Application Network.
 redirect_from: "/docs/getting_started/oan_guidance.html"
 ---

--- a/_source/_use_cases/mfa/index.md
+++ b/_source/_use_cases/mfa/index.md
@@ -1,5 +1,6 @@
 ---
 layout: docs_page
+weight: 2
 title: Multi-Factor Authentication
 excerpt: Using Okta's Multi-Factor Authentication API to add MFA to an existing application.
 ---

--- a/_source/documentation/index.html
+++ b/_source/documentation/index.html
@@ -13,7 +13,7 @@ redirect_from:
     <!-- <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p> -->
     <!-- START Subpages Grid w/Github Link -->
     <div class="Row">
-    {% assign documents = site.use_cases %}
+    {% assign documents = site.use_cases | sort:'weight' %}
       {% for document in documents %}
       {% unless document.id contains '/index' %}
         {% continue %}
@@ -34,7 +34,7 @@ redirect_from:
     <!-- <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p> -->
     <!-- START Subpages Grid -->
     <div class="Row">
-    {% assign documents = site.reference %}
+    {% assign documents = site.reference | sort:'weight' %}
       {% for document in documents %}
       <div class="Column--4 Column--small-12">
 	<a href="{% if document.id contains '/index' %}{{ document.url | remove: '/index' }}{% else %}{{ document.link }}{% endif %}">


### PR DESCRIPTION
This PR contains the following navigational changes:

* on http://developer.okta.com/documentation/:
        - In the Use Cases section the order is now Authentication, MFA, Integrate with Okta (more logical order than before). 
        - In the reference section, Getting started now shows up first.
* Going to the API getting started page now directs to the API test client setup instead of the design principles page
* Sidebar is re-arranged to match the changes to the /documentation nav
* /docs re-directs to /documentation now instead of docs/api/getting_started/design_principles.html

@mystiberry-okta do these seem OK to you?