### PR TITLE
Fix blog layout so its responsive

### DIFF
--- a/_source/_posts/2015-06-11-trustpage.md
+++ b/_source/_posts/2015-06-11-trustpage.md
@@ -39,20 +39,20 @@ For prospects, the Status/Trust page must do at least the following:
  
 Once users get their hands on a product, they often find new ways to use it that the founders never imagined. This experimentation can shape the future of products and platforms. This is especially true of products that also provide APIs. The growth of B2B2C, B2C2B and other hybrid distribution models means that you are putting your product in front of many different types of audiences, including direct customers, partners, resellers, channel partners, and early and late stage prospects. Understanding how all of these audiences report on the service, interpret the SLA, and react to downtime is crucial if you want to create products that users value.
 
-###Be highly available but prepare for risk 
+### Be highly available but prepare for risk 
 
 It is a truism that one cannot solve for all technical constraints. Choosing the right platform on which to build your Product and Status/Trust pages is very important, but hosting both pages on the same platform risks both being down at the same time if your site crashes. 
 
 Obviously, you cannot afford to let your Trust/Status page go down, so **high availability** is key. But just in case the page ever _does_ go down, you need a **risk mitigation plan**. Central to this is making sure that you are contsantly monitoring your Trust/Status page with enterprise-class monitoring tools. 
 
-###Send rapid, robust, and consistent notifications
+### Send rapid, robust, and consistent notifications
 In the event of trust page problems, make sure that you have ways to easily and automatically notify customers and site ops as soon as issues are detected. Employ RSS, Twitter, and other channels to notify customers; invest in monitoring tools to notify site ops.
 
 If you send notifications manually, take care not to introduce human error when the site is having issues, as these are usually chaotic periods for your ops team. 
 
 Realize that many of your customers will probably check your trust page _and_ call support, so it’s important that the trust page and the support team provide the same information. This also argues for ensuring that your support team is a key stakeholder in the development of your trust page. 
 
-###Conclusion
+### Conclusion
 
 Designing and developing the Trust Page has taught me much in the last few months. I’d be happy to hear from you on this topic, so please feel free to send comments or questions to <vimarsh.karbhari@okta.com>.
 

--- a/_source/_posts/2017-03-21-spring-boot-oauth.md
+++ b/_source/_posts/2017-03-21-spring-boot-oauth.md
@@ -128,7 +128,8 @@ security:
       userAuthorizationUri: # authorization_endpoint 
       clientAuthenticationScheme: form
     resource:
-      # from your Auth Server's metadata, check .well-known/openid-configuration if not in .well-known/oauth-authorization-server
+      # from your Auth Server's metadata, check .well-known/openid-configuration 
+      # if not in .well-known/oauth-authorization-server
       userInfoUri: # userinfo_endpoint
       preferTokenInfo: false
 ```

--- a/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
+++ b/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
@@ -667,7 +667,8 @@ After making these changes, any field with a `required` attribute will be requir
 In this screenshot, you might notice the address fields are blank. This is explained by the error in your console.
 
 ```
-If ngModel is used within a form tag, either the name attribute must be set or the form control must be defined as 'standalone' in ngModelOptions.
+If ngModel is used within a form tag, either the name attribute must be set or the form 
+control must be defined as 'standalone' in ngModelOptions.
 
 Example 1: <input [(ngModel)]="person.firstName" name="first">
 Example 2: <input [(ngModel)]="person.firstName" [ngModelOptions]="{standalone: true}">

--- a/_source/_sass/okta/components/_PageContent.scss
+++ b/_source/_sass/okta/components/_PageContent.scss
@@ -186,7 +186,7 @@
 			overflow: auto;
 			code {
 				white-space: pre;
-				// fix wide cost listings that don't overflow automatically
+				// fix wide code listings that don't overflow automatically
 				// Not sure why this fixes it, but it does! --mraible
 				width: 100px;
 			}

--- a/_source/_sass/okta/components/_PageContent.scss
+++ b/_source/_sass/okta/components/_PageContent.scss
@@ -186,9 +186,9 @@
 			overflow: auto;
 			code {
 				white-space: pre;
-                // fix wide cost listings that don't overflow automatically
-                // Not sure why this fixes it, but it does! --mraible
-                width: 100px;
+				// fix wide cost listings that don't overflow automatically
+				// Not sure why this fixes it, but it does! --mraible
+				width: 100px;
 			}
 		}
 

--- a/_source/_sass/okta/components/_PageContent.scss
+++ b/_source/_sass/okta/components/_PageContent.scss
@@ -186,6 +186,9 @@
 			overflow: auto;
 			code {
 				white-space: pre;
+                // fix wide cost listings that don't overflow automatically
+                // Not sure why this fixes it, but it does! --mraible
+                width: 100px;
 			}
 		}
 


### PR DESCRIPTION
Code listings with long lines causes the blog to be a fixed width and not squish when the browser is squished. This fixes that problem. Tested in Chrome and Firefox on Mac.

Before:

<img width="1062" alt="screen shot 2017-04-20 at 3 22 48 pm" src="https://cloud.githubusercontent.com/assets/17892/25253401/1291957a-25de-11e7-9e9c-90bbb8ee3cc6.png">

After:

<img width="1062" alt="screen shot 2017-04-20 at 3 23 25 pm" src="https://cloud.githubusercontent.com/assets/17892/25253405/172b34c4-25de-11e7-82b2-37fd6fa9b3e0.png">
