### PR TITLE
point users to OSW guide instead of reference

### DIFF
--- a/_source/_use_cases/authentication/index.md
+++ b/_source/_use_cases/authentication/index.md
@@ -49,7 +49,7 @@ can all be configured easily in the Okta administration console in the Okta dash
 
 ## Sign-in Widget
 
-The [Okta Sign-in Widget](/docs/api/resources/okta_signin_widget.html)
+The [Okta Sign-in Widget](/code/javascript/okta_sign-in_widget.html)
 provides an embeddable Javascript sign-in implementation that can
 easily be embedded into your customized login page.  The Sign-in
 widget carries the same feature set in the standard Okta sign-in page


### PR DESCRIPTION
The existing link was re-directing users to the Sign In Widget Reference, when we really want them to go to the guide page. 