### PR TITLE
Add scrollTop offset for deep linking to IDs from other pages.

### DIFF
--- a/_source/assets/js/docs.js
+++ b/_source/assets/js/docs.js
@@ -331,9 +331,7 @@ $(function() {
 		onScroll();
 
 		if (window.location.hash) {
-			$body.animate({
-				scrollTop: $(window.location.hash).offset().top - offset
-			});
+			$('html,body').scrollTop($(window.location.hash).offset().top - offset);
 		}
 
 	});

--- a/_source/assets/js/docs.js
+++ b/_source/assets/js/docs.js
@@ -330,5 +330,11 @@ $(function() {
 		init();
 		onScroll();
 
+		if (window.location.hash) {
+			$body.animate({
+				scrollTop: $(window.location.hash).offset().top - offset
+			});
+		}
+
 	});
 }());


### PR DESCRIPTION
This is to fix linking directly to ID hashes from other pages or outside of the developer to account for the fixed header.

![id under the fixed header](https://cloud.githubusercontent.com/assets/632978/22520770/82bee8c2-e86a-11e6-9601-408d62037309.png)
