### PR TITLE
OKTA-123957: behavior change when no parameters

### DIFF
--- a/_source/_docs/api/resources/events.md
+++ b/_source/_docs/api/resources/events.md
@@ -35,6 +35,8 @@ after     | Specifies the pagination cursor for the next page of events         
 
 > `startDate` and `filter` query parameters are mutually exclusive and cannot be used together in the same request
 
+> `startDate` defaults to 1 hour ago when `filter`, `after` and `startDate` query parameters are omitted.
+
 ###### Filters
 
 The following expressions are supported for events with the `filter` query parameter:


### PR DESCRIPTION
Noting default behavior changed by recent commit of @aminjashki-okta .

Resolves [OKTA-123957](https://oktainc.atlassian.net/browse/OKTA-123957)

@mystiberry-okta okay to merge?