### PR TITLE
Fix individual blog layout

### DIFF
--- a/_source/_layouts/blog_post.html
+++ b/_source/_layouts/blog_post.html
@@ -3,12 +3,14 @@ layout: master
 css: page-blog
 show_bottom_cta: true
 ---
-<section id="blog-post" class="section--full-width">{% comment %}
+<section class="PageContent" id="blog-post">{% comment %}
 	// assigned variables will "leak" into the included file
 	// we must capture the content however otherwise {{ content }}
 	// will leak as a raw string
-  {% endcomment %}{% assign post = page %}{% capture _post_content %}{{ content }}{% endcapture %}
-	<div class="blog">
-		{% include blog_post.html post_content=_post_content %}
+	{% endcomment %}{% assign post = page %}{% capture _post_content %}{{ content }}{% endcapture %}
+	<div class="PageContent-main">
+		<div class="wrap blog">
+			{% include blog_post.html post_content=_post_content %}
+		</div>
 	</div>
 </section>


### PR DESCRIPTION
This makes it so individual posts don't stretch to fit the page. It also fixes syntax highlighting on individual posts.

Before:

![before](https://cloud.githubusercontent.com/assets/17892/25105138/ab1ab034-2380-11e7-820c-d1ab56ebd316.png)

After:

![after](https://cloud.githubusercontent.com/assets/17892/25105156/b0a6e1a8-2380-11e7-994e-fa2e1008197d.png)
