### PR TITLE
Fix inconsistencies in URLs

### DIFF
--- a/_source/_docs/api/resources/authn.md
+++ b/_source/_docs/api/resources/authn.md
@@ -46,7 +46,7 @@ Trusted applications are backend applications that act as authentication broker 
 ### Primary Authentication
 {:.api .api-operation}
 
-{% api_operation post /api/v1/authn %}
+{% api_operation post /authn %}
 
 Every authentication transaction starts with primary authentication which validates a user's primary password credential. **Password Policy**, **MFA Policy**,  and **Sign-On Policy** are evaluated during primary authentication to determine if the user's password is expired, a factor should be enrolled, or additional verification is required. The [transaction state](#transaction-state) of the response depends on the user's status, group memberships and assigned policies.
 
@@ -731,7 +731,7 @@ curl -v -X POST \
 ### Change Password
 {:.api .api-operation}
 
-{% api_operation post api/v1/authn/credentials/change_password %}
+{% api_operation post /authn/credentials/change_password %}
 
 This operation changes a user's password by providing the existing password and the new password password for authentication transactions with either the `PASSWORD_EXPIRED` or `PASSWORD_WARN` state.
 
@@ -838,7 +838,7 @@ You can enroll, activate, and verify factors using the `/api/v1/authn/factors` e
 ### Enroll Factor
 {:.api .api-operation}
 
-{% api_operation post /api/v1/authn/factors %}
+{% api_operation post /authn/factors %}
 
 Enrolls a user with a [factor](factors.html#supported-factors-for-providers) assigned by their **MFA Policy**.
 

--- a/_source/_docs/api/resources/factor_admin.md
+++ b/_source/_docs/api/resources/factor_admin.md
@@ -76,7 +76,7 @@ deactivate         | Denies use of this factor for MFA
 ### Get Org Factor
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /api/v1/org/factors
+<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /org/factors
 
 Fetches a factor for the specified user.
 
@@ -255,7 +255,7 @@ curl -v -H "Authorization: SSWS yourtoken" \
 ### Activate SMS
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /api/v1/org/factors/okta_sms/lifecycle/activate
+<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /org/factors/okta_sms/lifecycle/activate
 
 Allows multi-factor authentication to use an SMS factor.
 
@@ -307,7 +307,7 @@ curl -v -H "Authorization: SSWS yourtoken" \
 ### Deactivate SMS
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /api/v1/org/factors/okta_sms/lifecycle/deactivate
+<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /org/factors/okta_sms/lifecycle/deactivate
 
 Denies use of an SMS factor for multi-factor authentication.
 
@@ -359,7 +359,7 @@ curl -v -H "Authorization: SSWS yourtoken" \
 ### Activate Okta Verify
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /api/v1/org/factors/okta_otp/lifecycle/activate
+<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /org/factors/okta_otp/lifecycle/activate
 
 Allows multi-factor authentication to use Okta Verify as a factor.
 
@@ -411,7 +411,7 @@ curl -v -H "Authorization: SSWS yourtoken" \
 ### Deactivate Okta Verify
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /api/v1/org/factors/okta_otp/lifecycle/deactivate
+<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /org/factors/okta_otp/lifecycle/deactivate
 
 Denies use of Okta Verify for multi-factor authentication.
 

--- a/_source/_docs/api/resources/factors.md
+++ b/_source/_docs/api/resources/factors.md
@@ -21,7 +21,7 @@ Explore the Factors API: [![Run in Postman](https://run.pstmn.io/button.svg)](ht
 ### Get Factor
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /api/v1/users/*:uid*/factors/*:fid*
+<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /users/*:uid*/factors/*:fid*
 
 Fetches a factor for the specified user
 
@@ -96,7 +96,7 @@ curl -v -X GET \
 ### List Enrolled Factors
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /api/v1/users/*:uid*/factors
+<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /users/*:uid*/factors
 
 Enumerates all the enrolled factors for the specified user
 
@@ -257,7 +257,7 @@ curl -v -X GET \
 ### List Factors to Enroll
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /api/v1/users/*:uid*/factors/catalog
+<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /users/*:uid*/factors/catalog
 
 Enumerates all the [supported factors](#supported-factors-for-providers) that can be enrolled for the specified user
 
@@ -415,7 +415,7 @@ curl -v -X GET \
 ### List Security Questions
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /api/v1/users/*:uid*/factors/questions
+<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /users/*:uid*/factors/questions
 
 Enumerates all available security questions for a user's `question` factor
 
@@ -474,7 +474,7 @@ curl -v -X GET \
 ### Enroll Factor
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /api/v1/users/*:id*/factors
+<span class="api-uri-template api-uri-post"><span class="api-label">POST</span> /users/*:id*/factors
 
 Enrolls a user with a supported [factor](#list-factors-to-enroll)
 
@@ -1786,7 +1786,7 @@ curl -v -X POST \
 ### Reset Factor
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-delete"><span class="api-label">DELETE</span> /api/v1/users/*:uid*/factors/*:fid*
+<span class="api-uri-template api-uri-delete"><span class="api-label">DELETE</span> /users/*:uid*/factors/*:fid*
 
 Unenrolls an existing factor for the specified user, allowing the user to enroll a new factor.
 

--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -259,7 +259,7 @@ users |  | <a href="#UserConditionObject">User Condition Object</a> | No |
 ### Get a Policy
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /api/v1/policies/<em>:policyId</em></span>
+<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /policies/<em>:policyId</em></span>
 
 #### Request Parameters
 
@@ -285,7 +285,7 @@ HTTP 200:
 ### Get a Policy with Rules
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /api/v1/policies/<em>:policyId</em>?expand=rules</span>
+<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /policies/<em>:policyId</em>?expand=rules</span>
 
 #### Request Parameters
 
@@ -312,7 +312,7 @@ HTTP 200:
 ### Get All Policies by Type
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /api/v1/policies?type=<em>:type</em></span>
+<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /policies?type=<em>:type</em></span>
 
 #### Request Parameters
 
@@ -340,7 +340,7 @@ HTTP 204:
 ### Delete Policy
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-delete"><span class="api-label">DELETE </span> /api/v1/policies/<em>:policyId</em></span>
+<span class="api-uri-template api-uri-delete"><span class="api-label">DELETE </span> /policies/<em>:policyId</em></span>
 
 #### Request Parameters
 
@@ -366,7 +366,7 @@ HTTP 204:
 ### Update a Policy
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-put"><span class="api-label">PUT </span> /api/v1/policies/<em>:policyId</em></span>
+<span class="api-uri-template api-uri-put"><span class="api-label">PUT </span> /policies/<em>:policyId</em></span>
 
 #### Request Parameters
 
@@ -405,7 +405,7 @@ HTTP 200:
 ### Create a Policy
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /api/v1/policies</span>
+<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /policies</span>
 
 #### Request Parameters
 
@@ -446,7 +446,7 @@ HTTP 204:
 ### Activate a Policy
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /api/v1/policies/<em>:policyId</em>/lifecycle/activate</span>
+<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /policies/<em>:policyId</em>/lifecycle/activate</span>
 
 #### Request Parameters
 
@@ -472,7 +472,7 @@ HTTP 204:
 ### Deactivate a Policy
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /api/v1/policies/<em>:policyId</em>/lifecycle/deactivate</span>
+<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /policies/<em>:policyId</em>/lifecycle/deactivate</span>
 
 #### Request Parameters
 
@@ -500,7 +500,7 @@ HTTP 200:
 ### Get Policy Rules
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /api/v1/policies/<em>:policyId</em>/rules</span>
+<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /policies/<em>:policyId</em>/rules</span>
 
 #### Request Parameters
 
@@ -526,7 +526,7 @@ HTTP 200:
 ### Create a rule
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /api/v1/policies/<em>:policyId</em>/rules</span>
+<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /policies/<em>:policyId</em>/rules</span>
 
 #### Request Parameters
 
@@ -570,7 +570,7 @@ HTTP 200:
 ### Delete a rule
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-delete"><span class="api-label">DELETE </span> /api/v1/policies/<em>:policyId</em>/rules/<em>:ruleId</em></span>
+<span class="api-uri-template api-uri-delete"><span class="api-label">DELETE </span> /policies/<em>:policyId</em>/rules/<em>:ruleId</em></span>
 
 #### Request Parameters
 
@@ -596,7 +596,7 @@ HTTP 204:
 ### Get a rule
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /api/v1/policies/<em>:policyId</em>/rules/<em>:ruleId</em></span>
+<span class="api-uri-template api-uri-get"><span class="api-label">GET </span> /policies/<em>:policyId</em>/rules/<em>:ruleId</em></span>
 
 #### Request Parameters
 
@@ -622,7 +622,7 @@ HTTP 200:
 ### Update a rule
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-put"><span class="api-label">PUT </span> /api/v1/policies/<em>:policyId</em>/rules/<em>:ruleId</em></span>
+<span class="api-uri-template api-uri-put"><span class="api-label">PUT </span> /policies/<em>:policyId</em>/rules/<em>:ruleId</em></span>
 
 #### Request Parameters
 
@@ -669,7 +669,7 @@ HTTP 200:
 ### Activate A Rule
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /api/v1/policies/<em>:policyId</em>/rules/<em>:ruleId</em>/lifecycle/activate</span>
+<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /policies/<em>:policyId</em>/rules/<em>:ruleId</em>/lifecycle/activate</span>
 
 #### Request Parameters
 
@@ -695,7 +695,7 @@ HTTP 204:
 ### Deactivate A Rule
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /api/v1/policies/<em>:policyId</em>/rules/<em>:ruleId</em>/lifecycle/deactivate</span>
+<span class="api-uri-template api-uri-post"><span class="api-label">POST </span> /policies/<em>:policyId</em>/rules/<em>:ruleId</em>/lifecycle/deactivate</span>
 
 #### Request Parameters
 

--- a/_source/_docs/api/resources/system_log.md
+++ b/_source/_docs/api/resources/system_log.md
@@ -19,7 +19,7 @@ Use this API to export event data as a batch job from your organization to anoth
 ### List Events
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /api/v1/logs</span>
+<span class="api-uri-template api-uri-get"><span class="api-label">GET</span> /logs</span>
 
 Fetch a list of events from your Okta organization system log.
 

--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -2307,7 +2307,7 @@ Content-Type: application/json
 ### Clear User Sessions
 {:.api .api-operation}
 
-<span class="api-uri-template api-uri-delete"><span class="api-label">DELETE</span> /api/v1/users/*:uid*/sessions
+<span class="api-uri-template api-uri-delete"><span class="api-label">DELETE</span> /users/*:uid*/sessions
 
 Removes all active identity provider sessions. This will force the user to authenticate on the next operation.
 


### PR DESCRIPTION
Remove '/api/v1' from URLs. I know the plan is to add this back everywhere, but I think it makes sense to keep things consistent for now.

@mystiberry-okta for your review.