### PR TITLE
Adjust /logs docs to reflect since param optional

### DIFF
--- a/_source/_docs/api/resources/system_log.md
+++ b/_source/_docs/api/resources/system_log.md
@@ -74,7 +74,7 @@ Fetch a list of events from your Okta organization system log.
 | Parameter | Description                                                                         | Param Type | DataType | Required | Minimum  | Maximum |
 | --------- | ----------------------------------------------------------------------------------- | ---------- | -------- | -------- | -------- | --------|
 | limit     | Specifies the number of results to return per page                                  | Query      | Number   | FALSE    |       0  |     100 |
-| since     | Specifies the datetime, inclusive and in ISO8601 format, to list events after                     | Query      | DateTime | TRUE     |          |         |
+| since     | Specifies the datetime, inclusive and in ISO8601 format, to list events after; defaults to 7 days prior to the "until" parameter | Query      | DateTime | FALSE |          |         |
 | filter    | [SCIM Filter expression](/docs/api/getting_started/design_principles.html#filtering) for events | Query | String | FALSE |        |         |
 | q         | Search String fields for matching phrase                                            | Query      | String   | FALSE    |          |         |
 | until     | Specifies the first datetime, inclusive and in ISO8601 format, after which results aren't returned, can be empty which denotes no end date | Query       | DateTime | FALSE   |          |          |


### PR DESCRIPTION
This is a small adjustment to the System Log API (/api/v1/logs)
documentation to reflect the fact that the `since` request parameter is
no longer required.

Relates to OKTA-120927.

Before:
![image](https://cloud.githubusercontent.com/assets/26014539/24683767/14577eb8-1956-11e7-95a7-197cd361c2f5.png)

After:
![image](https://cloud.githubusercontent.com/assets/26014539/24683770/19bdb458-1956-11e7-8f75-bfbb0b483850.png)

Note to reviewers: this PR won't be merged until [the behavior it documents](https://github.com/okta/sage/pull/381) is merged and deployed.