### PR TITLE
Added support for Okta Release Lifecycle links to API Lifecycle badge liquid tags

### DIFF
--- a/_source/_docs/api/resources/authn.md
+++ b/_source/_docs/api/resources/authn.md
@@ -1732,7 +1732,7 @@ curl -v -X POST \
 #### Enroll U2F Factor
 {:.api .api-operation}
 
-> Enrolling a U2F factor is [an {% api_lifecycle ea %} feature](/docs/api/getting_started/releases-at-okta.html).
+> Enrolling a U2F factor is an {% api_lifecycle ea %} feature.
 
 Enrolls a user with a U2F factor.  The enrollment process starts with getting an `appId` and `nonce` from Okta and using those to get registration information from the U2F key using the U2F javascript API.
 
@@ -2521,7 +2521,7 @@ curl -v -X POST \
 #### Activate U2F Factor
 {:.api .api-operation}
 
-> Activating a U2F factor is [an {% api_lifecycle ea %} feature](/docs/api/getting_started/releases-at-okta.html).
+> Activating a U2F factor is an {% api_lifecycle ea %} feature.
 
 Activation gets the registration information from the U2F token using the platform APIs and passes it to Okta.
 

--- a/_source/_docs/api/resources/factor_admin.md
+++ b/_source/_docs/api/resources/factor_admin.md
@@ -11,7 +11,7 @@ The Okta Factors Administration API is a subset of the Factors API. It provides 
 
 After activating a facor with this API, it cannot be used until you enable a policy that uses this factor. If there is only one factor enabled in the policy, this API cannot disable that factor.
 
-> This API is [a {% api_lifecycle beta%} feature](/docs/api/getting_started/releases-at-okta.html).
+> This API is a {% api_lifecycle beta%} feature.
 
 
 ## Factor Model

--- a/_source/_docs/api/resources/idps.md
+++ b/_source/_docs/api/resources/idps.md
@@ -676,7 +676,7 @@ curl -v -X POST \
                 "filter": null,
                 "action": "AUTO"
             },
-            "subject": { 
+            "subject": {
                 "userNameTemplate": {
                     "template": "idpuser.userPrincipalName",
                     "type": null
@@ -1256,7 +1256,7 @@ curl -v -X GET \
   }
 ]
 ~~~
- 
+
 #### Find Identity Providers by Name
 {:.api .api-operation}
 
@@ -1936,7 +1936,7 @@ Operations for just-in-time provisioning or account linking with a `CALLOUT` act
 
 Fetches an IdP transaction by `id`
 
-You must use a `CALLOUT` action for [user provisioning](#user-provisioning-action-type) or [account linking](#account-link-action-type) 
+You must use a `CALLOUT` action for [user provisioning](#user-provisioning-action-type) or [account linking](#account-link-action-type)
 to obtain an IdP transaction `id`.
 
 ##### Request Parameters
@@ -1977,7 +1977,7 @@ curl -v -X GET \
     "type": "FACEBOOK"
   },
   "context": {
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) 
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko)
         Chrome/47.0.2526.106 Safari/537.36",
     "ipAddress": "127.0.0.1"
   },
@@ -2259,7 +2259,7 @@ curl -v -X POST \
     "type": "FACEBOOK"
   },
   "context": {
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) 
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko)
         Chrome/47.0.2526.106 Safari/537.36",
     "ipAddress": "127.0.0.1"
   },
@@ -2336,7 +2336,7 @@ curl -v -X POST \
     "type": "FACEBOOK"
   },
   "context": {
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) 
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko)
         Chrome/47.0.2526.106 Safari/537.36",
     "ipAddress": "127.0.0.1"
   },
@@ -2363,7 +2363,7 @@ curl -v -X POST \
 
 
 ### Find Users
-{:.api .api-operation} 
+{:.api .api-operation}
 
 {% api_operation get /api/v1/idps/*:id*/users %}
 
@@ -2427,11 +2427,11 @@ GET https://example.okta.com/api/v1/idps/0oa4lb6lbtmH355Hx0h7/users
 ~~~
 
 ### Unlink User from IdP
-{:.api .api-operation} 
+{:.api .api-operation}
 
 {% api_operation delete /api/v1/idps/*:id*/users/*:uid* %}
 
-Removes the link between the Okta user and the IdP user. 
+Removes the link between the Okta user and the IdP user.
 The next time the user federates into Okta via this IdP, they have to re-link their account according to the account link policy configured in Okta for this IdP.
 
 ##### Request Parameters
@@ -2716,7 +2716,7 @@ HTTP/1.1 204 No Content
 
 ## Identity Provider Signing Key Store Operations
 
-> You must enable the key rollover feature to perform the following operations. Key rollover is [an {% api_lifecycle ea %} feature](/docs/api/getting_started/releases-at-okta.html); contact Customer Support to enable it.
+> You must enable the key rollover feature to perform the following operations. Key rollover is an {% api_lifecycle ea %} feature; contact Customer Support to enable it.
 
 > EA feature constraint: Okta currently uses the same key for both request signing and decrypting SAML Assertions that have been encrypted by the IdP. Changing your signing key also changes your decryption key.
 
@@ -3379,7 +3379,7 @@ Federation trust credentials for verifying assertions from the IdP:
 
 Determines the [IdP Key Credential](#identity-provider-key-credential-model) used to sign requests sent to the IdP.
 
-> You must enable the key rollover feature to perform [Signing Key Operations](#identity-provider-signing-key-store-operations). Key rollover is [an {% api_lifecycle ea %} feature](/docs/api/getting_started/releases-at-okta.html); contact Customer Support to enable it.
+> You must enable the key rollover feature to perform [Signing Key Operations](#identity-provider-signing-key-store-operations). Key rollover is an {% api_lifecycle ea %} feature; contact Customer Support to enable it.
 
 |---------+----------------------------------------------------------------------------------------------------------------+----------+----------+----------+-----------+-----------+--------------------------------------------|
 | Property | Description                                                                                                   | DataType | Nullable | Readonly | MinLength | MaxLength | Validation                                 |
@@ -3714,7 +3714,7 @@ Specifies the user provisioning action during authentication when an IdP user is
 
 Property Details
 
-* To successfully provision a new Okta user, JIT provisioning must be enabled in your organization security settings for `AUTO` or `CALLOUT` actions. 
+* To successfully provision a new Okta user, JIT provisioning must be enabled in your organization security settings for `AUTO` or `CALLOUT` actions.
 * If the target username is not unique or the resulting Okta user profile is missing a required profile attribute, JIT provisioning may fail.
 * New Okta users are provisioned with either a `FEDERATION` or `SOCIAL` authentication provider depending on the IdP `type`.
 
@@ -3939,11 +3939,11 @@ Specifies the behavior for establishing, validating, and matching a username for
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | -------- | -------- | --------- | --------- | ------------------------------------------------------------------- |
 | userNameTemplate | [Okta EL Expression](../getting_started/okta_expression_lang.html) to generate or transform a unique username for the IdP user     | [UserName Template Object](#username-template-object)  | FALSE    | FALSE    |           |           | [Okta EL Expression](../getting_started/okta_expression_lang.html)  |
 | filter           | Optional [regular expression pattern](https://en.wikipedia.org/wiki/Regular_expression) used to filter untrusted IdP usernames      | String                                                 | TRUE     | FALSE    | 0         | 1024      |                                                                     |
-| matchType        | Determines the Okta user profile attribute match conditions for account linking and authentication of the transformed IdP username  | `USERNAME`, `EMAIL`, `USERNAME_OR_EMAIL` or `CUSTOM_ATTRIBUTE`      | FALSE    | FALSE    |           |           |  
+| matchType        | Determines the Okta user profile attribute match conditions for account linking and authentication of the transformed IdP username  | `USERNAME`, `EMAIL`, `USERNAME_OR_EMAIL` or `CUSTOM_ATTRIBUTE`      | FALSE    | FALSE    |           |           |
 | matchAttribute        | Okta user profile attribute for matching transformed IdP username. Only for matchType `CUSTOM_ATTRIBUTE` and `SAML2` IdP*  | String      | TRUE    | FALSE    |           |           | Must be a valid Okta user profile attribute of type String (with no format or 'email' format only), Integer or Number                                                                  |
 |------------------+-------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------+----------+----------+-----------+-----------+---------------------------------------------------------------------|
 
-> \*`CUSTOM_ATTRIBUTE` with `matchType` is an [{% api_lifecycle ea %} feature](/docs/api/getting_started/releases-at-okta.html). Contact Support to enable it.
+> \*`CUSTOM_ATTRIBUTE` with `matchType` is an {% api_lifecycle ea %} feature. Contact Support to enable it.
 
 
 Property Details
@@ -3977,7 +3977,7 @@ Property Details
 
 * IdP user profile attributes can be referenced with the `idpuser` prefix such as `idpuser.subjectNameId`.
 
-* You must define a IdP user profile attribute before it can be referenced in an Okta EL expression. To define an IdP user attribute policy, you may need to create a new IdP instance without a base profile property, edit the IdP user profile, 
+* You must define a IdP user profile attribute before it can be referenced in an Okta EL expression. To define an IdP user attribute policy, you may need to create a new IdP instance without a base profile property, edit the IdP user profile,
    then update the IdP instance with an expression that references the IdP user profile attribute you just created.
 
 ~~~json
@@ -4094,8 +4094,8 @@ Property Details
 
 ### Links Object
 
-Specifies link relationships (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the IdP 
-using the [JSON Hypertext Application Language](http://tools.ietf.org/html/draft-kelly-json-hal-06) specification.  
+Specifies link relationships (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the IdP
+using the [JSON Hypertext Application Language](http://tools.ietf.org/html/draft-kelly-json-hal-06) specification.
 This object is used for dynamic discovery of related resources and lifecycle operations, and is read only.
 
 |--------------------+-----------------------------------------------------------------------------------------------------------------------------------|
@@ -4127,7 +4127,7 @@ The Identity Provider Transaction Model represents an account link or just-in-ti
     "type": "FACEBOOK"
   },
   "context": {
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) 
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko)
         Chrome/47.0.2526.106 Safari/537.36",
     "ipAddress": "54.197.192.167"
   },
@@ -4214,7 +4214,7 @@ Additional context that describes the HTTP client for the transaction:
 ~~~json
 {
   "context": {
-    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) 
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko)
         Chrome/47.0.2526.106 Safari/537.36",
     "ipAddress": "54.197.192.167"
   }
@@ -4223,7 +4223,7 @@ Additional context that describes the HTTP client for the transaction:
 
 ### Links Object
 
-Specifies link relationships (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the IdP transaction using the [JSON Hypertext Application Language](http://tools.ietf.org/html/draft-kelly-json-hal-06) specification.  
+Specifies link relationships (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the IdP transaction using the [JSON Hypertext Application Language](http://tools.ietf.org/html/draft-kelly-json-hal-06) specification.
 This object is used for dynamic discovery of related resources and lifecycle operations, and is read only.
 
 |--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/_source/_docs/api/resources/oauth-clients.md
+++ b/_source/_docs/api/resources/oauth-clients.md
@@ -12,7 +12,7 @@ OAuth 2.0 and OpenID Connect endpoints. This API largely follows the contract de
 Note that clients managed via this API are modeled as applications in Okta and will show in the Applications section of the
 Administrator dashboard. Changes made via the API will reflect in the UI and vice versa.
 
-> This API is [a {% api_lifecycle beta%} feature](/docs/api/getting_started/releases-at-okta.html).
+> This API is an {% api_lifecycle beta%} feature.
 
 ## Client Application Model
 
@@ -56,20 +56,20 @@ Administrator dashboard. Changes made via the API will reflect in the UI and vic
 Client applications have the following properties:
 
 |----------------------------+-------------------------------------------------------------------+------------------------------------------------------------------------+----------+--------+----------|
-| Property                   | Description                                                       | DataType                                                               | Nullable | Unique | Readonly | 
-| -------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------- | -------- | ------ | -------- | 
+| Property                   | Description                                                       | DataType                                                               | Nullable | Unique | Readonly |
+| -------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------- | -------- | ------ | -------- |
 | client_id                  | unique key for the client application                             | String                                                                 | FALSE    | TRUE   | TRUE     |
 | client_id_issued_at        | time at which the client_id was issued (measured in unix seconds) | Number                                                                 | FALSE    | FALSE  | TRUE     |
 | client_name                | human-readable string name of the client application              | String                                                                 | FALSE    | FALSE  | FALSE    |
 | client_secret              | OAuth 2.0 client secret string (used for confidential clients)    | String                                                                 | TRUE     | TRUE   | TRUE     |
-| logo_uri                   | URL string that references a logo for the client                  | String                                                                 | TRUE     | FALSE  | FALSE    | 
+| logo_uri                   | URL string that references a logo for the client                  | String                                                                 | TRUE     | FALSE  | FALSE    |
 | application_type           | The type of client application                                    | `web`, `native`, `browser`, or `service`                               | TRUE     | TRUE   | TRUE     |
 | redirect_uris              | array of redirection URI strings for use in redirect-based flows  | Array                                                                  | TRUE     | FALSE  | FALSE    |
 | response_types             | array of OAuth 2.0 response type strings                          | Array of `code`, `token`, `id_token`                                   | TRUE     | FALSE  | FALSE    |
-| grant_types                | array of OAuth 2.0 grant type strings                             | Array of `authorization_code`, `implicit`, `password`, `refresh_token`, `client_credentials` | FALSE    | FALSE  | FALSE    | 
+| grant_types                | array of OAuth 2.0 grant type strings                             | Array of `authorization_code`, `implicit`, `password`, `refresh_token`, `client_credentials` | FALSE    | FALSE  | FALSE    |
 | token_endpoint_auth_method | requested authentication method for the token endpoint            | `none`, `client_secret_post`, or `client_secret_basic`                 | FALSE    | FALSE  | FALSE    |
 | initiate_login_uri         | URL that a third party can use to initiate a login by the client  | String                                                                 | TRUE     | FALSE  | FALSE    |
-| _links                     | discoverable resources related to the app                         | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)         | TRUE     | FALSE  | TRUE     | 
+| _links                     | discoverable resources related to the app                         | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)         | TRUE     | FALSE  | TRUE     |
 |----------------------------+-------------------------------------------------------------------+------------------------------------------------------------------------+----------+--------+----------|
 
 > The `client_id`, `client_id_issued_at`, and `client_secret` attributes are only available after a client is created.
@@ -86,7 +86,7 @@ Client applications have the following properties:
   the OAuth 2.0 authorization code grant.
 
 > At least one redirect URI and response type is required for all client types, with exceptions: if the client uses the
-  [Resource Owner Password](https://tools.ietf.org/html/rfc6749#section-4.3) flow (if `grant_types` contains the value `password`) 
+  [Resource Owner Password](https://tools.ietf.org/html/rfc6749#section-4.3) flow (if `grant_types` contains the value `password`)
   or [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow (if `grant_types` contains the value `client_credentials`)
   then no redirect URI or response type is necessary. In these cases you can pass either null or an empty array for these attributes.
 
@@ -414,7 +414,7 @@ Updates the settings for a client application from your organization.
 ##### Request Parameters
 {:.api .api-request .api-request-params}
 
-Parameter | Description                        | ParamType | DataType                               | Required | 
+Parameter | Description                        | ParamType | DataType                               | Required |
 --------- | ---------------------------------- | --------- | -------------------------------------- | -------- |
 clientId  | `clientId` of a specific client    | URL       | String                                 | TRUE     |
 settings  | OAuth client registration settings | Body      | [Client Settings](#oauth-client-model) | TRUE     |
@@ -501,7 +501,7 @@ Generates a new client secret for the specified client application.
 ##### Request Parameters
 {:.api .api-request .api-request-params}
 
-Parameter | Description                        | ParamType | DataType                               | Required | 
+Parameter | Description                        | ParamType | DataType                               | Required |
 --------- | ---------------------------------- | --------- | -------------------------------------- | -------- |
 clientId  | `clientId` of a specific client    | URL       | String                                 | TRUE     |
 
@@ -571,7 +571,7 @@ Removes a client application from your organization.
 ##### Request Parameters
 {:.api .api-request .api-request-params}
 
-Parameter | Description                        | ParamType | DataType | Required | 
+Parameter | Description                        | ParamType | DataType | Required |
 --------- | ---------------------------------- | --------- | -------- | -------- |
 clientId  | `clientId` of a specific client    | URL       | String   | TRUE     |
 

--- a/_source/_docs/api/resources/oauth2.md
+++ b/_source/_docs/api/resources/oauth2.md
@@ -5,16 +5,16 @@ title: OAuth 2.0
 
 # OAuth 2.0 API
 
-Okta is a fully standards-compliant [OAuth 2.0](http://oauth.net/documentation) authorization server and a certified [OpenID Provider](http://openid.net/certification). 
+Okta is a fully standards-compliant [OAuth 2.0](http://oauth.net/documentation) authorization server and a certified [OpenID Provider](http://openid.net/certification).
 The OAuth 2.0 APIs provide API security via scoped access tokens, and OpenID Connect provides user authentication and an SSO layer which is lighter and easier to use than SAML.
 
 There are several use cases and Okta product features built on top of the OAuth 2.0 APIs:
 
-* Social Authentication -- [{% api_lifecycle ea %}](/docs/api/getting_started/releases-at-okta.html)
-* OpenID Connect -- [{% api_lifecycle ea %}](/docs/api/getting_started/releases-at-okta.html)
-* API Access Management -- [{% api_lifecycle ea %}](/docs/api/getting_started/releases-at-okta.html)
+* Social Authentication -- {% api_lifecycle ea %}
+* OpenID Connect -- {% api_lifecycle ea %}
+* API Access Management -- {% api_lifecycle ea %}
 
-It's important to understand which use case you are targeting and build your application according to the correct patterns for that use case. 
+It's important to understand which use case you are targeting and build your application according to the correct patterns for that use case.
 The OAuth 2.0 APIs each have several different [query params](#authentication-request) which dictate which type of flow you are using and the mechanics of that flow.
 
 At the very basic level, the main API endpoints are:
@@ -33,16 +33,16 @@ At the very basic level, the main API endpoints are:
     * Assumes Resource Owner and Public Client are on the same device
 
     ![Browser/Single-Page Application](/assets/img/browser_spa_implicit_flow.png)
-    
+
 2. Native Application
 
     * Installed on a device or computer, such as mobile applications or installed desktop applications
     * Uses [Authorization Code Grant Flow](https://tools.ietf.org/html/rfc6749#section-4.1)
     * Can use custom redirect URIs like `myApp://oauth:2.0:native`
-    
+
     ![Native Application Flow](/assets/img/native_auth_flow.png)
 
-    > Note: For native applications, the client_id and client_secret are embedded in the source code of the application; in this context, the client secret isn't treated as a secret. 
+    > Note: For native applications, the client_id and client_secret are embedded in the source code of the application; in this context, the client secret isn't treated as a secret.
         Therefore native apps should make use of Proof Key for Code Exchange (PKCE) to mitigate authorization code interception.
         For more information, see the PKCE note in [Parameter Details](#parameter-details).
 
@@ -52,7 +52,7 @@ At the very basic level, the main API endpoints are:
     * Uses [Authorization Code Grant Flow](https://tools.ietf.org/html/rfc6749#section-4.1)
     * Assumes Resource Owner and Client are on separate devices
     * Most secure flow as tokens never pass through user-agent
-    
+
     ![Web Application Flow](/assets/img/web_app_flow.png)
 
 4. Service Application
@@ -61,18 +61,18 @@ At the very basic level, the main API endpoints are:
     * Uses [Client Credentials Flow](https://tools.ietf.org/html/rfc6749#section-4.4)
     * Optimized for [Confidential Clients](https://tools.ietf.org/html/rfc6749#section-2.1) acting on behalf of itself or a user
     * Back-channel only flow to obtain an access token using the Client’s credentials
-    
+
     ![Service Application Flow](/assets/img/service_app_flow.png).
 
 
-    > Note: The OAuth 2.0 specification mandates that clients implement CSRF protection for their redirection URI endpoints. 
-    This is what the `state` parameter is used for in the flows described above; the client should send a state value in on the authorization request, 
+    > Note: The OAuth 2.0 specification mandates that clients implement CSRF protection for their redirection URI endpoints.
+    This is what the `state` parameter is used for in the flows described above; the client should send a state value in on the authorization request,
     and it must validate that returned "state" parameter from the authorization server matches the original value.
 
 ## Custom User Experience
 
-By default, the Authorization Endpoint displays the Okta login page and authenticates users if they don't have an existing session. 
-If you prefer to use a fully customized user experience, you can instead authenticate the user via the [Authentication API](http://developer.okta.com/docs/api/resources/authn.html). 
+By default, the Authorization Endpoint displays the Okta login page and authenticates users if they don't have an existing session.
+If you prefer to use a fully customized user experience, you can instead authenticate the user via the [Authentication API](http://developer.okta.com/docs/api/resources/authn.html).
 This authentication method produces a `sessionToken` which can be passed into the Authorize Endpoint, and the user won't see an Okta login page.
 
 ## Access Token
@@ -189,7 +189,7 @@ Custom claims are associated with scopes. If one of the associated scopes is gra
 
 ## Validating Access Tokens
 
-Okta uses public key cryptography to sign tokens and verify that they are valid. 
+Okta uses public key cryptography to sign tokens and verify that they are valid.
 
 The resource server must validate the Access Token before allowing the client to access protected resources.
 
@@ -269,7 +269,7 @@ For example, assume the following conditions are in effect:
 
 Because Rule A has a higher priority, the requests for user U are evaluated in Rule A, and Rule B is not evaluated.
 
-The requests with client_credential grant type match "no user" condition, which excludes everyone, because there is no user session for the request.
+The requests with `client_credentials` grant type match "no user" condition, which excludes everyone, because there is no user session for the request.
 
 The actions in a Rule define which scopes can be granted to the requests, thus determines which claims will be added into the tokens. They also define the lifetime of the Access Token and Refresh Token.
 
@@ -277,8 +277,8 @@ The actions in a Rule define which scopes can be granted to the requests, thus d
 
 API Access Management allows you to build custom authorization servers in Okta which can be used to protect your own API endpoints. An authorization server defines your security boundary, for example “staging” or “production.” Within each authorization server you can define your own OAuth scopes, claims, and access policies. This allows your apps and your APIs to anchor to a central authorization point and leverage the rich identity features of Okta, such as Universal Directory for transforming attributes, adaptive MFA for end-users, analytics, and system log, and extend it out to the API economy.
 
-At its core, an authorization server is simply an OAuth 2.0 token minting engine. 
-Each authorization server has a unique issuer URI and its own signing key for tokens in order to keep proper boundary between security domains. 
+At its core, an authorization server is simply an OAuth 2.0 token minting engine.
+Each authorization server has a unique issuer URI and its own signing key for tokens in order to keep proper boundary between security domains.
 The authorization server also acts as an OpenID Connect Provider, which means you can request ID tokens in addition to access tokens from the authorization server endpoints.
 To configure an authorization server, log into your org and navigate to **Security** > **API** > **Add Authorization Server**.
 
@@ -288,7 +288,7 @@ You can use OpenID Connect without the API Access Management feature, using the 
 However, you can also use OpenID Connect with an authorization server specified:
 
 * `/oauth2/v1/userinfo` for OpenID Connect without API Access Management
-* `/oauth2/:authorizationServerId/v1/userinfo` for OpenID Connect with API Access Management 
+* `/oauth2/:authorizationServerId/v1/userinfo` for OpenID Connect with API Access Management
 
 You can't mix tokens between different authorization servers. By design, authorization servers don't have trust relationships with each other.
 
@@ -307,23 +307,23 @@ This is a starting point for OAuth 2.0 flows such as implicit and authorization 
 Parameter         | Description                                                                                        | Param Type | DataType  | Required | Default         |
 ----------------- | -------------------------------------------------------------------------------------------------- | ---------- | --------- | -------- | --------------- |
 [idp](idps.html)  | The Identity provider used to do the authentication. If omitted, use Okta as the identity provider. | Query      | String    | FALSE    | Okta is the IDP. |
-sessionToken      | An Okta one-time sessionToken. This allows an API-based user login flow (rather than Okta login UI). Session tokens can be obtained via the [Authentication API](authn.html).   | Query | String    | FALSE | |             
+sessionToken      | An Okta one-time sessionToken. This allows an API-based user login flow (rather than Okta login UI). Session tokens can be obtained via the [Authentication API](authn.html).   | Query | String    | FALSE | |
 response_type     | Can be a combination of *code*, *token*, and *id_token*. The chosen combination determines which flow is used; see this reference from the [OAuth 2.0 specification](https://tools.ietf.org/html/rfc6749#section-3.1.1). The code response type returns an authorization code which can be later exchanged for an Access Token or a Refresh Token. | Query        | String   |   TRUE   |  |
-client_id         | Obtained during either [UI client registration](../../guides/social_authentication.html) or [API client registration](oauth-clients.html). It is the identifier for the client and it must match what is preregistered in Okta. | Query        | String   | TRUE     | 
-redirect_uri      | Specifies the callback location where the authorization code should be sent and it must match what is preregistered in Okta as a part of client registration. | Query        | String   |  TRUE    | 
+client_id         | Obtained during either [UI client registration](../../guides/social_authentication.html) or [API client registration](oauth-clients.html). It is the identifier for the client and it must match what is preregistered in Okta. | Query        | String   | TRUE     |
+redirect_uri      | Specifies the callback location where the authorization code should be sent and it must match what is preregistered in Okta as a part of client registration. | Query        | String   |  TRUE    |
 display           | Specifies how to display the authentication and consent UI. Valid values: *page* or *popup*.  | Query        | String   | FALSE     |  |
 max_age           | Specifies the allowable elapsed time, in seconds, since the last time the end user was actively authenticated by Okta. | Query      | String    | FALSE    | |
 response_mode     | Specifies how the authorization response should be returned. [Valid values: *fragment*, *form_post*, *query* or *okta_post_message*](#parameter-details). If *id_token* or *token* is specified as the response type, then *query* isn't allowed as a response mode. Defaults to *fragment* in implicit and hybrid flow. Defaults to *query* in authorization code flow and cannot be set as *okta_post_message*. | Query        | String   | FALSE      | See Description.
-scope          | **Required.** Can be a combination of reserved scopes and custom scopes. The combination determines the claims that are returned in the access_token and id_token. The openid scope has to be specified to get back an id_token. | Query        | String   | TRUE     | 
-state          | A client application provided state string that might be useful to the application upon receipt of the response. It can contain alphanumeric, comma, period, underscore and hyphen characters.   | Query        | String   |  TRUE    | 
-prompt         | Can be either *none* or *login*. The value determines if Okta should not prompt for authentication (if needed), or force a prompt (even if the user had an existing session). Default: The default behavior is based on whether there's an existing Okta session. | Query        | String   | FALSE     | See Description. 
-nonce          | Specifies a nonce that is reflected back in the ID Token. It is used to mitigate replay attacks. | Query        | String   | TRUE     | 
-code_challenge | Specifies a challenge of [PKCE](#parameter-details). The challenge is verified in the Access Token request.  | Query        | String   | FALSE    | 
-code_challenge_method | Specifies the method that was used to derive the code challenge. Only S256 is supported.  | Query        | String   | FALSE    | 
+scope          | **Required.** Can be a combination of reserved scopes and custom scopes. The combination determines the claims that are returned in the access_token and id_token. The openid scope has to be specified to get back an id_token. | Query        | String   | TRUE     |
+state          | A client application provided state string that might be useful to the application upon receipt of the response. It can contain alphanumeric, comma, period, underscore and hyphen characters.   | Query        | String   |  TRUE    |
+prompt         | Can be either *none* or *login*. The value determines if Okta should not prompt for authentication (if needed), or force a prompt (even if the user had an existing session). Default: The default behavior is based on whether there's an existing Okta session. | Query        | String   | FALSE     | See Description.
+nonce          | Specifies a nonce that is reflected back in the ID Token. It is used to mitigate replay attacks. | Query        | String   | TRUE     |
+code_challenge | Specifies a challenge of [PKCE](#parameter-details). The challenge is verified in the Access Token request.  | Query        | String   | FALSE    |
+code_challenge_method | Specifies the method that was used to derive the code challenge. Only S256 is supported.  | Query        | String   | FALSE    |
 
 #### Parameter Details
- 
- * *idp* and *sessionToken* are Okta extensions to the [OIDC specification](http://openid.net/specs/openid-connect-core-1_0.html#Authentication). 
+
+ * *idp* and *sessionToken* are Okta extensions to the [OIDC specification](http://openid.net/specs/openid-connect-core-1_0.html#Authentication).
     All other parameters comply with the [OAuth 2.0 specification](https://tools.ietf.org/html/rfc6749) and their behavior is consistent with the specification.
  * Each value for *response_mode* delivers different behavior:
     * *fragment* -- Parameters are encoded in the URL fragment added to the *redirect_uri* when redirecting back to the client.
@@ -331,48 +331,48 @@ code_challenge_method | Specifies the method that was used to derive the code ch
     * *form_post* -- Parameters are encoded as HTML form values that are auto-submitted in the User Agent.Thus, the values are transmitted via the HTTP POST method to the client
       and the result parameters are encoded in the body using the application/x-www-form-urlencoded format.
     * *okta_post_message* -- Uses [HTML5 Web Messaging](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) (for example, window.postMessage()) instead of the redirect for the authorization response from the authorization endpoint.
-      *okta_post_message* is an adaptation of the [Web Message Response Mode](https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00#section-4.1). 
-      This value provides a secure way for a single-page application to perform a sign-in flow 
+      *okta_post_message* is an adaptation of the [Web Message Response Mode](https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00#section-4.1).
+      This value provides a secure way for a single-page application to perform a sign-in flow
       in a popup window or an iFrame and receive the ID token and/or access token back in the parent page without leaving the context of that page.
       The data model for the [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) call is in the next section.
-      
- * Okta requires the OAuth 2.0 *state* parameter on all requests to the authorization endpoint in order to prevent cross-site request forgery (CSRF). 
- The OAuth 2.0 specification [requires](https://tools.ietf.org/html/rfc6749#section-10.12) that clients protect their redirect URIs against CSRF by sending a value in the authorize request which binds the request to the user-agent's authenticated state. 
+
+ * Okta requires the OAuth 2.0 *state* parameter on all requests to the authorization endpoint in order to prevent cross-site request forgery (CSRF).
+ The OAuth 2.0 specification [requires](https://tools.ietf.org/html/rfc6749#section-10.12) that clients protect their redirect URIs against CSRF by sending a value in the authorize request which binds the request to the user-agent's authenticated state.
  Using the *state* parameter is also a countermeasure to several other known attacks as outlined in [OAuth 2.0 Threat Model and Security Considerations](https://tools.ietf.org/html/rfc6819).
 
  * [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) (PKCE) is a stronger mechanism for binding the authorization code to the client than just a client secret, and prevents [a code interception attack](https://tools.ietf.org/html/rfc7636#section-1) if both the code and the client credentials are intercepted (which can happen on mobile/native devices). The PKCE-enabled client creates a large random string as code_verifier and derives code_challenge from it using code_challenge_method. It passes the code_challenge and code_challenge_method in the authorization request for code flow. When a client tries to redeem the code, it must pass the code_verifer. Okta recomputes the challenge and returns the requested token only if it matches the code_challenge in the original authorization request. When a client, whose token_endpoint_auth_method is 'none', makes a code flow authorization request, the code_challenge parameter is required.
-      
+
 #### postMessage() Data Model
 
 Use the postMessage() data model to help you when working with the *okta_post_message* value of the *response_mode* request parameter.
 
 *message*:
 
-Parameter         | Description                                                                                        | DataType  | 
------------------ | -------------------------------------------------------------------------------------------------- | ----------| 
+Parameter         | Description                                                                                        | DataType  |
+----------------- | -------------------------------------------------------------------------------------------------- | ----------|
 id_token          | The ID Token JWT contains the details of the authentication event and the claims corresponding to the requested scopes. This is returned if the `response_type` includes `id_token`. | String   |
 access_token      | The *access_token* used to access the [`/oauth2/v1/userinfo`](/docs/api/resources/oidc.html#get-user-information) endpoint. This is returned if the *response_type* included a token. <b>Important</b>: Unlike the ID Token JWT, the *access_token* structure is specific to Okta, and is subject to change. | String    |
 state             | If the request contained a `state` parameter, then the same unmodified value is returned back in the response. | String    |
 error             | The error-code string providing information if anything goes wrong.                                | String    |
 error_description | Additional description of the error.                                                               | String    |
 
-*targetOrigin*: 
+*targetOrigin*:
 
 Specifies what the origin of *parentWindow* must be in order for the postMessage() event to be dispatched
-(this is enforced by the browser). The *okta-post-message* response mode always uses the origin from the *redirect_uri* 
+(this is enforced by the browser). The *okta-post-message* response mode always uses the origin from the *redirect_uri*
 specified by the client. This is crucial to prevent the sensitive token data from being exposed to a malicious site.
 
 #### Response Parameters
 
-The response depends on the response type passed to the API. For example, a *fragment* response mode returns values in the fragment portion of a redirect to the specified *redirect_uri* while a *form_post* response mode POSTs the return values to the redirect URI. 
+The response depends on the response type passed to the API. For example, a *fragment* response mode returns values in the fragment portion of a redirect to the specified *redirect_uri* while a *form_post* response mode POSTs the return values to the redirect URI.
 Irrespective of the response type, the contents of the response is always one of the following.
 
-Parameter         | Description                                                                                        | DataType  | 
------------------ | -------------------------------------------------------------------------------------------------- | ----------| 
-id_token          | The ID Token JWT contains the details of the authentication event and the claims corresponding to the requested scopes. This is returned if the *response_type* includes *id_token*.| String    | 
+Parameter         | Description                                                                                        | DataType  |
+----------------- | -------------------------------------------------------------------------------------------------- | ----------|
+id_token          | The ID Token JWT contains the details of the authentication event and the claims corresponding to the requested scopes. This is returned if the *response_type* includes *id_token*.| String    |
 access_token      | The *access_token* that is used to access the resource. This is returned if the *response_type* included a token. | String  |
 token_type        | The token type is always `Bearer` and is returned only when *token* is specified as a *response_type*. | String |
-code              | An opaque value that can be used to redeem tokens from [token endpoint](#token-request).| String    | 
+code              | An opaque value that can be used to redeem tokens from [token endpoint](#token-request).| String    |
 expires_in        | The number of seconds until the *access_token* expires. This is only returned if the response included an *access_token*. | String |
 scope             | The scopes of the *access_token*. This is only returned if the response included an *access_token*. | String |
 state             | The same unmodified value from the request is returned back in the response. | String |
@@ -381,27 +381,27 @@ error_description | Further description of the error. | String |
 
 ##### Possible Errors
 
-These APIs are compliant with the OpenID Connect and OAuth 2.0 spec with some Okta specific extensions. 
+These APIs are compliant with the OpenID Connect and OAuth 2.0 spec with some Okta specific extensions.
 
 [OAuth 2.0 Spec error codes](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
 
-Error Id         | Details                                                                | 
------------------| -----------------------------------------------------------------------| 
-unsupported_response_type  | The specified response type is invalid or unsupported.   | 
-unsupported_response_mode  | The specified response mode is invalid or unsupported. This error is also thrown for disallowed response modes. For example, if the query response mode is specified for a response type that includes id_token.    | 
-invalid_scope   | The scopes list contains an invalid or unsupported value.    | 
-server_error    | The server encountered an internal error.    | 
+Error Id         | Details                                                                |
+-----------------| -----------------------------------------------------------------------|
+unsupported_response_type  | The specified response type is invalid or unsupported.   |
+unsupported_response_mode  | The specified response mode is invalid or unsupported. This error is also thrown for disallowed response modes. For example, if the query response mode is specified for a response type that includes id_token.    |
+invalid_scope   | The scopes list contains an invalid or unsupported value.    |
+server_error    | The server encountered an internal error.    |
 temporarily_unavailable    | The server is temporarily unavailable, but should be able to process the request at a later time.    |
 invalid_request | The request is missing a necessary parameter or the parameter has an invalid value. |
 invalid_grant   | The specified grant is invalid, expired, revoked, or does not match the redirect URI used in the authorization request.
 invalid_token   | The provided access token is invalid.
 invalid_client  | The specified client id is invalid.
-access_denied   | The server denied the request. 
+access_denied   | The server denied the request.
 
 [Open-ID Spec error codes](http://openid.net/specs/openid-connect-core-1_0.html#AuthError)
 
-Error Id           | Details                                                                | 
--------------------| -----------------------------------------------------------------------| 
+Error Id           | Details                                                                |
+-------------------| -----------------------------------------------------------------------|
 login_required     | The request specified that no prompt should be shown but the user is currently not authenticated.    |
 insufficient_scope | The access token provided does not contain the necessary scopes to access the resource.              |
 
@@ -441,7 +441,7 @@ http://www.example.com/#error=invalid_scope&error_description=The+requested+scop
 
 {% api_operation post /oauth2/:authorizationServerId/v1/token %}
 
-The API takes a grant type of either *authorization_code*, *password*, *refresh_token*, or [*client_credentials* {% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html) and the corresponding credentials and returns back an Access Token. A Refresh Token will be returned if *offline_access* scope is requested using authorization_code, password, or refresh_token grant type. Additionally, using the authorization_code grant type will return an ID Token if the *openid* scope is requested.
+The API takes a grant type of either *authorization_code*, *password*, *refresh_token*, or *client_credentials* and the corresponding credentials and returns back an Access Token. A Refresh Token will be returned if *offline_access* scope is requested using authorization_code, password, or refresh_token grant type. Additionally, using the authorization_code grant type will return an ID Token if the *openid* scope is requested.
 
 > Note:  No errors occur if you use this endpoint, but it isn’t useful until custom scopes or resource servers are available. We recommend you wait until custom scopes and resource servers are available.
 
@@ -451,7 +451,7 @@ The following parameters can be posted as a part of the URL-encoded form values 
 
 Parameter          | Description                                                                                         | Type       |
 -------------------+-----------------------------------------------------------------------------------------------------+------------|
-grant_type         | Can be one of the following: *authorization_code*, *password*, *refresh_token*, or [*client_credentials* {% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html). Determines the mechanism Okta will use to authorize the creation of the tokens. | String |  
+grant_type         | Can be one of the following: *authorization_code*, *password*, *refresh_token*, or *client_credentials*. Determines the mechanism Okta will use to authorize the creation of the tokens. | String |
 code               | Expected if grant_type specified *authorization_code*. The value is what was returned from the [authorization endpoint](#authentication-request). | String
 refresh_token      | Expected if the grant_type specified *refresh_token*. The value is what was returned from this endpoint via a previous invocation. | String |
 username           | Expected if the grant_type specified *password*. | String |
@@ -462,18 +462,15 @@ code_verifier      | Expected if grant_type specified *authorization_code* for n
 client_id          | Expected if *code_verifier* is included or client credentials are not provided in the Authorization header. This is used in conjunction with the client_secret parameter to authenticate the client application. | String |
 client_secret      | Expected if *code_verifier* is not included and client credentials are not provided in the Authorization header. This is used in conjunction with the client_id parameter to authenticate the client application. | String |
 
-> The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow (if `grant_types` is `client_credentials`) is [a {% api_lifecycle beta %} feature](/docs/api/getting_started/releases-at-okta.html).
-
-
 ##### Token Authentication Method
 
-For clients authenticating by client credentials, provide the [`client_id`](oidc.html#request-parameters) 
+For clients authenticating by client credentials, provide the [`client_id`](oidc.html#request-parameters)
 and [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect) either as an Authorization header in the Basic auth scheme (basic authentication) or as additional parameters to the POST body. Including credentials in both the headers and the POST body is not allowed.
 
 For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request.
 
 ~~~sh
-Authorization: Basic ${Base64(<client_id>:<client_secret>)} 
+Authorization: Basic ${Base64(<client_id>:<client_secret>)}
 ~~~
 
 #### Response Parameters
@@ -495,7 +492,7 @@ For web and native application types, an additional process is required:
 1. Use the Okta Administration UI and check the **Refresh Token** checkbox under **Allowed Grant Types** on the client application page.
 2. Pass the *offline_access* scope to your authorize request.
 
-#### List of Errors 
+#### List of Errors
 
 Error Id                |  Details                                                                                                     |
 ------------------------+--------------------------------------------------------------------------------------------------------------|
@@ -549,8 +546,8 @@ Content-Type: application/json;charset=UTF-8
 
 {% api_operation post /oauth2/:authorizationServerId/v1/introspect %}
 
-The API takes an Access Token or Refresh Token, and returns a boolean indicating whether it is active or not. 
-If the token is active, additional data about the token is also returned. If the token is invalid, expired, or revoked, it is considered inactive. 
+The API takes an Access Token or Refresh Token, and returns a boolean indicating whether it is active or not.
+If the token is active, additional data about the token is also returned. If the token is invalid, expired, or revoked, it is considered inactive.
 An implicit client can only introspect its own tokens, while a confidential client may inspect all access tokens.
 
 > Note; [ID Tokens](oidc.html#id-token) are also valid, however, they are usually validated on the service provider or app side of a flow.
@@ -561,7 +558,7 @@ The following parameters can be posted as a part of the URL-encoded form values 
 
 Parameter       | Description                                                                                         | Type       |
 ----------------+-----------------------------------------------------------------------------------------------------+------------|
-token           | An access token or refresh token.                                                                   | String     |  
+token           | An access token or refresh token.                                                                   | String     |
 token_type_hint | A hint of the type of *token*.                                                               | String     |
 client_id       | The client ID generated as a part of client registration. This is used in conjunction with the *client_secret* parameter to authenticate the client application. | String |
 client_secret   | The client secret generated as a part of client registration. This is used in conjunction with the *client_id* parameter to authenticate the client application. | String |
@@ -575,7 +572,7 @@ Use one authentication mechanism with a given request. Using both returns an err
 For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request.
 
 ~~~sh
-Authorization: Basic ${Base64(<client_id>:<client_secret>)} 
+Authorization: Basic ${Base64(<client_id>:<client_secret>)}
 ~~~
 
 #### Response Parameters
@@ -584,7 +581,7 @@ Based on the type of token and whether it is active or not, the returned JSON co
 
 Parameter   | Description                                                                                         | Type       |
 ------------+-----------------------------------------------------------------------------------------------------+------------|
-active      | An access token or refresh token.                                                                   | boolean    |  
+active      | An access token or refresh token.                                                                   | boolean    |
 token_type  | The type of the token. The value is always `Bearer`.                                                | String     |
 scope       | A space-delimited list of scopes.                                                                   | String     |
 client_id   | The ID of the client associated with the token.                                                     | String     |
@@ -599,7 +596,7 @@ jti         | The identifier of the token.                                      
 device_id   | The ID of the device associated with the token                                                      | String     |
 uid         | The user ID. This parameter is returned only if the token is an access token and the subject is an end user.     | String     |
 
-#### List of Errors 
+#### List of Errors
 
 Error Id                |  Details                                                                                                     |
 ------------------------+--------------------------------------------------------------------------------------------------------------|
@@ -674,7 +671,7 @@ The following parameters can be posted as a part of the URL-encoded form values 
 
 Parameter       | Description                                                                                         | Type       |
 ----------------+-----------------------------------------------------------------------------------------------------+------------|
-token           | An access token or refresh token.                                                                   | String     |  
+token           | An access token or refresh token.                                                                   | String     |
 token_type_hint | A hint of the type of *token*.                                                               | String     |
 client_id       | The client ID generated as a part of client registration. This is used in conjunction with the *client_secret* parameter to authenticate the client application. | String |
 client_secret   | The client secret generated as a part of client registration. This is used in conjunction with the *client_id* parameter to authenticate the client application. | String |
@@ -690,14 +687,14 @@ Use one authentication mechanism with a given request. Using both returns an err
 For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request.
 
 ~~~sh
-Authorization: Basic ${Base64(<client_id>:<client_secret>)} 
+Authorization: Basic ${Base64(<client_id>:<client_secret>)}
 ~~~
 
 #### Response Parameters
 
 A successful revocation is denoted by an empty response with an HTTP 200. Note that revoking an invalid, expired, or revoked token will still be considered a success as to not leak information
 
-#### List of Errors 
+#### List of Errors
 
 Error Id                |  Details                                                                                                     |
 ------------------------+--------------------------------------------------------------------------------------------------------------|
@@ -770,7 +767,7 @@ Content-Type: application/json;charset=UTF-8
 ~~~
 
 >Okta strongly recommends retrieving keys dynamically with the JWKS published in the discovery document.
-It is safe to cache keys for performance. 
+It is safe to cache keys for performance.
 
 
 Any of the keys listed are used to sign tokens. The order of keys in the result doesn't indicate which keys are used.
@@ -977,7 +974,7 @@ defaultResourceUri        | The url of the resource being secured by this author
 
 {:.api .api-operation}
 
-{% api_operation post /api/v1/as %} [{% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html)
+{% api_operation post /api/v1/as %} {% api_lifecycle beta %}
 
 ~~~sh
 curl -v -X POST \
@@ -1075,7 +1072,7 @@ credentials |  The credentials signing object with the `rotationMode` of the aut
 
 {:.api .api-operation}
 
-{% api_operation post /api/v1/as/:authorizationServerId %} [{% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html)
+{% api_operation post /api/v1/as/:authorizationServerId %} {% api_lifecycle beta %}
 
 ~~~sh
 curl -v -X POST \
@@ -1166,7 +1163,7 @@ Returns authorization server identified by authorizationServerId.
 
 {:.api .api-operation}
 
-{% api_operation get /api/v1/as/:authorizationServerId %} [{% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html)
+{% api_operation get /api/v1/as/:authorizationServerId %} {% api_lifecycle beta %}
 
 #### Request Example
 
@@ -1278,7 +1275,7 @@ Returns the current keys in rotation for the authorization server.
 
 {:.api .api-operation}
 
-{% api_operation get /api/v1/as/:authorizationServerId/credentials/keys %} [{% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html)
+{% api_operation get /api/v1/as/:authorizationServerId/credentials/keys %} {% api_lifecycle beta %}
 
 #### Request Example
 
@@ -1359,7 +1356,7 @@ use        | Can be only *sig*. Determines the type of keys being rotated for th
 
 {:.api .api-operation}
 
-{% api_operation post /api/v1/as/:authorizationServerId/credentials/lifecycle/keyRotate %} [{% api_lifecycle beta %}(/docs/api/getting_started/releases-at-okta.html)
+{% api_operation post /api/v1/as/:authorizationServerId/credentials/lifecycle/keyRotate %} {% api_lifecycle beta %}
 
 
 ##### Request Example

--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -15,13 +15,13 @@ and the client obtains an Okta session.
 
 OAuth 2.0 is an authorization framework for delegated access to APIs, and OpenID Connect is an SSO protocol for authenticating end-users and asserting their identity.
 OpenID Connect extends OAuth 2.0:
- 
+
 * Provides a signed *id_token* for the client and a UserInfo endpoint from which you can fetch user attributes.
 * Provides a standard set of scopes and claims for identities including profile, email, address, and phone.
 
 ![OpenID Architecture Diagram](/assets/img/openID_overview.png)
 
-Okta is the identity provider responsible for verifying the identity of users and applications that exist in an organization’s directory, 
+Okta is the identity provider responsible for verifying the identity of users and applications that exist in an organization’s directory,
 and issuing identity tokens upon successful authentication of those users and applications.
 
 The basic authentication flow with Okta as your identity provider:
@@ -33,8 +33,8 @@ The basic authentication flow with Okta as your identity provider:
 5. Okta mints a token and sends it in the response.
 6. The application validates the identity token’s integrity. For more information, see [Validating ID Tokens](#validating-id-tokens).
 
-> Important: Okta uses public key cryptography to sign tokens and verify that they are valid. 
-See the last section of [Validating ID Tokens](#validating-id-tokens) for more information on the necessary logic 
+> Important: Okta uses public key cryptography to sign tokens and verify that they are valid.
+See the last section of [Validating ID Tokens](#validating-id-tokens) for more information on the necessary logic
 you must have in your application to ensure it’s always updated with the latest keys.
 
 The flow of requests and responses for the authentication process is based on OAuth 2.0 and OpenID Connect protocols.
@@ -50,8 +50,8 @@ The claims requested by the `profile`, `email`, `address`, and `phone` scope val
 
 ## Scopes
 
-OpenID Connect uses scope values to specify what access privileges are being requested for Access Tokens. 
-The scopes associated with Access Tokens determine which claims are available when they are used 
+OpenID Connect uses scope values to specify what access privileges are being requested for Access Tokens.
+The scopes associated with Access Tokens determine which claims are available when they are used
 to access [the OIDC `userinfo` endpoint](http://developer.okta.com/docs/api/resources/oidc.html#get-user-information). The following scopes are supported:
 
 |--------------+--------------------------------------------------------------------------------|--------------|
@@ -76,13 +76,13 @@ to access [the OIDC `userinfo` endpoint](http://developer.okta.com/docs/api/reso
 
 ## ID Token
 
-OpenID Connect introduces an [ID Token](http://openid.net/specs/openid-connect-core-1_0.html#IDToken) 
-which is a [JSON web token (JWT)](https://tools.ietf.org/html/rfc7519) that contains information about an authentication event 
+OpenID Connect introduces an [ID Token](http://openid.net/specs/openid-connect-core-1_0.html#IDToken)
+which is a [JSON web token (JWT)](https://tools.ietf.org/html/rfc7519) that contains information about an authentication event
 as well as claims about the authenticated user.
 
 ID Tokens should always be [validated](#validating-id-tokens) by the client to ensure their integrity.
 
-The ID Token (*id_token*) consists of three period-separated, base64URL-encoded JSON segments: [a header](#header), [the payload](#payload), and [the signature](#signature). 
+The ID Token (*id_token*) consists of three period-separated, base64URL-encoded JSON segments: [a header](#header), [the payload](#payload), and [the signature](#signature).
 
 ### ID Token Header
 
@@ -121,11 +121,11 @@ The ID Token (*id_token*) consists of three period-separated, base64URL-encoded 
   "updated_at":1311280970,
   "email":"john.doe@example.com",
   "email_verified":true,
-  "address" : { "street_address": "123 Hollywood Blvd.", 
-  		"locality": "Los Angeles", 
-  		"region": "CA", 
-  		"postal_code": "90210", 
-  		"country": "US" 
+  "address" : { "street_address": "123 Hollywood Blvd.",
+  		"locality": "Los Angeles",
+  		"region": "CA",
+  		"postal_code": "90210",
+  		"country": "US"
   	},
   "phone_number":"+1 (425) 555-1212"
 }
@@ -154,7 +154,7 @@ Claims in the header are always returned.
 Claims in the payload are either base claims, independent of scope (always returned), or dependent on scope (not always returned).
 
 ##### Base claims (always present)
- 
+
 |--------------+-------------------+----------------------------------------------------------------------------------+--------------|--------------------------|
 | Property     |  Description                                                                      | DataType     | Example                  |
 |--------------+---------+----------+----------------------------------------------------------------------------------+--------------|--------------------------|
@@ -171,7 +171,7 @@ Claims in the payload are either base claims, independent of scope (always retur
 | nonce     |  Value used to associate a Client session with an ID Token, and to mitigate replay attacks. |  String   | "n-0S6_WzA2Mj"  |
 | at_hash     | The base64URL-encoded first 128-bits of the SHA-256 hash of the Access Token. This is only returned if an Access Token is also returned with an ID Token.  | String    | "MTIzNDU2Nzg5MDEyMzQ1Ng"     |
 | c_hash  | The base64URL-encoded first 128-bits of the SHA-256 hash of the authorization code. This is only returned if an authorization code is also returned with the ID Token. | String | "DE5MzQ1TIzlr30gokT2UDN"   |
-           
+
 ##### Scope-dependent claims (not always returned)
 
 |--------------+-------------------+----------------------------------------------------------------------------------+--------------|--------------------------|
@@ -196,7 +196,7 @@ Claims in the payload are either base claims, independent of scope (always retur
 
 Be aware of the following before you work with scope-dependent claims:
 
-* To protect against arbitrarily large numbers of groups matching the group filter, the groups claim has a limit of 100. 
+* To protect against arbitrarily large numbers of groups matching the group filter, the groups claim has a limit of 100.
 If more than 100 groups match the filter, then the request fails. Expect that this limit may change in the future.
 For more information about configuring an app for OpenID Connect, including group claims, see [Using OpenID Connect](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect).
 * **Important:** Scope-dependent claims are returned differently depending on the values in `response_type` and the scopes requested:
@@ -263,7 +263,7 @@ Returns a JSON document with information requested in the scopes list of the tok
 }
 ~~~
 
-The claims in the response are identical to those returned for the requested scopes in the *id_token* JWT, except for the sub-claim which is always present. 
+The claims in the response are identical to those returned for the requested scopes in the *id_token* JWT, except for the sub-claim which is always present.
 See [Scope-Dependent Claims](#scope-dependent-claims-not-always-returned) for more information about individual claims.
 
 #### Response Example (Error)
@@ -296,7 +296,7 @@ and only via POST data or within request headers. If you store them on your serv
 
 Clients must validate the ID Token in the Token Response in the following manner:
 
-1. Verify that the *iss* (issuer) claim in the ID Token exactly matches the issuer identifier for your Okta org (which is typically obtained during [Discovery](#openid-connect-discovery-document). 
+1. Verify that the *iss* (issuer) claim in the ID Token exactly matches the issuer identifier for your Okta org (which is typically obtained during [Discovery](#openid-connect-discovery-document).
 2. Verify that the *aud* (audience) claim contains the *client_id* of your app.
 3. Verify the signature of the ID Token according to [JWS](https://tools.ietf.org/html/rfc7515) using the algorithm specified in the JWT *alg* header property. Use the public keys provided by Okta via the [Discovery Document](#openid-connect-discovery-document).
 4. Verify that the expiry time (from the *exp* claim) has not already passed.
@@ -325,8 +325,8 @@ Please note the following:
 
 {% api_operation post /oauth2/v1/introspect %}
 
-The API takes an Access Token or Refresh Token, and returns a boolean indicating whether it is active or not. 
-If the token is active, additional data about the token is also returned. If the token is invalid, expired, or revoked, it is considered inactive. 
+The API takes an Access Token or Refresh Token, and returns a boolean indicating whether it is active or not.
+If the token is active, additional data about the token is also returned. If the token is invalid, expired, or revoked, it is considered inactive.
 An implicit client can only introspect its own tokens, while a confidential client may inspect all access tokens.
 
 > Note; [ID Tokens](oidc.html#id-token) are also valid, however, they are usually validated on the service provider or app side of a flow.
@@ -337,7 +337,7 @@ The following parameters can be posted as a part of the URL-encoded form values 
 
 Parameter       | Description                                                                                         | Type       |
 ----------------+-----------------------------------------------------------------------------------------------------+------------|
-token           | An access token, ID token, or refresh token.                                                                   | String     |  
+token           | An access token, ID token, or refresh token.                                                                   | String     |
 token_type_hint | A hint of the type of *token*.                                                               | String     |
 client_id       | The client ID generated as a part of client registration. This is used in conjunction with the *client_secret* parameter to authenticate the client application. | String |
 client_secret   | The client secret generated as a part of client registration. This is used in conjunction with the *client_id* parameter to authenticate the client application. | String |
@@ -351,7 +351,7 @@ Use one authentication mechanism with a given request. Using both returns an err
 For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request.
 
 ~~~sh
-Authorization: Basic ${Base64(<client_id>:<client_secret>)} 
+Authorization: Basic ${Base64(<client_id>:<client_secret>)}
 ~~~
 
 #### Response Parameters
@@ -360,7 +360,7 @@ Based on the type of token and whether it is active or not, the returned JSON co
 
 Parameter   | Description                                                                                         | Type       |
 ------------+-----------------------------------------------------------------------------------------------------+------------|
-active      | An access token or refresh token.                                                                   | boolean    |  
+active      | An access token or refresh token.                                                                   | boolean    |
 token_type  | The type of the token. The value is always `Bearer`.                                                | String     |
 scope       | A space-delimited list of scopes.                                                                   | String     |
 client_id   | The ID of the client associated with the token.                                                     | String     |
@@ -375,7 +375,7 @@ jti         | The identifier of the token.                                      
 device_id   | The ID of the device associated with the token                                                      | String     |
 uid         | The user ID. This parameter is returned only if the token is an access token and the subject is an end user.     | String     |
 
-#### List of Errors 
+#### List of Errors
 
 Error Id                |  Details                                                                                                     |
 ------------------------+--------------------------------------------------------------------------------------------------------------|
@@ -449,7 +449,7 @@ The following parameters can be posted as a part of the URL-encoded form values 
 
 Parameter       | Description                                                                                         | Type       |
 ----------------+-----------------------------------------------------------------------------------------------------+------------|
-token           | An access token or refresh token.                                                                   | String     |  
+token           | An access token or refresh token.                                                                   | String     |
 token_type_hint | A hint of the type of *token*.                                                               | String     |
 client_id       | The client ID generated as a part of client registration. This is used in conjunction with the *client_secret* parameter to authenticate the client application. | String |
 client_secret   | The client secret generated as a part of client registration. This is used in conjunction with the *client_id* parameter to authenticate the client application. | String |
@@ -465,14 +465,14 @@ Use one authentication mechanism with a given request. Using both returns an err
 For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request.
 
 ~~~sh
-Authorization: Basic ${Base64(<client_id>:<client_secret>)} 
+Authorization: Basic ${Base64(<client_id>:<client_secret>)}
 ~~~
 
 #### Response Parameters
 
 A successful revocation is denoted by an empty response with an HTTP 200. Note that revoking an invalid, expired, or revoked token will still be considered a success as to not leak information
 
-#### List of Errors 
+#### List of Errors
 
 Error Id                |  Details                                                                                                     |
 ------------------------+--------------------------------------------------------------------------------------------------------------|
@@ -553,16 +553,16 @@ client_id         | Your app's client ID. | Query      | String    | FALSE    | 
 }
 ~~~
 
->Okta strongly recommends retrieving keys dynamically with the JWKS published in the discovery document. 
-It is safe to cache or persist downloaded keys for performance. 
-However, if the client application is pinned to a signing key, the verification might fail since Okta rotates the key automatically. 
+>Okta strongly recommends retrieving keys dynamically with the JWKS published in the discovery document.
+It is safe to cache or persist downloaded keys for performance.
+However, if the client application is pinned to a signing key, the verification might fail since Okta rotates the key automatically.
 Pinned client applications must periodically check the Okta signing keys.
 
 Any of the two or three keys listed are used to sign tokens.The order of keys in the result doesn't indicate which keys are used.
 
 Standard open-source libraries are available for every major language to perform [JWS](https://tools.ietf.org/html/rfc7515) signature validation.
 
-#### Alternative Validation 
+#### Alternative Validation
 
 You can use an [introspection request](#introspection-request) for validation.
 
@@ -571,7 +571,7 @@ You can use an [introspection request](#introspection-request) for validation.
 
 {% api_operation get /.well-known/openid-configuration %}
 
-This API endpoint returns metadata related to OpenID Connect that can be used by clients to programmatically configure their interactions with Okta. 
+This API endpoint returns metadata related to OpenID Connect that can be used by clients to programmatically configure their interactions with Okta.
 This API doesn't require any authentication and returns a JSON object with the following structure.
 
 ~~~json
@@ -682,23 +682,23 @@ This is a starting point for OpenID Connect flows such as implicit and authoriza
 Parameter         | Description                                                                                        | Param Type | DataType  | Required | Default         |
 ----------------- | -------------------------------------------------------------------------------------------------- | ---------- | --------- | -------- | --------------- |
 [idp](idps.html)  | The Identity provider used to do the authentication. If omitted, use Okta as the identity provider. | Query      | String    | FALSE    | Okta is the IDP. |
-sessionToken      | An Okta one-time sessionToken. This allows an API-based user login flow (rather than Okta login UI). Session tokens can be obtained via the [Authentication API](authn.html).   | Query | String    | FALSE | |             
+sessionToken      | An Okta one-time sessionToken. This allows an API-based user login flow (rather than Okta login UI). Session tokens can be obtained via the [Authentication API](authn.html).   | Query | String    | FALSE | |
 response_type     | Can be a combination of *code*, *token*, and *id_token*. The chosen combination determines which flow is used; see this reference from the [OIDC specification](http://openid.net/specs/openid-connect-core-1_0.html#Authentication). The code response type returns an authorization code which can be later exchanged for an Access Token or a Refresh Token. | Query        | String   |   TRUE   |  |
-client_id         | Obtained during either [UI client registration](../../guides/social_authentication.html) or [API client registration](oauth-clients.html). It is the identifier for the client and it must match what is preregistered in Okta. | Query        | String   | TRUE     | 
-redirect_uri      | Specifies the callback location where the authorization code should be sent and it must match what is preregistered in Okta as a part of client registration. | Query        | String   |  TRUE    | 
+client_id         | Obtained during either [UI client registration](../../guides/social_authentication.html) or [API client registration](oauth-clients.html). It is the identifier for the client and it must match what is preregistered in Okta. | Query        | String   | TRUE     |
+redirect_uri      | Specifies the callback location where the authorization code should be sent and it must match what is preregistered in Okta as a part of client registration. | Query        | String   |  TRUE    |
 display           | Specifies how to display the authentication and consent UI. Valid values: *page* or *popup*.  | Query        | String   | FALSE     |  |
 max_age           | Specifies the allowable elapsed time, in seconds, since the last time the end user was actively authenticated by Okta. | Query      | String    | FALSE    | |
 response_mode     | Specifies how the authorization response should be returned. [Valid values: *fragment*, *form_post*, *query* or *okta_post_message*](#parameter-details). If *id_token* or *token* is specified as the response type, then *query* isn't allowed as a response mode. Defaults to *fragment* in implicit and hybrid flow. Defaults to *query* in authorization code flow and cannot be set as *okta_post_message*. | Query        | String   | FALSE      | See Description.
-scope          | **Required.** Can be a combination of reserved scopes and custom scopes. The combination determines the claims that are returned in the access_token and id_token. The openid scope has to be specified to get back an id_token. | Query        | String   | TRUE     | 
-state          | A client application provided state string that might be useful to the application upon receipt of the response. It can contain alphanumeric, comma, period, underscore and hyphen characters.   | Query        | String   |  TRUE    | 
-prompt         | Can be either *none* or *login*. The value determines if Okta should not prompt for authentication (if needed), or force a prompt (even if the user had an existing session). Default: The default behavior is based on whether there's an existing Okta session. | Query        | String   | FALSE     | See Description. 
-nonce          | Specifies a nonce that is reflected back in the ID Token. It is used to mitigate replay attacks. | Query        | String   | TRUE     | 
-code_challenge | Specifies a challenge of [PKCE](#parameter-details). The challenge is verified in the Access Token request.  | Query        | String   | FALSE    | 
-code_challenge_method | Specifies the method that was used to derive the code challenge. Only S256 is supported.  | Query        | String   | FALSE    | 
+scope          | **Required.** Can be a combination of reserved scopes and custom scopes. The combination determines the claims that are returned in the access_token and id_token. The openid scope has to be specified to get back an id_token. | Query        | String   | TRUE     |
+state          | A client application provided state string that might be useful to the application upon receipt of the response. It can contain alphanumeric, comma, period, underscore and hyphen characters.   | Query        | String   |  TRUE    |
+prompt         | Can be either *none* or *login*. The value determines if Okta should not prompt for authentication (if needed), or force a prompt (even if the user had an existing session). Default: The default behavior is based on whether there's an existing Okta session. | Query        | String   | FALSE     | See Description.
+nonce          | Specifies a nonce that is reflected back in the ID Token. It is used to mitigate replay attacks. | Query        | String   | TRUE     |
+code_challenge | Specifies a challenge of [PKCE](#parameter-details). The challenge is verified in the Access Token request.  | Query        | String   | FALSE    |
+code_challenge_method | Specifies the method that was used to derive the code challenge. Only S256 is supported.  | Query        | String   | FALSE    |
 
 #### Parameter Details
- 
- * *idp* and *sessionToken* are Okta extensions to [the OpenID specification](http://openid.net/specs/openid-connect-core-1_0.html#Authentication). 
+
+ * *idp* and *sessionToken* are Okta extensions to [the OpenID specification](http://openid.net/specs/openid-connect-core-1_0.html#Authentication).
     All other parameters comply with the OpenID Connect specification and their behavior is consistent with the specification.
  * Each value for *response_mode* delivers different behavior:
     * *fragment* -- Parameters are encoded in the URL fragment added to the *redirect_uri* when redirecting back to the client.
@@ -706,48 +706,48 @@ code_challenge_method | Specifies the method that was used to derive the code ch
     * *form_post* -- Parameters are encoded as HTML form values that are auto-submitted in the User Agent.Thus, the values are transmitted via the HTTP POST method to the client
       and the result parameters are encoded in the body using the application/x-www-form-urlencoded format.
     * *okta_post_message* -- Uses [HTML5 Web Messaging](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) (for example, window.postMessage()) instead of the redirect for the authorization response from the authorization endpoint.
-      *okta_post_message* is an adaptation of the [Web Message Response Mode](https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00#section-4.1). 
-      This value provides a secure way for a single-page application to perform a sign-in flow 
+      *okta_post_message* is an adaptation of the [Web Message Response Mode](https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00#section-4.1).
+      This value provides a secure way for a single-page application to perform a sign-in flow
       in a popup window or an iFrame and receive the ID token and/or access token back in the parent page without leaving the context of that page.
       The data model for the [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) call is in the next section.
-      
- * Okta requires the OAuth 2.0 *state* parameter on all requests to the authorization endpoint in order to prevent cross-site request forgery (CSRF). 
- The OAuth 2.0 specification [requires](https://tools.ietf.org/html/rfc6749#section-10.12) that clients protect their redirect URIs against CSRF by sending a value in the authorize request which binds the request to the user-agent's authenticated state. 
+
+ * Okta requires the OAuth 2.0 *state* parameter on all requests to the authorization endpoint in order to prevent cross-site request forgery (CSRF).
+ The OAuth 2.0 specification [requires](https://tools.ietf.org/html/rfc6749#section-10.12) that clients protect their redirect URIs against CSRF by sending a value in the authorize request which binds the request to the user-agent's authenticated state.
  Using the *state* parameter is also a countermeasure to several other known attacks as outlined in [OAuth 2.0 Threat Model and Security Considerations](https://tools.ietf.org/html/rfc6819).
 
  * [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) (PKCE) is a stronger mechanism for binding the authorization code to the client than just a client secret, and prevents [a code interception attack](https://tools.ietf.org/html/rfc7636#section-1) if both the code and the client credentials are intercepted (which can happen on mobile/native devices). The PKCE-enabled client creates a large random string as code_verifier and derives code_challenge from it using code_challenge_method. It passes the code_challenge and code_challenge_method in the authorization request for code flow. When a client tries to redeem the code, it must pass the code_verifer. Okta recomputes the challenge and returns the requested token only if it matches the code_challenge in the original authorization request. When a client, whose token_endpoint_auth_method is 'none', makes a code flow authorization request, the code_challenge parameter is required.
-      
+
 #### postMessage() Data Model
 
 Use the postMessage() data model to help you when working with the *okta_post_message* value of the *response_mode* request parameter.
 
 *message*:
 
-Parameter         | Description                                                                                        | DataType  | 
------------------ | -------------------------------------------------------------------------------------------------- | ----------| 
+Parameter         | Description                                                                                        | DataType  |
+----------------- | -------------------------------------------------------------------------------------------------- | ----------|
 id_token          | The ID Token JWT contains the details of the authentication event and the claims corresponding to the requested scopes. This is returned if the `response_type` includes `id_token`. | String   |
 access_token      | The *access_token* used to access the [`/oauth2/v1/userinfo`](/docs/api/resources/oidc.html#get-user-information) endpoint. This is returned if the *response_type* included a token. <b>Important</b>: Unlike the ID Token JWT, the *access_token* structure is specific to Okta, and is subject to change. | String    |
 state             | If the request contained a `state` parameter, then the same unmodified value is returned back in the response. | String    |
 error             | The error-code string providing information if anything goes wrong.                                | String    |
 error_description | Additional description of the error.                                                               | String    |
 
-*targetOrigin*: 
+*targetOrigin*:
 
 Specifies what the origin of *parentWindow* must be in order for the postMessage() event to be dispatched
-(this is enforced by the browser). The *okta-post-message* response mode always uses the origin from the *redirect_uri* 
+(this is enforced by the browser). The *okta-post-message* response mode always uses the origin from the *redirect_uri*
 specified by the client. This is crucial to prevent the sensitive token data from being exposed to a malicious site.
 
 #### Response Parameters
 
-The response depends on the response type passed to the API. For example, a *fragment* response mode returns values in the fragment portion of a redirect to the specified *redirect_uri* while a *form_post* response mode POSTs the return values to the redirect URI. 
+The response depends on the response type passed to the API. For example, a *fragment* response mode returns values in the fragment portion of a redirect to the specified *redirect_uri* while a *form_post* response mode POSTs the return values to the redirect URI.
 Irrespective of the response type, the contents of the response is always one of the following.
 
-Parameter         | Description                                                                                        | DataType  | 
------------------ | -------------------------------------------------------------------------------------------------- | ----------| 
-id_token          | The ID Token JWT contains the details of the authentication event and the claims corresponding to the requested scopes. This is returned if the *response_type* includes *id_token*.| String    | 
+Parameter         | Description                                                                                        | DataType  |
+----------------- | -------------------------------------------------------------------------------------------------- | ----------|
+id_token          | The ID Token JWT contains the details of the authentication event and the claims corresponding to the requested scopes. This is returned if the *response_type* includes *id_token*.| String    |
 access_token      | The *access_token* that is used to access the [`/oauth2/v1/userinfo`](/docs/api/resources/oidc.html#get-user-information) endpoint. This is returned if the *response_type* included a token. Unlike the ID Token JWT, the *access_token* structure is specific to Okta, and is subject to change.| String  |
 token_type        | The token type is always `Bearer` and is returned only when *token* is specified as a *response_type*. | String |
-code              | An opaque value that can be used to redeem tokens from [token endpoint](#token-request).| String    | 
+code              | An opaque value that can be used to redeem tokens from [token endpoint](#token-request).| String    |
 expires_in        | The number of seconds until the *access_token* expires. This is only returned if the response included an *access_token*. | String |
 scope             | The scopes of the *access_token*. This is only returned if the response included an *access_token*. | String |
 state             | The same unmodified value from the request is returned back in the response. | String |
@@ -756,27 +756,27 @@ error_description | Further description of the error. | String |
 
 ##### Possible Errors
 
-These APIs are compliant with the OpenID Connect and OAuth 2.0 spec with some Okta specific extensions. 
+These APIs are compliant with the OpenID Connect and OAuth 2.0 spec with some Okta specific extensions.
 
 [OAuth 2.0 Spec error codes](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
 
-Error Id         | Details                                                                | 
------------------| -----------------------------------------------------------------------| 
-unsupported_response_type  | The specified response type is invalid or unsupported.   | 
-unsupported_response_mode  | The specified response mode is invalid or unsupported. This error is also thrown for disallowed response modes. For example, if the query response mode is specified for a response type that includes id_token.    | 
-invalid_scope   | The scopes list contains an invalid or unsupported value.    | 
-server_error    | The server encountered an internal error.    | 
+Error Id         | Details                                                                |
+-----------------| -----------------------------------------------------------------------|
+unsupported_response_type  | The specified response type is invalid or unsupported.   |
+unsupported_response_mode  | The specified response mode is invalid or unsupported. This error is also thrown for disallowed response modes. For example, if the query response mode is specified for a response type that includes id_token.    |
+invalid_scope   | The scopes list contains an invalid or unsupported value.    |
+server_error    | The server encountered an internal error.    |
 temporarily_unavailable    | The server is temporarily unavailable, but should be able to process the request at a later time.    |
 invalid_request | The request is missing a necessary parameter or the parameter has an invalid value. |
 invalid_grant   | The specified grant is invalid, expired, revoked, or does not match the redirect URI used in the authorization request.
 invalid_token   | The provided access token is invalid.
 invalid_client  | The specified client id is invalid.
-access_denied   | The server denied the request. 
+access_denied   | The server denied the request.
 
 [Open-ID Spec error codes](http://openid.net/specs/openid-connect-core-1_0.html#AuthError)
 
-Error Id           | Details                                                                | 
--------------------| -----------------------------------------------------------------------| 
+Error Id           | Details                                                                |
+-------------------| -----------------------------------------------------------------------|
 login_required     | The request specified that no prompt should be shown but the user is currently not authenticated.    |
 insufficient_scope | The access token provided does not contain the necessary scopes to access the resource.              |
 
@@ -816,7 +816,7 @@ http://www.example.com/#error=invalid_scope&error_description=The+requested+scop
 
 {% api_operation post /oauth2/v1/token %}
 
-The API takes a grant type of either *authorization_code*, *password*, *refresh_token*, or [*client_credentials* {% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html) and the corresponding credentials and returns back an Access Token. A Refresh Token will be returned if *offline_access* scope is requested using authorization_code, password, or refresh_token grant type. Additionally, using the authorization_code grant type will return an ID Token if the *openid* scope is requested.
+The API takes a grant type of either *authorization_code*, *password*, *refresh_token*, or *client_credentials* {% api_lifecycle beta %} and the corresponding credentials and returns back an Access Token. A Refresh Token will be returned if *offline_access* scope is requested using authorization_code, password, or refresh_token grant type. Additionally, using the authorization_code grant type will return an ID Token if the *openid* scope is requested.
 
 > Note:  No errors occur if you use this endpoint, but it isn’t useful until custom scopes or resource servers are available. We recommend you wait until custom scopes and resource servers are available.
 
@@ -826,7 +826,7 @@ The following parameters can be posted as a part of the URL-encoded form values 
 
 Parameter          | Description                                                                                         | Type       |
 -------------------+-----------------------------------------------------------------------------------------------------+------------|
-grant_type         | Can be one of the following: *authorization_code*, *password*, *refresh_token*, or [*client_credentials* {% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html). Determines the mechanism Okta will use to authorize the creation of the tokens. | String |  
+grant_type         | Can be one of the following: *authorization_code*, *password*, *refresh_token*, or [*client_credentials* {% api_lifecycle beta %}](/docs/api/getting_started/releases-at-okta.html). Determines the mechanism Okta will use to authorize the creation of the tokens. | String |
 code               | Expected if grant_type specified *authorization_code*. The value is what was returned from the [authorization endpoint](#authentication-request). | String
 refresh_token      | Expected if the grant_type specified *refresh_token*. The value is what was returned from this endpoint via a previous invocation. | String |
 username           | Expected if the grant_type specified *password*. | String |
@@ -835,18 +835,18 @@ scope              | Optional if *refresh_token*, or *password* is specified as 
 redirect_uri       | Expected if grant_type is *authorization_code*. Specifies the callback location where the authorization was sent; must match what is preregistered in Okta for this client. | String |
 code_verifier      | The code verifier of [PKCE](#parameter-details). Okta uses it to recompute the code_challenge and verify if it matches the original code_challenge in the authorization request. | String |
 
-> The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow (if `grant_types` is `client_credentials`) is [a {% api_lifecycle beta %} feature](/docs/api/getting_started/releases-at-okta.html).
+> The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) flow (if `grant_types` is `client_credentials`) is a {% api_lifecycle beta %} feature.
 
 
 ##### Token Authentication Method
 
-The client can authenticate by providing the [`client_id`](oidc.html#request-parameters) 
+The client can authenticate by providing the [`client_id`](oidc.html#request-parameters)
 and [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect) as an Authorization header in the Basic auth scheme (basic authentication).
 
 For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request.
 
 ~~~sh
-Authorization: Basic ${Base64(<client_id>:<client_secret>)} 
+Authorization: Basic ${Base64(<client_id>:<client_secret>)}
 ~~~
 
 #### Response Parameters
@@ -868,7 +868,7 @@ For web and native application types, an additional process is required:
 1. Use the Okta Administration UI and check the **Refresh Token** checkbox under **Allowed Grant Types** on the client application page.
 2. Pass the *offline_access* scope to your authorize request.
 
-#### List of Errors 
+#### List of Errors
 
 Error Id                |  Details                                                                                                     |
 ------------------------+--------------------------------------------------------------------------------------------------------------|

--- a/_source/_docs/api/resources/resource-server-beta/required-config-changes-for-auth-server.md
+++ b/_source/_docs/api/resources/resource-server-beta/required-config-changes-for-auth-server.md
@@ -5,7 +5,7 @@ title: Configuration Changes Required for API Access Management Beta Update
 
 # Configuration Changes Required for API Access Management Beta Update
 
-> API Access Management is [a {% api_lifecycle beta %} feature](/docs/api/getting_started/releases-at-okta.html).
+> API Access Management is a {% api_lifecycle beta %} feature.
 
 Okta provides a private authorization server for OAuth 2.0 (Beta).
 However, with release 2016.45, you can use a shared authorization server instead, which provides several benefits:

--- a/_source/_docs/api/resources/sessions.md
+++ b/_source/_docs/api/resources/sessions.md
@@ -26,7 +26,7 @@ Okta provides a very rich [Authentication API](./authn.html) to validate a [user
 
 ## Getting Started
 
-Explore the Sessions API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/17d9f7e4f331c1d3c858) 
+Explore the Sessions API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/17d9f7e4f331c1d3c858)
 
 ## Session Operations
 
@@ -203,7 +203,7 @@ If the session is invalid, a `404 Not Found` response will be returned.
 ### Extend Session
 {:.api .api-operation}
 
-{% api_operation put /api/v1/sessions/*:id* %} [{% api_lifecycle deprecated %}](/docs/api/getting_started/releases-at-okta.html)
+{% api_operation put /api/v1/sessions/*:id* %} {% api_lifecycle deprecated %}
 
 Extends the lifetime of a user's session.
 
@@ -667,7 +667,7 @@ Sessions have the following properties:
 | mfaActive                                 | indicates whether the user has [enrolled an MFA factor](./factors.html#list-enrolled-factors) | Boolean                                   | FALSE    | FALSE  | TRUE     |
 |-------------------------------------------+-----------------------------------------------------------------------------------------------+-------------------------------------------+----------+--------+----------|
 
-> The `mfaActive` parameter is [a {% api_lifecycle deprecated %} feature](/docs/api/getting_started/releases-at-okta.html). Use the `lastFactorVerification` attribute in conjunction with `amr` to understand if the user has performed MFA for the current session. Use the [Factors API](./factors.html#list-enrolled-factors) to query the factor enrollment status for a given user.
+> The `mfaActive` parameter is a {% api_lifecycle deprecated %} feature]. Use the `lastFactorVerification` attribute in conjunction with `amr` to understand if the user has performed MFA for the current session. Use the [Factors API](./factors.html#list-enrolled-factors) to query the factor enrollment status for a given user.
 
 #### Optional Session Properties
 
@@ -680,9 +680,9 @@ The [Create Session](#create-session) operation can optionally return the follow
 | cookieTokenUrl                                | URL for a a transparent 1x1 pixel image which contains a one-time session token which when visited sets the session cookie in your browser for your organization.                  |
 |-----------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 
-> The `cookieToken` is [a {% api_lifecycle deprecated %} property](/docs/api/getting_started/releases-at-okta.html). Instead, use the [Authentication API](./authn.html), which supports the full user authentication pipeline and produces a `sessionToken` which can be used in this API.
+> The `cookieToken` is a {% api_lifecycle deprecated %} property. Instead, use the [Authentication API](./authn.html), which supports the full user authentication pipeline and produces a `sessionToken` which can be used in this API.
 
-> The `cookieTokenUrl` is [a {% api_lifecycle deprecated %} property](/docs/api/getting_started/releases-at-okta.html). because modern browsers block cookies set via embedding images from another origin (cross-domain).
+> The `cookieTokenUrl` is a {% api_lifecycle deprecated %} property]. because modern browsers block cookies set via embedding images from another origin (cross-domain).
 
 ### Session Status
 

--- a/_source/_docs/api/resources/system_log.md
+++ b/_source/_docs/api/resources/system_log.md
@@ -5,7 +5,7 @@ title: System Log (Beta)
 
 # System Log API
 
-This API is [a {% api_lifecycle beta%} feature](/docs/api/getting_started/releases-at-okta.html).
+This API is a {% api_lifecycle beta%} feature.
 
 The Okta System Log API provides read access to your organization's system log. This API provides more functionality than the Events API:
 
@@ -29,8 +29,8 @@ Fetch a list of events from your Okta organization system log.
 
 Parameter | Description                                                                         | Param Type | DataType | Required | Minimum  | Maximum | Default
 --------- | ----------------------------------------------------------------------------------- | ---------- | -------- | -------- | -------    -------   -------
-limit     | Specifies the number of results to page                                             | Query      | Number   | FALSE     |       0  |     100 |  
-since     | Specifies the last date before the oldest result is returned                        | Query      | DateTime | TRUE     |       0  |    1000 | 
+limit     | Specifies the number of results to page                                             | Query      | Number   | FALSE     |       0  |     100 |
+since     | Specifies the last date before the oldest result is returned                        | Query      | DateTime | TRUE     |       0  |    1000 |
 filter    | [Filter expression](/docs/api/getting_started/design_principles.html#filtering) for events | Query | String | FALSE    |
 q         | Finds a user that matches firstName, lastName, and email properties                 | Query      | String   | FALSE    |
 until     | Specifies the first date after which results aren't returned, can be empty which denotes no end date | Query      | DateTime | FALSE    |

--- a/_source/_docs/api/resources/tokens.md
+++ b/_source/_docs/api/resources/tokens.md
@@ -7,7 +7,7 @@ redirect_from: "/docs/getting_started/tokens.html"
 
 # Overiew
 
-> This endpoint is [a {% api_lifecycle deprecated %}](/docs/api/getting_started/releases-at-okta.html) feature. Please see [Getting an API Token](/docs/getting_started/getting_a_token.html).
+> This endpoint is a {% api_lifecycle deprecated %} feature. Please see [Getting an API Token](/docs/getting_started/getting_a_token.html).
 
 ## Create tokens
 

--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -1159,7 +1159,7 @@ curl -v -X GET \
 #### List Users with Search
 {:.api .api-operation}
 
-> Listing users with search is [an {% api_lifecycle ea %} feature](/docs/api/getting_started/releases-at-okta.html).
+> Listing users with search is an {% api_lifecycle ea %} feature.
 
 Searches for user by the properties specified in the search parameter (case insensitive).
 
@@ -2002,7 +2002,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 ~~~
 
-> Deleting users is [an {% api_lifecycle ea %} feature](/docs/api/getting_started/releases-at-okta.html).
+> Deleting users is an {% api_lifecycle ea %} feature.
 
 ### Delete User
 {:.api .api-operation}
@@ -2663,7 +2663,7 @@ The User model defines several read-only properties:
 
 {% beta %}
 
->Note: Profile image is [a {% api_lifecycle beta%} feature](/docs/api/getting_started/releases-at-okta.html).
+>Note: Profile image is a {% api_lifecycle beta %} feature.
 
 During the profile image Beta, image property definitions in the schema are of the `Object` data type with an additional `extendedType` of `Image`.
 When a user is retrieved via the API, however, the value will be a URL (represented as a String).  Some caveats apply:

--- a/_source/_plugins/ApiTags.rb
+++ b/_source/_plugins/ApiTags.rb
@@ -13,11 +13,37 @@ module Okta
     def render(context)
       case @api_lifecycle.downcase
         when "beta"
-          "<span class=\"api-label api-label-beta #{@class}\"><i class=\"fa fa-warning\"></i> Beta</span>"
+          %{
+          <a href="/docs/api/getting_started/releases-at-okta.html#beta">
+            <span class="api-label api-label-beta #{@class}">
+              <i class="fa fa-warning"></i> Beta
+            </span>
+          </a>
+          }
         when "ea"
-          "<span class=\"api-label api-label-ea #{@class}\"><i class=\"fa fa-flag\"></i> Early Access</span>"
+          %{
+          <a href="/docs/api/getting_started/releases-at-okta.html#early-access-ea">
+            <span class="api-label api-label-ea #{@class}">
+              <i class="fa fa-flag"></i> Early Access
+            </span>
+          </a>
+          }
+        when "ga"
+          %{
+          <a href="/docs/api/getting_started/releases-at-okta.html#general-availability-ga">
+            <span class="api-label api-label-ga #{@class}">
+              <i class="fa fa-circle-o"></i> General Availability
+            </span>
+          </a>
+          }
         when "deprecated"
-          "<span class=\"api-label api-label-deprecated #{@class}\"><i class=\"fa fa-fire-extinguisher\"></i> Deprecated</span>"
+          %{
+          <a href="/docs/api/getting_started/releases-at-okta.html#deprecation">
+            <span class="api-label api-label-deprecated #{@class}">
+              <i class="fa fa-fire-extinguisher"></i> Deprecated
+            </span>
+          </a>
+          }
       end
     end
   end


### PR DESCRIPTION
DRY'd up the use of lifecycle badges to link back to the new okta release lifecycle page (See _source/_plugins/ApiTags.rb).  

Going forward folks don't need to copy/paste all the link markdown and can just use the api lifecycle tag.  I removed all the manual links in existing documents.

> Note:  For some reason `client_credentials` grant_type was marked as beta.  This should be EA now with API Access Management EA.  I removed the beta badges.

@mystiberry-okta @jpf 
