### PR TITLE
Update Liquid template code with hack to remove whitespace 

### DIFF
--- a/_source/_includes/blog_post.html
+++ b/_source/_includes/blog_post.html
@@ -3,42 +3,33 @@
 	<article class="post-block">
 	  <header class="post-title-block">
 	    <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
-	    <div class="attribution">
-	      {% for post_author in post.author %}
-	      {% assign author = site.data.authors[post_author] %}
-	      {% if forloop.first %}
+	    <div class="attribution">{%
+          for post_author in post.author %}{% assign author = site.data.authors[post_author] %}{% if forloop.first %}
 	      <img src="/assets/img/{{ author.avatar }}"
 	           alt="{{ author.avatar }}"
-	           class="author-avatar">
-	      {% endif %}
+	           class="author-avatar">{%
+          endif %}
 	      <address>{{ author.full_name }}</address>
-	      &nbsp;
-		  {% if author.github %}
-		    <a class="social_link" href="{{ author.github }}"><i class="fa fa-github-square"></i></a>
-		  {% endif %}
-		  {% if author.twitter %}
-		    <a class="social_link" href="{{ author.twitter }}"><i class="fa fa-twitter-square"></i></a>
-		  {% endif %}
-		  {% if author.linkedin %}
-	 		<a class="social_link" href="{{ author.linkedin }}"><i class="fa fa-linkedin-square"></i></a>
-		  {% endif %}
-		  {% if author.web%}
-		    <a class="social_link" href="{{ author.web }}"><i class="fa fa-external-link-square"></i></a>
-		  {% endif %}
-		    <span class="sepr">&middot;</span>
-	      {% endfor %}
-	      <time datetime="{{ post.date | date: '%F'}}">
-	      {{ post.date | date: "%B %-d, %Y" }}
-	      </time>
+	      &nbsp;{%
+          if author.github %}
+		  <a class="social_link" href="{{ author.github }}"><i class="fa fa-github-square"></i></a>{%
+          endif %}{%
+          if author.twitter %}
+		  <a class="social_link" href="{{ author.twitter }}"><i class="fa fa-twitter-square"></i></a>{%
+          endif %}{%
+          if author.linkedin %}
+	 	  <a class="social_link" href="{{ author.linkedin }}"><i class="fa fa-linkedin-square"></i></a>{%
+          endif %}{% if author.web%}
+		  <a class="social_link" href="{{ author.web }}"><i class="fa fa-external-link-square"></i></a>{%
+          endif %}
+		  <span class="sepr">&middot;</span>{%
+          endfor %}
+	      <time datetime="{{ post.date | date: '%F'}}">{{ post.date | date: "%B %-d, %Y" }}</time>
 	    </div>
 	  </header>
-
 	  <section class="post-content">
 	    {{ include.post_content }}
 	  </section>
-
-
-
 	</article>
 </div>
 </section>

--- a/_source/_includes/code.html
+++ b/_source/_includes/code.html
@@ -1,18 +1,9 @@
-<div class="Row">
-{% assign indices = site.code | sort: 'id' %}
-{% for index in indices %}
-  {% unless index.id contains '/index' %}
-    {% continue %}
-  {% endunless %}
-  {% assign parts = index.id | split: "/" %}
-  {% unless parts[3] contains 'index' %}
-    {% continue %}
-  {% endunless %}
-  {% assign language = parts[2] %}
+<div class="Row">{%
+  assign indices = site.code | sort: 'id' %}{% for index in indices %}{% unless index.id contains '/index' %}{% continue %}{% endunless %}{% assign parts = index.id | split: "/" %}{% unless parts[3] contains 'index' %}{% continue %}{% endunless %}{% assign language = parts[2] %}
 <div class="Column--3 Column--small-6">
   <a href="/code/{{ language }}/">
     <div class="IconTile--{{ language }}"></div>
   </a>
-</div>
-{% endfor %}
+</div>{%
+endfor %}
 </div>

--- a/_source/_includes/footer.html
+++ b/_source/_includes/footer.html
@@ -1,46 +1,63 @@
-
-        <footer class="footer">
-            <div class="Wrap">
-
-                <ul>
-                    <li><a href="http://www.okta.com" target="_blank">Okta.com</a></li>
-                    <li><a href="/blog">Blog</a></li>
-                    <li><a href="/docs/platform-release-notes/platform-release-notes.html">Platform Release Notes</a></li>
-                    <li><a href="/terms/">Terms &amp; Conditions</a></li>
-                    <li><a href="/3rd_party_notices/">3rd Party Notices</a></li>
-                    <li><a href="/privacy/">Privacy Policy</a></li>
-                    <li><a href="http://okta.com/developer/contact/">Contact Sales</a></li>
-                    <li><a href="mailto:{{ site.email }}">Contact Support</a></li>
-                </ul>
-
-                <ul>
-                    <li><a class="icon" href="http://github.com/{{ site.github_username }}" target="_blank"><i class="fa fa-github"></i></a></li>
-                    <li><a class="icon" href="http://twitter.com/{{ site.twitter_username }}" target="_blank"><i class="fa fa-twitter"></i></a></li>
-                    <li><a class="icon" href="http://stackoverflow.com/search?q=okta" target="_blank"><i class="fa fa-stack-overflow"></i></a></li>
-                    <li><a class="icon" href="http://feeds.feedburner.com/OktaBlog" target="_blank"><i class="fa fa-rss"></i></a></li>
-                    <!-- <li><a class="icon" href="http://community.okta.com" target="_blank"><i class="fa fa-comments"></i></a></li> -->
-                </ul>
-
-            </div>
-        </footer>
-
-    <script src="https://code.jquery.com/jquery-3.1.0.min.js"
-    integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
-    crossorigin="anonymous"></script>
-
-    {% for script in page.scripts %}
-    <script src="{{ script }}"></script>
-    {% endfor %}
-    {% for script in layout.scripts %}
-    <script src="{{ script }}"></script>
-    {% endfor %}
-
-    {% if page.js %}<script type="text/javascript" defer="defer" src="{{ "/assets/js/" | prepend: site.baseurl | append: page.js }}.js"></script>{% endif %}
-    {% if layout.js %}<script type="text/javascript" defer="defer" src="{{ "/assets/js/" | prepend: site.baseurl | append: layout.js }}.js"></script>{% endif %}
-
-    <script src="/assets/js/master.js"></script>
-
-    <!-- Remarketing tag -->
+<footer class="footer">
+      <div class="Wrap">
+        <ul>
+          <li>
+            <a href="http://www.okta.com" target="_blank">Okta.com</a>
+          </li>
+          <li>
+            <a href="/blog">Blog</a>
+          </li>
+          <li>
+            <a href="/docs/platform-release-notes/platform-release-notes.html">Platform Release Notes</a>
+          </li>
+          <li>
+            <a href="/terms/">Terms & Conditions</a>
+          </li>
+          <li>
+            <a href="/3rd_party_notices/">3rd Party Notices</a>
+          </li>
+          <li>
+            <a href="/privacy/">Privacy Policy</a>
+          </li>
+          <li>
+            <a href="http://okta.com/developer/contact/">Contact Sales</a>
+          </li>
+          <li>
+            <a href="mailto:{{ site.email }}">Contact Support</a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a class="icon" href="http://github.com/{{ site.github_username }}" target="_blank"><i class="fa fa-github"></i></a>
+          </li>
+          <li>
+            <a class="icon" href="http://twitter.com/{{ site.twitter_username }}" target="_blank"><i class="fa fa-twitter"></i></a>
+          </li>
+          <li>
+            <a class="icon" href="http://stackoverflow.com/search?q=okta" target="_blank"><i class="fa fa-stack-overflow"></i></a>
+          </li>
+          <li>
+            <a class="icon" href="http://feeds.feedburner.com/OktaBlog" target="_blank"><i class="fa fa-rss"></i></a>
+          </li><!-- <li><a class="icon" href="http://community.okta.com" target="_blank"><i class="fa fa-comments"></i></a></li> -->
+        </ul>
+      </div>
+    </footer>
+    <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s=" crossorigin="anonymous">
+    </script>{%
+    for script in page.scripts %}
+    <script src="{{ script }}">
+    </script>{%
+    endfor %}{%
+    for script in layout.scripts %}
+    <script src="{{ script }}">
+    </script>{%
+    endfor %}{% if page.js %}
+    <script type="text/javascript" defer="defer" src="{{ "/assets/js/" | prepend: site.baseurl | append: page.js }}.js">
+    </script>{% endif %}{% if layout.js %}
+    <script type="text/javascript" defer="defer" src="{{ "/assets/js/" | prepend: site.baseurl | append: layout.js }}.js">
+    </script>{% endif %}
+    <script src="/assets/js/master.js">
+    </script> <!-- Remarketing tag -->
     <script type="text/javascript">
         /* <![CDATA[ */
         var google_conversion_id = 1006913831;
@@ -49,21 +66,14 @@
         /* ]]> */
     </script>
     <div style="display:none;">
-        <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
-    </script>
-    </div>
-    <noscript>
-        <div style="display:inline;">
-            <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/1006913831/?value=0&amp;guid=ON&amp;script=0"/>
-        </div>
-    </noscript>
-    <!-- End Remarketing tag -->
-
-    <!-- Crazy Egg Tracking -->
+      <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+      </script>
+    </div><noscript>
+    <div style="display:inline;"><img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/1006913831/?value=0&amp;guid=ON&amp;script=0"></div></noscript> <!-- End Remarketing tag -->
+     <!-- Crazy Egg Tracking -->
     <script type="text/javascript">
     setTimeout(function(){var a=document.createElement("script");
     var b=document.getElementsByTagName("script")[0];
     a.src=document.location.protocol+"//script.crazyegg.com/pages/scripts/0021/9333.js?"+Math.floor(new Date().getTime()/3600000);
     a.async=true;a.type="text/javascript";b.parentNode.insertBefore(a,b)}, 1);
-    </script>
-    <!-- End Crazy Egg Tracking -->
+    </script> <!-- End Crazy Egg Tracking -->

--- a/_source/_includes/head.html
+++ b/_source/_includes/head.html
@@ -1,30 +1,33 @@
 <head>
-    <script src="//use.typekit.net/jff5neq.js"></script>
-    <script>try{Typekit.load({ async: true });}catch(e){}</script>
+  <script src="//use.typekit.net/jff5neq.js">
+  </script>
+  <script>
+  try{Typekit.load({ async: true });}catch(e){}
+  </script>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="IE=edge,chrome=1">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">{%
+  if page.css %}
+  <link rel="stylesheet" href="{{ "/assets/css/" | prepend: site.baseurl | append: page.css }}.css">
+  {% endif
+  %}{% if layout.css %}
+  <link rel="stylesheet" href="{{ "/assets/css/" | prepend: site.baseurl | append: layout.css }}.css">{%
+  endif %}
+  <link rel="stylesheet" type="text/css" media="all" href="/assets/css/animate.css">
+  <link rel="stylesheet" type="text/css" media="all" href="/assets/css/okta.css">
+  <title>{% if page.meta_title %}{{ page.meta_title }}{% elsif page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}"><!-- GA -->
 
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="IE=edge,chrome=1">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-    {% if page.css %}<link rel="stylesheet" href="{{ "/assets/css/" | prepend: site.baseurl | append: page.css }}.css">{% endif %}
-    {% if layout.css %}<link rel="stylesheet" href="{{ "/assets/css/" | prepend: site.baseurl | append: layout.css }}.css">{% endif %}
-    <link rel="stylesheet" type="text/css" media="all" href="/assets/css/animate.css">
-    <link rel="stylesheet" type="text/css" media="all" href="/assets/css/okta.css">
-
-    <title>{% if page.meta_title %}{{ page.meta_title }}{% elsif page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
-
-    <!-- GA -->
-    <script>
-    	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    	ga('create', '{{ site.ga_ua_id }}', 'auto');
-    	ga('send', 'pageview');
-    </script>
+  <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', '{{ site.ga_ua_id }}', 'auto');
+        ga('send', 'pageview');
+  </script>
 </head>

--- a/_source/_includes/header.html
+++ b/_source/_includes/header.html
@@ -1,62 +1,55 @@
 <header id="header">
-    <div class="Wrap">
-        <h1 class="logo"><a href="/">Okta</a></h1>
-
-        <!-- START Primary Nav -->
+      <div class="Wrap">
+        <h1 class="logo"><a href="/">Okta</a></h1><!-- START Primary Nav -->
         <nav>
-            <div id="top-nav">
-                <a href="#" id="mobile-close" class="mobile-toggle">
-                    <span></span>
-                    <span></span>
-                </a>
-
-
-                <a class="Button--green" href="{{ site.get_started_url }}">Get Started</a>
-                <a class="SearchIcon" href="#"></a>
-                <ul>
-						<li><a href="/product/">Product</a></li>
-						<li><a href="/documentation/">Documentation</a></li>
-						<li><a href="/code/">Code</a></li>
-                    <li class="has-dropdown">
-                        <a href="#">Support</a>
-                        <div class="dropdown-window">
-                            <p class="stack-overflow">
-	                                Post your question on <a href="http://stackoverflow.com/search?q=okta" target="_blank">Stack Overflow</a>
-	                            </p>
-                            <p class="email">
-                                Email us:<br>
-                                <a href="mailto:{{ site.email }}">{{ site.email }}</a>
-                            </p>
-                            <p class="tel">
-                                Call us:<br>
-                                <a href="tel:18887227871">1 (888) 722-7871</a>
-                            </p>
-                        </div>
-                    </li>
-                </ul>
-                <form id="form_search" method="get" action="http://developer.okta.com/search/">
-                    <input type="text" name="q" id="q" autocomplete="off">
-                </form>
-            </div>
-
-            <div id="mobile-nav">
-                <a id="mobile-search" href="http://developer.okta.com/search/"><span class="icon-search-light"></span></a>
-                <a id="mobile-open" class="mobile-toggle" href="#top-nav">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </a>
-            </div>
-        </nav>
-        <!-- END Primary Nav -->
-    </div>
-</header>
-<!-- Google Tag Manager -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TJ45R6"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-TJ45R6');</script>
-<!-- End Google Tag Manager -->
+          <div id="top-nav">
+            <a href="#" id="mobile-close" class="mobile-toggle">
+              <span></span>
+              <span></span>
+            </a>
+            <a class="Button--green" href="{{ site.get_started_url }}">Get Started</a>
+            <a class="SearchIcon" href="#"></a>
+            <ul>
+              <li>
+                <a href="/product/">Product</a>
+              </li>
+              <li>
+                <a href="/documentation/">Documentation</a>
+              </li>
+              <li>
+                <a href="/code/">Code</a>
+              </li>
+              <li class="has-dropdown">
+                <a href="#">Support</a>
+                <div class="dropdown-window">
+                  <p class="stack-overflow">Post your question on <a href="http://stackoverflow.com/search?q=okta" target="_blank">Stack Overflow</a></p>
+                  <p class="email">Email us:<br>
+                  <a href="mailto:{{ site.email }}">{{ site.email }}</a></p>
+                  <p class="tel">Call us:<br>
+                  <a href="tel:18887227871">1 (888) 722-7871</a></p>
+                </div>
+              </li>
+            </ul>
+            <form id="form_search" method="get" action="http://developer.okta.com/search/" name="form_search">
+              <input type="text" name="q" id="q" autocomplete="off">
+            </form>
+          </div>
+          <div id="mobile-nav">
+            <a id="mobile-search" href="http://developer.okta.com/search/"><span class="icon-search-light"></span></a>
+            <a id="mobile-open" class="mobile-toggle" href="#top-nav">
+              <span></span>
+              <span></span>
+              <span></span>
+            </a>
+          </div>
+        </nav><!-- END Primary Nav -->
+      </div>
+    </header><!-- Google Tag Manager -->
+    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TJ45R6" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <script>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-TJ45R6');
+    </script> <!-- End Google Tag Manager -->

--- a/_source/_includes/sidebar.html
+++ b/_source/_includes/sidebar.html
@@ -1,102 +1,53 @@
 <aside class="Sidebar">
-    <h2 class="Sidebar-location Sidebar-toggle h6">Navigation</h3>
-    <div class="Sidebar-close Sidebar-toggle"></div>
-    <div>
-        <h3 class="Sidebar-title">Use Cases</h3>
-        <ul class="Sidebar-nav">
-            {% assign documents = site.use_cases | sort: 'weight' %}
-            {% for document in documents %}
-            {% unless document.id contains '/index' %}
-                {% continue %}
-            {% endunless %}
-            <li{% if document.title == page.title%} class="is-active"{% endif %}><a href="{{ document.url | remove: '/index' }}">{{ document.title }}</a></li>
-            {% endfor %}
-        </ul>
-
-        <h3 class="Sidebar-title">Reference</h3>
-        <ul class="Sidebar-nav">
+        <h2 class="Sidebar-location Sidebar-toggle h6">Navigation</h2>
+        <div class="Sidebar-close Sidebar-toggle"></div>
+        <div>
+          <h3 class="Sidebar-title">Use Cases</h3>
+          <ul class="Sidebar-nav">{% assign documents = site.use_cases | sort: 'weight' %}{% for document in documents %}{% unless document.id contains '/index' %}{% continue %}{% endunless %}
+            <li{% if document.title == page.title%} class="is-active"{% endif %}>
+              <a href="{{ document.url | remove: '/index' }}">{{ document.title }}</a>
+            </li>{%
+            endfor %}
+          </ul>
+          <h3 class="Sidebar-title">Reference</h3>
+          <ul class="Sidebar-nav">
             <li{% if page.title contains '/getting_started' %} class="is-active"{% endif %}>
-                <a href="/docs/api/getting_started/api_test_client.html">Getting Started</a>
-                {% if page.id contains "docs/api/getting_started" %}
-                    <ul>
-                    {% assign docs = site.docs | sort: 'weight' %}
-                    {% for doc in docs %}
-                        {% unless doc.id contains "docs/api/getting_started" %}{% continue %}{% endunless %}
-                        {% if doc.id contains "/index" %}{% continue %}{% endif %}
-                        <li{% if doc.title == page.title%} class="is-active"{% endif %}><a href="{{ doc.id }}.html">{{ doc.title }}</a></li>
-                    {% endfor %}
-                    </ul>
-                {% endif %}
-            </li>
-
-            {% assign auth_references = "/docs/api/resources/authn,/docs/api/resources/oauth2,/docs/api/resources/oidc,/docs/api/resources/social_authentication,/docs/api/resources/sessions,/docs/api/resources/okta_signin_widget" | split: "," %}
-            {% assign api_references = "/docs/api/resources/apps,/docs/api/resources/events,/docs/api/resources/factor_admin,/docs/api/resources/factors,/docs/api/resources/groups,/docs/api/resources/idps,/docs/api/resources/policy,/docs/api/resources/roles,/docs/api/resources/schemas,/docs/api/resources/system_log,/docs/api/resources/templates,/docs/api/resources/tokens,/docs/api/resources/users" | split: "," %}
-
+              <a href="/docs/api/getting_started/api_test_client.html">Getting Started</a>{% if page.id contains "docs/api/getting_started" %}
+              <ul>{% assign docs = site.docs | sort: 'weight' %}{% for doc in docs %}{% unless doc.id contains "docs/api/getting_started" %}{% continue %}{% endunless %}{% if doc.id contains "/index" %}{% continue %}{% endif %}
+                <li{% if doc.title == page.title%} class="is-active"{% endif %}>
+                  <a href="{{ doc.id }}.html">{{ doc.title }}</a>
+                </li>{% endfor %}
+              </ul>{% endif %}
+            </li>{% assign auth_references = "/docs/api/resources/authn,/docs/api/resources/oauth2,/docs/api/resources/oidc,/docs/api/resources/social_authentication,/docs/api/resources/sessions,/docs/api/resources/okta_signin_widget" | split: "," %}{% assign api_references = "/docs/api/resources/apps,/docs/api/resources/events,/docs/api/resources/factor_admin,/docs/api/resources/factors,/docs/api/resources/groups,/docs/api/resources/idps,/docs/api/resources/policy,/docs/api/resources/roles,/docs/api/resources/schemas,/docs/api/resources/system_log,/docs/api/resources/templates,/docs/api/resources/tokens,/docs/api/resources/users" | split: "," %}
             <li>
-                <a href="/docs/api/resources/authn.html">Authentication Reference</a>
-
-                {% if page.id contains "docs/api/resources" %}
-                    <ul id="Sidebar_References" class="Sidebar-hide">
-                        {% assign docs = site.docs %}
-                        {% assign docids = auth_references %}
-                        {% for docid in docids %}
-                            {% for doc in docs %}
-                                {% unless doc.id == docid %}{% continue %}{% endunless %}
-                                <li{% if doc.title == page.title%} class="is-active"{% endif %}><a href="{{ doc.url }}">{{ doc.title }}</a></li>
-                            {% endfor %}
-                        {% endfor %}
-                    </ul>
-                {% endif %}
+              <a href="/docs/api/resources/authn.html">Authentication Reference</a>{% if page.id contains "docs/api/resources" %}
+              <ul id="Sidebar_References" class="Sidebar-hide">{% assign docs = site.docs %}{% assign docids = auth_references %}{% for docid in docids %}{% for doc in docs %}{% unless doc.id == docid %}{% continue %}{% endunless %}
+                <li{% if doc.title == page.title%} class="is-active"{% endif %}><a href="{{ doc.url }}">{{ doc.title }}</a></li>{% endfor %}{% endfor %}
+              </ul>{% endif %}
             </li>
-
             <li>
-                <a href="/docs/api/resources/apps.html">API Reference</a>
-
-                {% if page.id contains "docs/api/resources" %}
-                    <ul id="Sidebar_Resources" class="Sidebar-hide">
-                        {% assign docs = site.docs %}
-                        {% assign docids = api_references %}
-                        {% for docid in docids %}
-                            {% for doc in docs %}
-                                {% if doc.beta %}{% continue %}{% endif %}
-                                {% unless doc.id == docid %}{% continue %}{% endunless %}
-                                <li{% if doc.title == page.title%} class="is-active"{% endif %}><a href="{{ doc.url }}">{{ doc.title }}</a></li>
-                            {% endfor %}
-                        {% endfor %}
-                    </ul>
-                {% endif %}
-
-            </li>
-            {% assign documents = site.reference %}
-            {% for document in documents %}
-                {% if document.id contains "docs/api/getting_started" %}{% continue %}{% endif %}
-                {% if document.id contains "docs/api/resources" %}{% continue %}{% endif %}
-                {% if document.id contains "reference/api_reference" %}{% continue %}{% endif %}
-                {% if document.id contains "reference/getting_started" %}{% continue %}{% endif %}
-                {% if document.id contains "reference/authentication_reference" %}{% continue %}{% endif %}
-
-                <li{% if document.title == page.title or page.title contains document.title %} class="is-active"{% endif %}>
-                    <a href="{% if document.id contains '/index' %}{{ document.url | remove: '/index' }}{% else %}{{ document.link }}{% endif %}">
-                        {{ document.title }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
-
-        {% comment %}
-        <h3 class="Sidebar-title">Standards</h3>
-        <ul class="Sidebar-nav">
+              <a href="/docs/api/resources/apps.html">API Reference</a>{% if page.id contains "docs/api/resources" %}
+              <ul id="Sidebar_Resources" class="Sidebar-hide">{% assign docs = site.docs %}{% assign docids = api_references %}{% for docid in docids %}{% for doc in docs %}{% if doc.beta %}{% continue %}{% endif %}{% unless doc.id == docid %}{% continue %}{% endunless %}
+                <li{% if doc.title == page.title%} class="is-active"{% endif %}><a href="{{ doc.url }}">{{ doc.title }}</a></li>{% endfor %}{% endfor %}
+              </ul>{% endif %}
+            </li>{% assign documents = site.reference %}{% for document in documents %}{% if document.id contains "docs/api/getting_started" %}{% continue %}{% endif %}{% if document.id contains "docs/api/resources" %}{% continue %}{% endif %}{% if document.id contains "reference/api_reference" %}{% continue %}{% endif %}{% if document.id contains "reference/getting_started" %}{% continue %}{% endif %}{% if document.id contains "reference/authentication_reference" %}{% continue %}{% endif %}
+            <li{% if document.title == page.title or page.title contains document.title %} class="is-active"{% endif %}>
+              <a href="{% if document.id contains '/index' %}{{ document.url | remove: '/index' }}{% else %}{{ document.link }}{% endif %}">{{ document.title }}</a>
+            </li>{% endfor %}
+          </ul>
+          {% comment %}
+          <h3 class="Sidebar-title">Standards</h3>
+          <ul class="Sidebar-nav">
             {% assign elements = site.standards %}
             {% for element in elements %}
-                {% unless element.id contains '/index' %}{% continue %}{% endunless %}
-                <li{% if element.title == page.title%} class="is-active"{% endif %}>
-                    <a href="{{ element.url | remove: '/index' }}">{{ element.title }}</a>
-                </li>
+            {% unless element.id contains '/index' %}{% continue %}{% endunless %}
+            <li{% if element.title == page.title%} class="is-active"{% endif %}>
+              <a href="{{ element.url | remove: '/index' }}">{{ element.title }}</a>
+            </li>
             {% endfor %}
-        </ul>
-        {% endcomment %}
-
-        <script>
+          </ul>{%
+          endcomment %}
+          <script>
             if (document.querySelectorAll("#Sidebar_Resources .is-active").length) {
                 document.getElementById('Sidebar_Resources').classList.remove('Sidebar-hide');
             }
@@ -104,7 +55,6 @@
             if (document.querySelectorAll("#Sidebar_References .is-active").length) {
                 document.getElementById('Sidebar_References').classList.remove('Sidebar-hide');
             }
-        </script>
-
-    </div>
-</aside>
+          </script>
+        </div>
+      </aside>

--- a/_source/_layouts/base.html
+++ b/_source/_layouts/base.html
@@ -1,15 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html class="no-js" lang="en" dir="ltr">
-  {% include head.html %}
-  <body>
-	<div class="Page">
-          <!-- START Header -->
-	  {% include header.html %}
-	  <!-- END Header -->
-	  {{ content }}
-	  <!-- START Footer -->
-	  {% include footer.html %}
-	  <!-- END Footer -->
-	</div>
+{% include head.html %}
+<body>
+  <div class="Page">
+    <!-- START Header -->
+    {% include header.html %}     <!-- END Header -->
+    {{ content }}
+    <!-- START Footer -->
+    {% include footer.html %}
+     <!-- END Footer -->
+  </div>
 </body>
 </html>

--- a/_source/_layouts/blog_index.html
+++ b/_source/_layouts/blog_index.html
@@ -3,16 +3,10 @@ layout: master
 css: page-blog
 show_bottom_cta: true
 ---
-
 <section class="PageContent" id="blog-index">
   <!-- START Page Content -->
   <div class="PageContent-main">
-
-	<div class="wrap blog">
-		{% for post in site.posts %}
-		{% capture _post_content %}{{ post.content }}{% endcapture %}
-		{% include blog_post.html post_content=_post_content %}
-		{% endfor %}
+	<div class="wrap blog">{% for post in site.posts %}{% capture _post_content %}{{ post.content }}{% endcapture %}{% include blog_post.html post_content=_post_content %}{% endfor %}
 	</div>
   </div>
   <!-- END Page Content -->

--- a/_source/_layouts/blog_post.html
+++ b/_source/_layouts/blog_post.html
@@ -3,21 +3,12 @@ layout: master
 css: page-blog
 show_bottom_cta: true
 ---
-
-<section id="blog-post" class="section--full-width">
-
-	{% comment %}
+<section id="blog-post" class="section--full-width">{% comment %}
 	// assigned variables will "leak" into the included file
 	// we must capture the content however otherwise {{ content }}
 	// will leak as a raw string
-	{% endcomment %}
-
-	{% assign post = page %}
-	{% capture _post_content %}{{ content }}{% endcapture %}
-
-
+  {% endcomment %}{% assign post = page %}{% capture _post_content %}{{ content }}{% endcapture %}
 	<div class="blog">
 		{% include blog_post.html post_content=_post_content %}
 	</div>
-
 </section>

--- a/_source/_layouts/code.html
+++ b/_source/_layouts/code.html
@@ -14,39 +14,24 @@
            <div class="Sidebar-close Sidebar-toggle"></div>
 	   <div>
 	     <h3 class="Sidebar-title">Programming languages</h3>
-	     <ul class="Sidebar-nav">
-	       {% assign indices = site.code | sort: 'id' %}
-	       {% for index in indices %}
-	         {% unless index.id contains '/index' %}
-	           {% continue %}
-	         {% endunless %}
-	         {% assign parts = index.id | split: "/" %}
-                 {% assign language = parts[2] %}
-                 {% assign element = index %}
-	       <li{% if element.title == page.title%} class="is-active"{% endif %}><a href="/code/{{ language | prepend: site.baseurl }}">{{ element.title }}</a></li>
-	       {% endfor %}
+	     <ul class="Sidebar-nav">{%
+           assign indices = site.code | sort: 'id' %}{% for index in indices %}{% unless index.id contains '/index' %}{% continue %}{% endunless %}{% assign parts = index.id | split: "/" %}{% assign language = parts[2] %}{% assign element = index %}
+           <li{% if element.title == page.title%} class="is-active"{% endif %}><a href="/code/{{ language | prepend: site.baseurl }}">{{ element.title }}</a></li>{%
+           endfor %}
 	     </ul>
 	   </div>
         </aside>
       <!-- END Fixed sidebar -->
       <!-- START Page Content -->
       <div class="PageContent-main">
-	{{ content }}
-
-
-
+	    {{ content }}
       </div>
       <!-- END Page Content -->
-
-
     </section>
     <!-- END Page Center w/Sub Nav & Content -->
-
-
     <!-- START Footer -->
     {% include footer.html %}
     <!-- END Footer -->
-
   </div>
 </body>
 </html>

--- a/_source/_layouts/docs_page.html
+++ b/_source/_layouts/docs_page.html
@@ -2,24 +2,19 @@
 layout: base
 js: docs
 ---
-
-    <!-- START Page Center w/Sub Nav & Content -->
+ <!-- START Page Center w/Sub Nav & Content -->
     <section class="PageContent DynamicSidebar has-tableOfContents">
-      <!-- START Fixed sidebar -->
-      {% include sidebar.html %}
-      <!-- END Fixed sidebar -->
+      <!-- START Fixed sidebar -->{% include sidebar.html %}<!-- END Fixed sidebar -->
       <!-- START Page Content -->
       <div class="PageContent-main" id="docs-body">
       {{ content }}
       </div>
       <div class="TableOfContents TableOfContentsPreload">
-          <div class="TableOfContents-item is-level1">
-              <script>
+        <div class="TableOfContents-item is-level1">
+          <script>
                   document.write(document.title.split('|')[0].trim());
-              </script>
-          </div>
-          <div class="TableOfContentsLoader"></div>
-      </div>
-      <!-- END Page Content -->
-    </section>
-    <!-- END Page Center w/Sub Nav & Content -->
+          </script>
+        </div>
+        <div class="TableOfContentsLoader"></div>
+      </div><!-- END Page Content -->
+    </section><!-- END Page Center w/Sub Nav & Content -->

--- a/_source/_layouts/master.html
+++ b/_source/_layouts/master.html
@@ -5,39 +5,23 @@
 <!--[if IE 9 ]>    <html class="ie9 no-flexbox"> <![endif]-->
 <!--[if IE 10 ]>    <html class="ie10 no-flexbox"> <![endif]-->
 <!--[if (gt IE 10)|!(IE)]><!--> <html class="modern"> <!--<![endif]-->
-<head>
-
-	{% include head.html %}
-
-
-{% if include.body_id %}
-  {% assign body_id = include.body_id %}
-{% else %}
-  {% assign active_page_name  = page.url | split: "/" | last | remove: ".html" %}
-  {% assign split_url         = page.url | split: "/" %}
-  {% assign body_id           = split_url[1] %}
-{% endif %}
-<body id="{{ body_id }}">
-
+  <head>{%
+    include head.html %}{% if include.body_id %}{% assign body_id = include.body_id %}{% else %}{% assign active_page_name  = page.url | split: "/" | last | remove: ".html" %}{% assign split_url         = page.url | split: "/" %}{% assign body_id           = split_url[1] %}{% endif %}
+    <body id="{{ body_id }}">
 	{% include header.html %}
-
-	<div class="page-content">
-
-		{% if page.valprop %}
+	<div class="page-content">{%
+      if page.valprop %}
 		<section id="valprop" class="section--full-width bg--light-blue">
 			<div class="wrap">
-				<header>
-					{% if page.valprop.title %}<h1>{{ page.valprop.title }}</h1>{% endif %}
-					{% if page.valprop.description %}<p class="text--large">{{ page.valprop.description }}</p>{% endif %}
-				</header>
-
-				{% if page.valprop.show_cta %}<a href="{% if page.valprop.cta_link %}{{ page.valprop.cta_link }}{% else %}https://www.okta.com/developer/signup/{% endif %}" class="button--large"><span>{% if page.valprop.cta_label %}{{ page.valprop.cta_label }}{% else %}Get a Free Developer Account{% endif %}</span></a>{% endif %}
+			  <header>{%
+                if page.valprop.title %}<h1>{{ page.valprop.title }}</h1>{% endif %}{%
+                if page.valprop.description %}<p class="text--large">{{ page.valprop.description }}</p>{% endif %}
+			  </header>{%
+              if page.valprop.show_cta %}<a href="{% if page.valprop.cta_link %}{{ page.valprop.cta_link }}{% else %}https://www.okta.com/developer/signup/{% endif %}" class="button--large"><span>{% if page.valprop.cta_label %}{{ page.valprop.cta_label }}{% else %}Get a Free Developer Account{% endif %}</span></a>{% endif %}
 			</div>
-		</section>
-		{% endif %}
-
+		</section>{%
+        endif %}
 		{{ content }}
-
 		{% if page.show_bottom_cta %}
 		<section id="bottom-cta" class="section--full-width text-align--center">
 			<div class="wrap">
@@ -47,14 +31,9 @@
 				</header>
 				<a href="https://www.okta.com/developer/signup/" class="button--large"><span>Get a Free Developer Account</span></a>
 			</div>
-		</section>
-		{% endif %}
-
-	</div>
-
-	{% unless page.hide_footer %}
-		{% include footer.html %}
-	{% endunless %}
+		</section>{%
+        endif %}
+	</div>{% unless
+    page.hide_footer %}{% include footer.html %}{% endunless %}
 </body>
-
 </html>

--- a/_source/_layouts/software.html
+++ b/_source/_layouts/software.html
@@ -14,93 +14,59 @@
            <div class="Sidebar-close Sidebar-toggle"></div>
 	   <div>
 	     <h3 class="Sidebar-title">Programming languages</h3>
-	     <ul class="Sidebar-nav">
-	       {% comment %}
-
+	     <ul class="Sidebar-nav">{% comment %}
 	       The code below gets a list of programming languages.
 	       It ultimately defines to variables:
 	       - 'langauge' the name of the directory in the '_code' directory that has the language
 	       - 'element' the 'index.md' file for the language subdirectory in '_code'
-
-	       {% endcomment %}
-	       {% assign indices = site.code | sort: 'id' %}
-	       {% for index in indices %}
-	         {% unless index.id contains '/index' %}
-	           {% continue %}
-	         {% endunless %}
-	         {% assign parts = index.id | split: "/" %}
-                 {% unless parts[3] contains 'index' %}
-	           {% continue %}
-	         {% endunless %}
-                 {% assign language = parts[2] %}
-                 {% assign element = index %}
-	       <li{% if element.title == page.title%} class="is-active"{% endif %}><a href="/code/{{ language | prepend: site.baseurl }}">{{ element.title }}</a></li>
-	       {% endfor %}
+	       {% endcomment %}{% assign indices = site.code | sort: 'id' %}{% for index in indices %}{% unless index.id contains '/index' %}{% continue %}{% endunless %}{% assign parts = index.id | split: "/" %}{% unless parts[3] contains 'index' %}{% continue %}{% endunless %}{% assign language = parts[2] %}{% assign element = index %}
+	       <li{% if element.title == page.title%} class="is-active"{% endif %}><a href="/code/{{ language | prepend: site.baseurl }}">{{ element.title }}</a></li>{%
+           endfor %}
 	     </ul>
 	   </div>
         </aside>
       <!-- END Fixed sidebar -->
       <!-- START Page Content -->
-      <div class="PageContent-main">
-	{{ content }}
-
-
-	<!-- HELLO WORLD -->
-	<!-- {% assign key = page.id | remove: "index" %} -->
-	<!-- {{ key | inspect }} -->
-	<!-- Tag: {{  site.categories | inspect }} -->
-	<!-- Key: {{ key | inspect }} -->
-	<!-- Pages: {{ site.code | sort: 'id' | inspect }} -->
-
-	<!-- <h1>{{ framework }}</h1> -->
-	<!-- <p> -->
-	<!--   {{ blurb }} -->
-	<!-- </p> -->
-	<!-- START Subpages Grid -->
-	<div class="Row">
-	{% assign indices = site.code | sort: 'id' %}
-	{% for index in indices %}
-	{% if index.id == page.id %}
-          {% continue %}
-	{% endif %}
-	{% unless index.id contains key %}
-	  {% continue %}
-	{% endunless %}
-	<!-- index.id {{ index.id | inspect }} -->
-	{% assign item = index %}
-	<div class="Column--4 Column--small-12">
-	  {% unless item.github_url %}
-	  <a href="{{ item.url | remove: '/index' }}.html">
-          {% endunless %}
-	    <h3 class="h4">{{ item.title }}</h3>
-	  {% unless item.github_url %}
-	  </a>
-          {% endunless %}
+      <div class="PageContent-main">{{ content }}
+        <!-- HELLO WORLD -->
+	    <!-- {% assign key = page.id | remove: "index" %} -->
+	    <!-- {{ key | inspect }} -->
+	    <!-- Tag: {{  site.categories | inspect }} -->
+	    <!-- Key: {{ key | inspect }} -->
+	    <!-- Pages: {{ site.code | sort: 'id' | inspect }} -->
+	    <!-- <h1>{{ framework }}</h1> -->
+	    <!-- <p> -->
+	    <!--   {{ blurb }} -->
+	    <!-- </p> -->
+	    <!-- START Subpages Grid -->
+	<div class="Row">{%
+      assign indices = site.code | sort: 'id' %}{% for index in indices %}{% if index.id == page.id %}{% continue %}{% endif %}{% unless index.id contains key %}{% continue %}{% endunless %}
+      <!-- index.id {{ index.id | inspect }} -->{%
+      assign item = index %}
+	  <div class="Column--4 Column--small-12">{% unless item.github_url %}
+        <a href="{{ item.url | remove: '/index' }}.html">{%
+          endunless %}
+	      <h3 class="h4">{{ item.title }}</h3>{%
+          unless item.github_url %}
+	    </a>{%
+        endunless %}
 	    <p>
 	      {{ item.excerpt }}
-	    </p>
-	    {% if item.github_url %}
-	    <a href="{{ item.github_url }}" class="github">Get it on Github</a>
-	    {% endif %}
-	  </div>
-	{% endfor %}
+	    </p>{%
+        if item.github_url %}
+	    <a href="{{ item.github_url }}" class="github">Get it on Github</a>{%
+        endif %}
+	  </div>{%
+      endfor %}
 	</div>
 	<!-- END Subpages Grid -->
-
-
-
       </div>
       <!-- END Page Content -->
-
-
     </section>
     <!-- END Page Center w/Sub Nav & Content -->
-
-
     <!-- START Footer -->
     {% include footer.html %}
     <!-- END Footer -->
-
   </div>
 </body>
 </html>


### PR DESCRIPTION
This is a "medium sized" update to remove whitespace from the HTML that Liquid template generates. The main issue here is that the current version of this site make extensive use of [Jekyll Collections](https://jekyllrb.com/docs/collections/) to generate pages and sidebars. 

This should be considered a temporary fix, until we can move back to generating sidebars and pages from [Jekyll Data Files](https://jekyllrb.com/docs/datafiles/), instead of collections. Meaning: Use a `config.yml` or similar kind of file to drive what shows up in the sidebar, which pages show up in the "Use Cases", "Reference", and "Code" sections, and so on.