### PR TITLE
Added section related to updating the phone using 'updatePhone' option

### DIFF
--- a/_source/_docs/api/resources/factors.md
+++ b/_source/_docs/api/resources/factors.md
@@ -703,6 +703,17 @@ curl -v -X GET \
           ]
         }
       }
+    },
+    "_embedded": {
+      "phones": [
+        {
+          "id": "mblldntFJevYKbyQQ0g3",
+          "profile": {
+            "phoneNumber": "+14081234567"
+          },
+          "status": "ACTIVE"
+        }
+      ]
     }
   },
   {
@@ -735,6 +746,9 @@ curl -v -X GET \
   }
 ]
 ~~~
+
+> Notice that `sms` factor type includes existing phone number in `_embedded`. You can either use the existing phone number or update it with a new number. See [Enroll Okta SMS factor] (#enroll-okta-sms-factor).
+
 
 ### List Security Questions
 {:.api .api-operation}
@@ -989,6 +1003,68 @@ curl -v -X POST \
     "errorId": "oaeneEaQF8qQrepOWHSkdoejw",
     "errorCauses": []
 }
+~~~
+
+###### Existing Phone
+
+`400 Bad Request` status code may be returned if you attempt to enroll with a different phone number when there is an existing mobile phone for the user.
+
+*Currently user can enroll only one mobile phone*
+
+~~~json
+{
+    "errorCode": "E0000001",
+    "errorSummary": "Api validation failed: factorEnrollRequest",
+    "errorLink": "E0000001",
+    "errorId": "oaeneEaQF8qQrepOWHSkdoejw",
+    "errorCauses": [
+       {
+          "errorSummary": "There is an existing verified phone number."
+       }
+    ]
+}
+~~~
+
+##### Enroll Okta SMS Factor by updating Phone Number
+{:.api .api-operation}
+
+If the user wants to use a different phone number (instead of existing phone number) then enroll API call needs to supply `updatePhone` option with `true`
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+  "factorType": "sms",
+  "provider": "OKTA",
+  "profile": {
+    "phoneNumber": "+1-555-415-1337"
+  }
+}' "https://${org}.okta.com/api/v1/users/${userId}/factors?updatePhone=true"
+~~~
+
+##### Enroll Okta SMS Factor by using existing Phone Number
+{:.api .api-operation}
+
+If the user wants to use the existing phone number then enroll API doesn't need to pass the phone number.
+Or you can pass the existing phone number in profile object.
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+  "factorType": "sms",
+  "provider": "OKTA"
+}' "https://${org}.okta.com/api/v1/users/${userId}/factors"
 ~~~
 
 ##### Enroll Okta SMS Factor Using Custom Template

--- a/_source/_docs/api/resources/factors.md
+++ b/_source/_docs/api/resources/factors.md
@@ -747,7 +747,7 @@ curl -v -X GET \
 ]
 ~~~
 
-> Notice that `sms` factor type includes existing phone number in `_embedded`. You can either use the existing phone number or update it with a new number. See [Enroll Okta SMS factor] (#enroll-okta-sms-factor).
+> Notice that the `sms` factor type includes an existing phone number in `_embedded`. You can either use the existing phone number or update it with a new number. See [Enroll Okta SMS factor](#enroll-okta-sms-factor) for more information.
 
 
 ### List Security Questions
@@ -1007,9 +1007,9 @@ curl -v -X POST \
 
 ###### Existing Phone
 
-`400 Bad Request` status code may be returned if you attempt to enroll with a different phone number when there is an existing mobile phone for the user.
+A `400 Bad Request` status code may be returned if you attempt to enroll with a different phone number when there is an existing mobile phone for the user.
 
-*Currently user can enroll only one mobile phone*
+*Currently, a user can enroll only one mobile phone.*
 
 ~~~json
 {
@@ -1025,10 +1025,10 @@ curl -v -X POST \
 }
 ~~~
 
-##### Enroll Okta SMS Factor by updating Phone Number
+##### Enroll Okta SMS Factor by Updating Phone Number
 {:.api .api-operation}
 
-If the user wants to use a different phone number (instead of existing phone number) then enroll API call needs to supply `updatePhone` option with `true`
+If the user wants to use a different phone number (instead of the existing phone number) then the enroll API call needs to supply `updatePhone` option with `true`.
 
 ###### Request Example
 {:.api .api-request .api-request-example}
@@ -1047,11 +1047,11 @@ curl -v -X POST \
 }' "https://${org}.okta.com/api/v1/users/${userId}/factors?updatePhone=true"
 ~~~
 
-##### Enroll Okta SMS Factor by using existing Phone Number
+##### Enroll Okta SMS Factor by Using Existing Phone Number
 {:.api .api-operation}
 
-If the user wants to use the existing phone number then enroll API doesn't need to pass the phone number.
-Or you can pass the existing phone number in profile object.
+If the user wants to use the existing phone number then the enroll API doesn't need to pass the phone number.
+Or, you can pass the existing phone number in a profile object.
 
 ###### Request Example
 {:.api .api-request .api-request-example}


### PR DESCRIPTION
Documentation about enrolling SMS factor using an existing phone via "/api/v1/users/{userId}/factors" API. 

Covers the following scenarios: 
- *update the phone number*
- *use existing phone number*

Primary Reviewer: @mystiberry-okta 

Optional Reviewers: @karlmcguinness-okta @tthompson-okta 

Note: We have similar gap in authentication api for the SMS factor. I will create another PR for that.