### PR TITLE
Add support for transclusion via import_external_markdown()

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@
 DEPLOY_BRANCH="master"
 TARGET_S3_BUCKET="s3://developer.okta.com-staging"
 
-source "scripts/common.sh"
+source "${0%/*}/common.sh"
 
 require_env_var "OKTA_HOME"
 require_env_var "BRANCH"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,22 +7,26 @@
 DEPLOY_BRANCH="master"
 TARGET_S3_BUCKET="s3://developer.okta.com-staging"
 
-if [ "${BRANCH}" != "${DEPLOY_BRANCH}" ];
-then
-    echo "build.sh: Not in branch '${DEPLOY_BRANCH}', not pushing website to S3"
-    exit ${SUCCESS};
-fi
+source "scripts/common.sh"
+
+require_env_var "OKTA_HOME"
+require_env_var "BRANCH"
+require_env_var "REPO"
 
 # `cd` to the path where Okta's build system has this repository
 cd ${OKTA_HOME}/${REPO}
-
-source "scripts/common.sh"
 
 interject "Building HTML in $(pwd)"
 if ! generate_html;
 then
     echo "Error building site"
     exit ${BUILD_FAILURE};
+fi
+
+if [ "${BRANCH}" != "${DEPLOY_BRANCH}" ];
+then
+    echo "build.sh: Not in branch '${DEPLOY_BRANCH}', not pushing website to S3"
+    exit ${SUCCESS};
 fi
 
 interject "Uploading HTML from '${GENERATED_SITE_LOCATION}' to '${TARGET_S3_BUCKET}'"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -5,12 +5,14 @@
 # Where the generated Jekyll site will be placed
 GENERATED_SITE_LOCATION="_site"
 
+# Define these ENV vars if they aren't defined already,
+# so these scripts can be run outside of CI
 if [[ -z "${BUILD_FAILURE}" ]]; then
     export BUILD_FAILURE=1
 fi
 
 if [[ -z "${SUCCESS}" ]]; then
-    export SUCCESS=1
+    export SUCCESS=0
 fi
 
 source "scripts/import_external_markdown.sh"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -5,6 +5,14 @@
 # Where the generated Jekyll site will be placed
 GENERATED_SITE_LOCATION="_site"
 
+if [[ -z "${BUILD_FAILURE}" ]]; then
+    export BUILD_FAILURE=1
+fi
+
+if [[ -z "${SUCCESS}" ]]; then
+    export SUCCESS=1
+fi
+
 # Print an easily visible line, useful for log files.
 function interject() {
     echo "----- ${1} -----"
@@ -65,5 +73,11 @@ function generate_html() {
     fi
 }
 
-
-
+function require_env_var() {
+    local env_var_name=$1
+    eval env_var=\$$env_var_name
+    if [[ -z "${env_var}" ]]; then
+        echo "Environment variable '${env_var_name}' must be defined, but isn't.";
+        exit 1
+    fi
+}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -13,16 +13,18 @@ if [[ -z "${SUCCESS}" ]]; then
     export SUCCESS=1
 fi
 
+source "scripts/import_external_markdown.sh"
+
 # Print an easily visible line, useful for log files.
 function interject() {
     echo "----- ${1} -----"
 }
 
-function check_for_protractor_dependencies() {
-    interject 'Checking Protractor dependencies'
+function check_for_npm_dependencies() {
+    interject 'Checking NPM dependencies'
     command -v npm > /dev/null 2>&1 || { echo "This script requires 'npm', which is not installed"; exit 1; }
     npm install --only=dev
-    interject 'Done checking Protractor dependencies'
+    interject 'Done checking NPM dependencies'
 }
 
 function check_for_jekyll_dependencies() {
@@ -63,6 +65,8 @@ function generate_html() {
     interject 'Using Jekyll to generate HTML'
     
     if [ ! -d $GENERATED_SITE_LOCATION ]; then
+        check_for_npm_dependencies
+        import_external_markdown
         bundle exec jekyll build
         local status=$?
         interject 'Done generating HTML'

--- a/scripts/import_external_markdown.sh
+++ b/scripts/import_external_markdown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# include_external_markdown.sh
+# import_external_markdown.sh
 #
 #   Searches Markdown files for a special string ("external_source"), then
 #   appends (or "transcludes") the referenced file into the Markdown
@@ -19,7 +19,7 @@
 #     Hello World!
 #
 #   Then here is what "/tmp/hello.md" would contain after
-#   running the import_external_documentation() function:
+#   running the import_external_markdown() function:
 #
 #     ----
 #     title: Testing
@@ -33,13 +33,18 @@
 # This is the string written into transcluded files, to makes this script idempotent 
 TRANSCLUDE_WAS_HERE="<!-- Imported from external_source file -->"
 # This is the key used in the front matter of Markdown files, used to point to the file to be transcluded
-EXTERNAL_SOURCE="external_source"
+EXTERNAL_SOURCE_STRING="external_source"
 
 # Given a filename, read the filename of a file to transclude
 function transclude_file() {
     filename=$1
-    source=`cat $filename | grep ${EXTERNAL_SOURCE} | cut -d : -f 2`
-    if [[ -z "${source}" ]]; then
+    external_source=`cat $filename | egrep ^${EXTERNAL_SOURCE_STRING} | cut -d : -f 2 | egrep -o '[^[:space:]]+'`
+    echo "Checking '${external_source}'"
+    if [[ "node_modules" != ${external_source%%/*} ]]; then
+        echo "Path for source file must start with 'node_modules'."
+        return 3
+    fi
+    if [[ -z "${external_source}" ]]; then
         echo "Error finding source!"
         return 1
     fi
@@ -47,17 +52,22 @@ function transclude_file() {
     if [ $? -eq 0 ]; then
         echo "${filename} seems to have already been modified, skipping"
         return 2
-    else
-        echo "${TRANSCLUDE_WAS_HERE}" >> $filename
-        awk '/\<\!-- START GITHUB ONLY --\>/{flag=0}/\<\!-- END GITHUB ONLY --\>/{flag=1;next}flag' $source >> $filename
-        echo "Appended contents of '${source}' to '${filename}'"
     fi
+
+    echo "${TRANSCLUDE_WAS_HERE}" >> $filename
+    grep 'START GITHUB ONLY' $external_source > /dev/null
+    if [ $? -eq 0 ]; then
+        awk '/\<\!-- START GITHUB ONLY --\>/{flag=0}/\<\!-- END GITHUB ONLY --\>/{flag=1;next}flag' $external_source >> $filename
+    else
+        cat $external_source >> $filename
+    fi
+    echo "Appended contents of '${external_source}' to '${filename}'"
 }
 
 # Run the transclude_file() function on every Markdown file that contains the string "external_source"
 function import_external_markdown() {
     # grep: "-l" is "--files-with-matches"
-    for file in `find _source -type f -iname '*.md' | xargs grep -l $EXTERNAL_SOURCE `; do
+    for file in `find _source -type f -iname '*.md' | xargs grep -l $EXTERNAL_SOURCE_STRING `; do
         transclude_file $file
     done
 }

--- a/scripts/import_external_markdown.sh
+++ b/scripts/import_external_markdown.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# include_external_markdown.sh
+#
+#   Searches Markdown files for a special string ("external_source"), then
+#   appends (or "transcludes") the referenced file into the Markdown
+#
+#   Example: Assume that we have two files: "/tmp/hello.md" and "/tmp/contents.md"
+#   also assume that GENERATED_SITE_LOCATION=/tmp
+#
+#   If "/tmp/hello.md" contained this content:
+#
+#     ----
+#     title: Testing
+#     external_source: /tmp/contents.md
+#     ----
+#
+#   And "/tmp/contents.md" contained this:
+#
+#     Hello World!
+#
+#   Then here is what "/tmp/hello.md" would contain after
+#   running the import_external_documentation() function:
+#
+#     ----
+#     title: Testing
+#     external_source: /tmp/contents.md
+#     ----
+#     <!-- Imported from external_source file -->
+#     Hello World!
+
+
+
+# This is the string written into transcluded files, to makes this script idempotent 
+TRANSCLUDE_WAS_HERE="<!-- Imported from external_source file -->"
+# This is the key used in the front matter of Markdown files, used to point to the file to be transcluded
+EXTERNAL_SOURCE="external_source"
+
+# Given a filename, read the filename of a file to transclude
+function transclude_file() {
+    filename=$1
+    source=`cat $filename | grep ${EXTERNAL_SOURCE} | cut -d : -f 2`
+    if [[ -z "${source}" ]]; then
+        echo "Error finding source!"
+        return 1
+    fi
+    grep "${TRANSCLUDE_WAS_HERE}" $filename > /dev/null
+    if [ $? -eq 0 ]; then
+        echo "${filename} seems to have already been modified, skipping"
+        return 2
+    else
+        echo "${TRANSCLUDE_WAS_HERE}" >> $filename
+        awk '/\<\!-- START GITHUB ONLY --\>/{flag=0}/\<\!-- END GITHUB ONLY --\>/{flag=1;next}flag' $source >> $filename
+        echo "Appended contents of '${source}' to '${filename}'"
+    fi
+}
+
+# Run the transclude_file() function on every Markdown file that contains the string "external_source"
+function import_external_markdown() {
+    # grep: "-l" is "--files-with-matches"
+    for file in `find _source -type f -iname '*.md' | xargs grep -l $EXTERNAL_SOURCE `; do
+        transclude_file $file
+    done
+}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,7 +6,7 @@
 # Author: Joël Franusic (joel.franusic@okta.com)
 # Copyright 2016 Okta, Inc.
 
-source "scripts/common.sh"
+source "${0%/*}/common.sh"
 
 require_env_var "OKTA_HOME"
 require_env_var "REPO"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -6,10 +6,13 @@
 # Author: Joël Franusic (joel.franusic@okta.com)
 # Copyright 2016 Okta, Inc.
 
+source "scripts/common.sh"
+
+require_env_var "OKTA_HOME"
+require_env_var "REPO"
+
 # `cd` to the path where Okta's build system has this repository
 cd ${OKTA_HOME}/${REPO}
-
-source "scripts/common.sh"
 
 function url_consistency_check() {
     interject "Checking ${GENERATED_SITE_LOCATION} to make sure documentation uses proper prefixes ('/api/v1', '/oauth2', etc) in example URLs"

--- a/scripts/selenium.sh
+++ b/scripts/selenium.sh
@@ -21,7 +21,7 @@ cd ${OKTA_HOME}/${REPO}
 source "scripts/common.sh"
 
 check_for_jekyll_dependencies
-check_for_protractor_dependencies
+check_for_npm_dependencies
 
 # Make a temporary file, then unlink it (-u)
 # this gives us a nice name for a temporary file

--- a/tests/selenium/spec/check-upstream-docs-tests.js
+++ b/tests/selenium/spec/check-upstream-docs-tests.js
@@ -1,0 +1,17 @@
+describe('upstream docs string tests', function() {
+  var baseUrl = 'http://localhost:4000';
+
+  it('has authClient.signIn visible in okta-auth-js documentation', function() {
+    browser.ignoreSynchronization = true
+    browser.get(baseUrl + "/code/javascript/okta_auth_sdk.html");
+
+    expect(element(by.css('#docs-body')).getText()).toContain('authClient.signIn');
+  });
+
+  it('has .renderEl visible in okta-signin-widget documentation', function() {
+    browser.ignoreSynchronization = true
+    browser.get(baseUrl + "/code/javascript/okta_sign-in_widget.html");
+
+    expect(element(by.css('#docs-body')).getText()).toContain('.renderEl');
+  });
+});


### PR DESCRIPTION
The `import_external_markdown()` function appends files from external repositories into Markdown files in the _source directory that use the `external_source:` frontmatter option.

The plan is to start including documentation from projects like `okta/okta-signin-widget` and `okta/okta-auth-js` into developer.okta.com by including the npm packages for those projects into the `package.json` file in this repository, then we can set up transclusion in files in this repository via the `external_source:` frontmatter option.