### PR TITLE
Fix links in 3rd Party Notices when hosted from S3

### DIFF
--- a/_source/_3rd_party_notices/index.html
+++ b/_source/_3rd_party_notices/index.html
@@ -11,7 +11,7 @@ layout: default
     {% if element.id contains '/index' %}
     {% continue %}
     {% endif %}
-    <li><a href="{{ element.url }}">{{ element.title }}</a></li>
+    <li><a href="{{ element.url }}.html">{{ element.title }}</a></li>
     {% endfor %}
     </ul>
   </div>


### PR DESCRIPTION
This will fix an issue with the links to our 3rd Party Notices files on static hosting sites