### PR TITLE
Add Disqus for comments on blog posts

### DIFF
--- a/3rd_party_notices/Android_Mobile.html
+++ b/3rd_party_notices/Android_Mobile.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Android Mobile product. Certain licenses and notices may appearin other parts...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Android_Mobile">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Android_Verify.html
+++ b/3rd_party_notices/Android_Verify.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Android Verify product. Certain licenses and notices may appearin other parts...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Android_Verify">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Connector_Agent_Tool.html
+++ b/3rd_party_notices/Connector_Agent_Tool.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Connector Agent Tool product. Certain licenses and notices mayappear in other...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Connector_Agent_Tool">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Framework_Tool.html
+++ b/3rd_party_notices/Framework_Tool.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Framework Tool product. Certain licenses and notices may appearin other parts...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Framework_Tool">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Office365.html
+++ b/3rd_party_notices/Office365.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Office365 product. Certain licenses and notices may appear inother parts of t...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Office365">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_AD_Agent_Setup.html
+++ b/3rd_party_notices/Okta_AD_Agent_Setup.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta AD Agent Setup product. Certain licenses and notices mayappear in other parts...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_AD_Agent_Setup">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_Auth_SDK.html
+++ b/3rd_party_notices/Okta_Auth_SDK.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Auth SDK product. Certain licenses and notices may appear inother parts of th...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_Auth_SDK">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool.html
+++ b/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Cloud Provisioning Connector Tool product. Certain licenses and notices may a...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_Confluence.html
+++ b/3rd_party_notices/Okta_Confluence.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Confluence product. Certain licenses and notices may appear inother parts of ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_Confluence">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_Jira.html
+++ b/3rd_party_notices/Okta_Jira.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Jira product. Certain licenses and notices may appear in otherparts of the pr...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_Jira">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_LDAP_Agent.html
+++ b/3rd_party_notices/Okta_LDAP_Agent.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta LDAP Agent product. Certain licenses and notices may appear inother parts of ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_LDAP_Agent">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_LDAP_Agent_Setup.html
+++ b/3rd_party_notices/Okta_LDAP_Agent_Setup.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta LDAP Agent Setup product. Certain licenses and notices mayappear in other par...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_LDAP_Agent_Setup">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_Password_Sync_Setup.html
+++ b/3rd_party_notices/Okta_Password_Sync_Setup.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Password Sync Setup product. Certain licenses and notices mayappear in other ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_Password_Sync_Setup">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_Radius_Agent_Setup.html
+++ b/3rd_party_notices/Okta_Radius_Agent_Setup.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Radius Agent Setup product. Certain licenses and notices mayappear in other p...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_Radius_Agent_Setup">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_Rsa_SecurID_Setup.html
+++ b/3rd_party_notices/Okta_Rsa_SecurID_Setup.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Rsa SecurID Setup product. Certain licenses and notices mayappear in other pa...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_Rsa_SecurID_Setup">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_SAML_Toolkit.html
+++ b/3rd_party_notices/Okta_SAML_Toolkit.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta SAML Toolkit product. Certain licenses and notices may appearin other parts o...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_SAML_Toolkit">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_SSO_IWA.html
+++ b/3rd_party_notices/Okta_SSO_IWA.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta SSO IWA product. Certain licenses and notices may appear inother parts of the...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_SSO_IWA">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_SWA_Chrome.html
+++ b/3rd_party_notices/Okta_SWA_Chrome.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta SWA Chrome product. Certain licenses and notices may appear inother parts of ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_SWA_Chrome">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_SWA_Firefox.html
+++ b/3rd_party_notices/Okta_SWA_Firefox.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta SWA Firefox product. Certain licenses and notices may appear inother parts of...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_SWA_Firefox">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_SWA_IE.html
+++ b/3rd_party_notices/Okta_SWA_IE.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta SWA IE product. Certain licenses and notices may appear in otherparts of the ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_SWA_IE">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_SWA_Safari.html
+++ b/3rd_party_notices/Okta_SWA_Safari.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta SWA Safari product. Certain licenses and notices may appear inother parts of ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_SWA_Safari">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Okta_Sign-In_Widget.html
+++ b/3rd_party_notices/Okta_Sign-In_Widget.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Sign-In Widget product. Certain licenses and notices may appearin other parts...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Okta_Sign-In_Widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/OpenID_Connect_Emulator.html
+++ b/3rd_party_notices/OpenID_Connect_Emulator.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta OpenID Connect Emulator product. Certain licenses and noticesmay appear in ot...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/OpenID_Connect_Emulator">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/SDK_Packaging.html
+++ b/3rd_party_notices/SDK_Packaging.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta SDK Packaging product. Certain licenses and notices may appearin other parts ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/SDK_Packaging">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Web_App_Client_JS.html
+++ b/3rd_party_notices/Web_App_Client_JS.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Web App Client JS product. Certain licenses and notices mayappear in other pa...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Web_App_Client_JS">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Windows_Shared.html
+++ b/3rd_party_notices/Windows_Shared.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Windows Shared product. Certain licenses and notices may appearin other parts...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Windows_Shared">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/Windows_Verify.html
+++ b/3rd_party_notices/Windows_Verify.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta Windows Verify product. Certain licenses and notices may appearin other parts...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/Windows_Verify">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/iOS_Mobile.html
+++ b/3rd_party_notices/iOS_Mobile.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta iOS Mobile product. Certain licenses and notices may appear inother parts of ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/iOS_Mobile">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/iOS_Verify.html
+++ b/3rd_party_notices/iOS_Verify.html
@@ -37,6 +37,10 @@
   <meta name="description" content="This document contains third party open source licenses and notices forthe Okta iOS Verify product. Certain licenses and notices may appear inother parts of ...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/iOS_Verify">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/3rd_party_notices/index.html
+++ b/3rd_party_notices/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="                        Okta Android Mobile product            Okta Android Verify product            Okta Connector Agent Tool product            Okta Frame...">
   <link rel="canonical" href="http://developer.okta.com/3rd_party_notices/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/404.html
+++ b/404.html
@@ -40,6 +40,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/404.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ baseurl: ""
 url: "http://developer.okta.com"
 twitter_username: okta
 github_username:  oktadeveloper
+disqus_shortname: oktadevblog
 
 gems:
   - jekyll-redirect-from

--- a/_source/_includes/blog_post.html
+++ b/_source/_includes/blog_post.html
@@ -1,4 +1,4 @@
-<section >
+<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -30,6 +30,29 @@
 	    <section class="post-content">
 	     {{ include.post_content }}
 	    </section>
+      {% if post.comments %}
+        <span id="disqus">
+          <div id="disqus_thread"></div>
+          <script type="text/javascript">
+            var disqus_title = '{{ page.title }}';
+            var disqus_url = '{{ page.url | prepend: site.url }}';
+
+            (function() {
+              var dsq = document.createElement('script');
+              dsq.async = true;
+              dsq.type = 'text/javascript';
+              dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+            })();
+          </script>
+          <noscript>
+            Please enable JavaScript to view the
+            <a href="https://disqus.com/?ref_noscript" rel="nofollow">
+              comments powered by Disqus.
+            </a>
+          </noscript>
+        </span>
+      {% endif %}
 	  </article>
   </div>
 </section>

--- a/_source/_includes/head.html
+++ b/_source/_includes/head.html
@@ -41,4 +41,8 @@
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = '{{ site.disqus_shortname }}';
+  </script>
+  </head>
 </head>

--- a/_source/_posts/2017-05-17-develop-a-mobile-app-with-ionic-and-spring-boot.md
+++ b/_source/_posts/2017-05-17-develop-a-mobile-app-with-ionic-and-spring-boot.md
@@ -3,6 +3,7 @@ layout: blog_post
 title: 'Tutorial: Develop a Mobile App With Ionic and Spring Boot'
 author: mraible
 tags: [spring boot, java, pwa, progressive web app, ionic, typescript, ios, android]
+comments: true
 ---
 
 You already know that building APIs with Spring Boot is incredibly easy. But, your API isn’t complete without a UI, right? Well, building UIs with Ionic is pretty easy too, especially if you know Angular! 

--- a/blog/2015/04/07/android-unit-testing-part-2.html
+++ b/blog/2015/04/07/android-unit-testing-part-2.html
@@ -44,6 +44,10 @@
   <meta name="description" content="This is the second of a four part series on Android Unit Testing. Inthese posts, we’ll walk through the key steps engineers should taketo make Android test f...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/04/07/android-unit-testing-part-2">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -320,6 +324,7 @@ to achieve test isolation using dependency injection. You can also
 check out the full code at <a href="https://github.com/vronin-okta/okta_blog_samples/tree/master/android_unit_testing">GitHub</a>.</p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2015/04/14/android-unit-testing-part-3.html
+++ b/blog/2015/04/14/android-unit-testing-part-3.html
@@ -44,6 +44,10 @@
   <meta name="description" content="This is the third of a four part series on Android Unit Testing. Inthe last two articles I discussed the general principles of havinggoodtestsand the way to ...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/04/14/android-unit-testing-part-3">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -285,6 +289,7 @@ how to make tests isolated. You can also check out the full code at
 <a href="https://github.com/vronin-okta/okta_blog_samples/tree/master/android_unit_testing">GitHub</a>.</p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2015/04/23/android-unit-testing-part-4.html
+++ b/blog/2015/04/23/android-unit-testing-part-4.html
@@ -44,6 +44,10 @@
   <meta name="description" content="This is the third of a four part series on Android Unit Testing. Inthe last two articles I discussed the general principles of havinggoodtestsand the way to ...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/04/23/android-unit-testing-part-4">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -288,6 +292,7 @@ steps in writing on our wiki. Thanks guys!</p>
 </ul>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2015/05/08/productionalizing-active-mq.html
+++ b/blog/2015/05/08/productionalizing-active-mq.html
@@ -44,6 +44,10 @@
   <meta name="description" content="This post describes our odyssey with ActiveMQ, an open-source version of the Java Messaging Service (JMS) API. We use ActiveMQ as the message broker among ou...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/05/08/productionalizing-active-mq">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -228,6 +232,7 @@ their hands dirty tackling product issues? Our CTO doesn’t code very often, bu
 he does, he patches the JVM.</p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2015/05/08/software-engineering-design-principles.html
+++ b/blog/2015/05/08/software-engineering-design-principles.html
@@ -44,6 +44,10 @@
   <meta name="description" content="Okta has been an agile development shop since the beginning. One importantaspect of being agile is enabling a mix of bottom-up and top-down decisionmaking. S...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/05/08/software-engineering-design-principles">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -347,6 +351,7 @@ enforce limits and design for infinity.</li>
 </div>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2015/05/22/tcmalloc.html
+++ b/blog/2015/05/22/tcmalloc.html
@@ -44,6 +44,10 @@
   <meta name="description" content="Sometimes fixing a problem causes or reveals a new one. And sometimes this sets off a chain reaction of problems and fixes, where each solution exposes a dee...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/05/22/tcmalloc">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -208,6 +212,7 @@ compared to the amount of available RAM, which meant that we were sacrificing bo
 <p>Beyond the technical lessons we learned during this period, we were reminded that sometimes the best thing to do is stay the course. At times we were tempted to pull back, but moving forward ultimately paid off as each improvement we made exposed the inadequacy (for our platform) of a downstream component.</p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2015/06/11/trustpage.html
+++ b/blog/2015/06/11/trustpage.html
@@ -44,6 +44,10 @@
   <meta name="description" content="I recently read an excellent article about how amazing products shape the trust relationship with customers. I think great products are the first step in bui...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/06/11/trustpage">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -189,6 +193,7 @@
 <p><em>The Trust Page is the work of an amazing team that includes Tim Gu, Shawn Gupta, Nathan Tate, Wendy Liao, and myself.</em></p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2015/12/02/tls-client-authentication-for-services.html
+++ b/blog/2015/12/02/tls-client-authentication-for-services.html
@@ -44,6 +44,10 @@
   <meta name="description" content="If you’re like me, the most aggravating thing is finding a Stack Overflowquestion that exactly describes the issue you are facing, only to scroll downand see...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/12/02/tls-client-authentication-for-services">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -545,6 +549,7 @@ you implement these authentication concepts in your applications.</p>
 </ol>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2015/12/07/oauth.html
+++ b/blog/2015/12/07/oauth.html
@@ -44,6 +44,10 @@
   <meta name="description" content="It seems that OAuth 2.0 is everywhere these days. Whether you are building a hot new single page web application (SPA), a native mobile experience, or just t...">
   <link rel="canonical" href="http://developer.okta.com/blog/2015/12/07/oauth">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -143,6 +147,7 @@
 <iframe src="https://player.vimeo.com/video/148164438" width="500" height="281" frameborder="0" webkitallowfullscreen="" mozallowfullscreen="" allowfullscreen=""></iframe>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2016/01/05/rest-service-auth-jwt.html
+++ b/blog/2016/01/05/rest-service-auth-jwt.html
@@ -44,6 +44,10 @@
   <meta name="description" content="Many companies are adopting micro-services based architectures to promotedecoupling and separation of concerns in their applications. One inherentchallenge w...">
   <link rel="canonical" href="http://developer.okta.com/blog/2016/01/05/rest-service-auth-jwt">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -173,6 +177,7 @@ services within an application.</p>
 <iframe src="https://player.vimeo.com/video/150714428" width="500" height="281" frameborder="0" webkitallowfullscreen="" mozallowfullscreen="" allowfullscreen=""></iframe>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2016/03/22/use-kentor-authservices-with-okta.html
+++ b/blog/2016/03/22/use-kentor-authservices-with-okta.html
@@ -44,6 +44,10 @@
   <meta name="description" content="If you’re wondering how to configure an ASP.NET application with KentorIT’s AuthServices and Okta, you’ve come to the right place. But before delving into th...">
   <link rel="canonical" href="http://developer.okta.com/blog/2016/03/22/use-kentor-authservices-with-okta">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -209,6 +213,7 @@
 <p><strong>Happy Okta’ing!</strong></p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/03/16/spring-boot-saml.html
+++ b/blog/2017/03/16/spring-boot-saml.html
@@ -44,6 +44,10 @@
   <meta name="description" content="Today I’d like to show you how build a Spring Boot application that leverages Okta’s Platform API for authentication via SAML. SAML (Security Assertion Marku...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/03/16/spring-boot-saml">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -374,6 +378,7 @@ Hello SAML!
 
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/03/21/spring-boot-oauth.html
+++ b/blog/2017/03/21/spring-boot-oauth.html
@@ -44,6 +44,10 @@
   <meta name="description" content="If you’re building a Spring Boot application, you’ll eventually need to add user authentication. You can do this with OAuth 2.0 (henceforth: OAuth). OAuth is...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/03/21/spring-boot-oauth">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -337,6 +341,7 @@ brew install springboot
 
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/03/27/angular-okta-sign-in-widget.html
+++ b/blog/2017/03/27/angular-okta-sign-in-widget.html
@@ -44,6 +44,10 @@
   <meta name="description" content="AngularJS reigned as king of JavaScript MVC frameworks for several years. However, when the Angular team announced they would not provide backwards compatibi...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/03/27/angular-okta-sign-in-widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -439,6 +443,7 @@ Chrome 56.0.2924 <span class="o">(</span>Mac OS X 10.11.6<span class="o">)</span
 <p>I hope you’ve enjoyed this quick tour of our Angular support. If you have questions about Okta’s features, or what we’re building next, please hit me up <a href="https://twitter.com/mraible">on Twitter</a>, <a href="http://stackoverflow.com/questions/tagged/okta">post a question to Stack Overflow with an “okta” tag</a>, or <a href="https://github.com/oktadeveloper/okta-angular-sign-in-widget-example/issues/new">open a new issue on GitHub</a>.</p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/03/30/react-okta-sign-in-widget.html
+++ b/blog/2017/03/30/react-okta-sign-in-widget.html
@@ -44,6 +44,10 @@
   <meta name="description" content="React has quickly become one of the most favored front-end web frameworks, and is second only to plain old HTML5, according to JAXenter. So it’s no surprise ...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/03/30/react-okta-sign-in-widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -395,6 +399,7 @@ npm start
 <p>I hope you’ve enjoyed this quick tour of our React support. If you have questions about Okta’s features, or what we’re building next, please hit me up on Twitter <a href="https://twitter.com/leebrandt">@leebrandt</a>, leave a comment below, or open an issue on GitHub.</p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/04/17/angular-authentication-with-oidc.html
+++ b/blog/2017/04/17/angular-authentication-with-oidc.html
@@ -44,6 +44,10 @@
   <meta name="description" content="Angular (formerly called Angular 2.0) is quickly becoming one of the most powerful ways to build a modern single-page app. A core strength is Angular’s focus...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/04/17/angular-authentication-with-oidc">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -1125,6 +1129,7 @@ Example 2: &lt;input [(ngModel)]="person.firstName" [ngModelOptions]="{standalon
 
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html
+++ b/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html
@@ -44,6 +44,10 @@
   <meta name="description" content="To simplify development and deployment, you want everything in the same artifact, so you put your Angular app “inside” your Spring Boot app, right? But what ...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -583,6 +587,7 @@ is present on the requested resource. Origin 'http://localhost:4200' is therefor
 <p>You can find the source code associated with this article <a href="https://github.com/oktadeveloper/spring-boot-angular-example">on GitHub</a>. If you find any bugs, please file an issue on GitHub, or ask your question on Stack Overflow with an <a href="http://stackoverflow.com/questions/tagged/okta">okta tag</a>. Of course, you can always <a href="https://twitter.com/mraible">ping me on Twitter</a> too.</p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/05/03/seven-new-vs-features.html
+++ b/blog/2017/05/03/seven-new-vs-features.html
@@ -44,6 +44,10 @@
   <meta name="description" content="Microsoft developers have been using Visual Studio for their IDE since before .NET was even a thing. Visual Studio is twenty years old this year, and on Marc...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/05/03/seven-new-vs-features">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -175,6 +179,7 @@
 
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html
+++ b/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html
@@ -44,6 +44,10 @@
   <meta name="description" content="A recent DoubleClick report that found 53% of visits are abandoned if a mobile site takes more than 3 seconds to load. That same report said the average mobi...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -632,6 +636,7 @@ cf push -p target/<span class="k">*</span>jar pwa-server
 </ul>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/05/10/developers-guide-to-docker-part-1.html
+++ b/blog/2017/05/10/developers-guide-to-docker-part-1.html
@@ -44,6 +44,10 @@
   <meta name="description" content="It works on my machine. We’ve all heard it. Most of us have said it. It’s been impossible to get around it… until now. Not only can adding Docker to your dev...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -233,6 +237,7 @@
 <p>Keep an eye out for future posts about Docker where we’ll look at creating images and containers from a <code class="highlighter-rouge">Dockerfile</code> and how to coordinate an environment of containers (API, database and UI) with Docker-Compose.</p>
 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html
+++ b/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html
@@ -44,6 +44,10 @@
   <meta name="description" content="You already know that building APIs with Spring Boot is incredibly easy. But, your API isn’t complete without a UI, right? Well, building UIs with Ionic is p...">
   <link rel="canonical" href="http://developer.okta.com/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -106,7 +110,7 @@
 	<div class="page-content">
 		<section id="blog-post" class="main-container">
 	<div class="wrap blog">
-		<section >
+		<section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -945,6 +949,29 @@ For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
 
 
 	    </section>
+      
+        <span id="disqus">
+          <div id="disqus_thread"></div>
+          <script type="text/javascript">
+            var disqus_title = 'Tutorial: Develop a Mobile App With Ionic and Spring Boot';
+            var disqus_url = 'http://developer.okta.com/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot';
+
+            (function() {
+              var dsq = document.createElement('script');
+              dsq.async = true;
+              dsq.type = 'text/javascript';
+              dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+            })();
+          </script>
+          <noscript>
+            Please enable JavaScript to view the
+            <a href="https://disqus.com/?ref_noscript" rel="nofollow">
+              comments powered by Disqus.
+            </a>
+          </noscript>
+        </span>
+      
 	  </article>
   </div>
 </section>

--- a/blog/index.html
+++ b/blog/index.html
@@ -45,6 +45,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/blog/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -109,7 +113,7 @@
     <div class="wrap blog">
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -139,6 +143,29 @@
 	    <section class="post-content">
 	     You already know that building APIs with Spring Boot is incredibly easy. But, your API isn’t complete without a UI, right? Well, building UIs with Ionic is pretty easy too, especially if you know Angular! Ionic is an open source framework designed to help you build mobile applications with web technologies. It started out as a framework based on AngularJS. Ionic 3.0 was recently released, with support for Angular 4, TypeScript 2.2, and lazy loading.... <a href="/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot">Read more</a> 
 	    </section>
+      
+        <span id="disqus">
+          <div id="disqus_thread"></div>
+          <script type="text/javascript">
+            var disqus_title = 'Blog';
+            var disqus_url = 'http://developer.okta.com/blog/';
+
+            (function() {
+              var dsq = document.createElement('script');
+              dsq.async = true;
+              dsq.type = 'text/javascript';
+              dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+            })();
+          </script>
+          <noscript>
+            Please enable JavaScript to view the
+            <a href="https://disqus.com/?ref_noscript" rel="nofollow">
+              comments powered by Disqus.
+            </a>
+          </noscript>
+        </span>
+      
 	  </article>
   </div>
 </section>
@@ -146,7 +173,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -176,6 +203,7 @@
 	    <section class="post-content">
 	     It works on my machine. We’ve all heard it. Most of us have said it. It’s been impossible to get around it… until now. Not only can adding Docker to your development environment solve that issue, but it can make it drop-dead simple to onboard new developers, keep a team working forward and allow everyone on the team use their desired tools! Why Containers? “Aren’t containers just lightweight Virtual Machines?” That’s the question I get... <a href="/blog/2017/05/10/developers-guide-to-docker-part-1">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -183,7 +211,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -213,6 +241,7 @@
 	    <section class="post-content">
 	     A recent DoubleClick report that found 53% of visits are abandoned if a mobile site takes more than 3 seconds to load. That same report said the average mobile sites load in 19 seconds. According to Alex Russell in his recent talk on the state of mobile development, one of the biggest problems in mobile today is that developers use powerful laptops and desktops to develop their mobile applications, rather than using a $200 device... <a href="/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -220,7 +249,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -250,6 +279,7 @@
 	    <section class="post-content">
 	     Microsoft developers have been using Visual Studio for their IDE since before .NET was even a thing. Visual Studio is twenty years old this year, and on March 7th, 2017 Microsoft released the latest version of it’s flagship developer product, Visual Studio. With this release are a bunch of new features, improvements, and exciting changes for the beloved Microsoft developer environment. Here are seven features in the new IDE that will excite developers using the... <a href="/blog/2017/05/03/seven-new-vs-features">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -257,7 +287,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -287,6 +317,7 @@
 	    <section class="post-content">
 	     To simplify development and deployment, you want everything in the same artifact, so you put your Angular app “inside” your Spring Boot app, right? But what if you could create your Angular app as a standalone app and make cross-origin requests to your API? Hey guess what, you can do both! I believe that most frontend developers are used to having their apps standalone and making cross-origin requests to APIs. The beauty of having a... <a href="/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -294,7 +325,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -324,6 +355,7 @@
 	    <section class="post-content">
 	     Angular (formerly called Angular 2.0) is quickly becoming one of the most powerful ways to build a modern single-page app. A core strength is Angular’s focus on building reusable components, which help you decouple the various concerns in your application. Take authentication, for example: it can be painful to build, but once you wrap it in a component, the authentication logic can be reused throughout your application. The Angular CLI makes it easy to scaffold... <a href="/blog/2017/04/17/angular-authentication-with-oidc">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -331,7 +363,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -361,6 +393,7 @@
 	    <section class="post-content">
 	     React has quickly become one of the most favored front-end web frameworks, and is second only to plain old HTML5, according to JAXenter. So it’s no surprise that developers are learning it, and employers are asking for it. In this tutorial, you’ll start with a very simple React app with a couple of pages and some routing built in, and add authentication using Okta’s Sign-In Widget. The Sign-In Widget is an embeddable Javascript widget that... <a href="/blog/2017/03/30/react-okta-sign-in-widget">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -368,7 +401,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -398,6 +431,7 @@
 	    <section class="post-content">
 	     AngularJS reigned as king of JavaScript MVC frameworks for several years. However, when the Angular team announced they would not provide backwards compatibility for their next version, there was a bit of a stir in its community, giving opportunities for frameworks like React and Vue.js to flourish. Fast forward a few years and both Angular 2 and Angular 4 have been released. Many developers are trying its TypeScript and finding the experience a pleasant one.... <a href="/blog/2017/03/27/angular-okta-sign-in-widget">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -405,7 +439,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -435,6 +469,7 @@
 	    <section class="post-content">
 	     If you’re building a Spring Boot application, you’ll eventually need to add user authentication. You can do this with OAuth 2.0 (henceforth: OAuth). OAuth is a standard that applications can use to provide client applications with “secure delegated access”. It works over HTTP and authorizes devices, APIs, servers, and applications with access tokens rather than credentials. Very simply, OAuth is a protocol that supports authorization workflows. It gives you a way to ensure that a... <a href="/blog/2017/03/21/spring-boot-oauth">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -442,7 +477,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -472,6 +507,7 @@
 	    <section class="post-content">
 	     Today I’d like to show you how build a Spring Boot application that leverages Okta’s Platform API for authentication via SAML. SAML (Security Assertion Markup Language) is an XML-based standard for securely exchanging authentication and authorization information between entities—specifically between identity providers, service providers, and users. Well-known IdPs include Salesforce, Okta, OneLogin, and Shibboleth. My Okta developer experience began a couple years ago (in December 2014) when I worked for a client that was adopting... <a href="/blog/2017/03/16/spring-boot-saml">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/page/2/index.html
+++ b/blog/page/2/index.html
@@ -45,6 +45,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/blog/page/2/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -109,7 +113,7 @@
     <div class="wrap blog">
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -139,6 +143,7 @@
 	    <section class="post-content">
 	     If you’re wondering how to configure an ASP.NET application with KentorIT’s AuthServices and Okta, you’ve come to the right place. But before delving into the specifics of how to make Okta work with an SAML-enabled ASP.NET application powered by KentorIT AuthServices, is is worth spending some time going over a critical, but easily fixable issue: Important note : As of March 22nd, 2016, you have 2 choices: Either get the source code of the AuthServices... <a href="/blog/2016/03/22/use-kentor-authservices-with-okta">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -146,7 +151,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -191,6 +196,7 @@
 	    <section class="post-content">
 	     Many companies are adopting micro-services based architectures to promote decoupling and separation of concerns in their applications. One inherent challenge with breaking applications up into small services is that now each service needs to deal with authenticating and authorizing requests made to it. Json Web Tokens (JWTs) offer a clean solution to this problem along with TLS client authentication lower down in the stack. Wils Dawson and I presented these topics to the Java User... <a href="/blog/2016/01/05/rest-service-auth-jwt">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -198,7 +204,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -228,6 +234,7 @@
 	    <section class="post-content">
 	     It seems that OAuth 2.0 is everywhere these days. Whether you are building a hot new single page web application (SPA), a native mobile experience, or just trying to integrate with the API economy, you can’t go far without running into the popular authorization framework for REST/APIs and social authentication. During Oktane15, Karl McGuinness, our Senior Director of Identity, demystified the powerful, yet often misunderstood, world of OAuth 2.0 and shared details on Okta’s growing... <a href="/blog/2015/12/07/oauth">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -235,7 +242,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -265,6 +272,7 @@
 	    <section class="post-content">
 	     If you’re like me, the most aggravating thing is finding a Stack Overflow question that exactly describes the issue you are facing, only to scroll down and see that it has remained unanswered since 2011. I was recently trying to configure Transport Layer Security (TLS) client authentication (also referred to as mutual SSL) between two internal services at Okta and found the lack of complete examples astonishing. I hope that this blog post provides a... <a href="/blog/2015/12/02/tls-client-authentication-for-services">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -272,7 +280,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -302,6 +310,7 @@
 	    <section class="post-content">
 	     I recently read an excellent article about how amazing products shape the trust relationship with customers. I think great products are the first step in building a trust relationship. And like other aspects of the product that are derived from the product but are not physically part of it, the trust relationship is now more important than ever before. When you use a product, every engagement with that product has a direct correlation with your... <a href="/blog/2015/06/11/trustpage">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -309,7 +318,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -333,6 +342,7 @@
 	    <section class="post-content">
 	     Sometimes fixing a problem causes or reveals a new one. And sometimes this sets off a chain reaction of problems and fixes, where each solution exposes a deeper issue. In technology, cascades like these are common, often painful, and occasionally welcome. Our battle against CPU contention last fall is a good example of such a cascade. What began as a buffer pool adjustment triggered a series of issues and fixes that generated plenty of stress,... <a href="/blog/2015/05/22/tcmalloc">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -340,7 +350,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -370,6 +380,7 @@
 	    <section class="post-content">
 	     Okta has been an agile development shop since the beginning. One important aspect of being agile is enabling a mix of bottom-up and top-down decision making. Specifically where high level vision and strategy is clearly communicated enabling teams to autonomously deliver value while also feeding back learnings from the trenches to inform the high level goals.1 Below are the tacit engineering design principles we’ve used to guide development at Okta. They continue to evolve as... <a href="/blog/2015/05/08/software-engineering-design-principles">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -377,7 +388,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -401,6 +412,7 @@
 	    <section class="post-content">
 	     This post describes our odyssey with ActiveMQ, an open-source version of the Java Messaging Service (JMS) API. We use ActiveMQ as the message broker among our app servers. First, a word of thanks. To overcome the challenges we faced with ActiveMQ, we are greatly indebted to a very thorough description of an OpenJDK bug, as well as some other online resources. If you’re having problems with ActiveMQ, read on. Maybe our story can help you.... <a href="/blog/2015/05/08/productionalizing-active-mq">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -408,7 +420,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -436,6 +448,7 @@
 	    <section class="post-content">
 	     This is the third of a four part series on Android Unit Testing. In the last two articles I discussed the general principles of having good tests and the way to run Android tests on JVM making them fast and how to make your code less coupled. This article will explain how to make tests isolated. We need to mock a dependency, inject it, and then modify our test to indicate that we are not... <a href="/blog/2015/04/23/android-unit-testing-part-4">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>
@@ -443,7 +456,7 @@
             <br/>
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -471,6 +484,7 @@
 	    <section class="post-content">
 	     This is the third of a four part series on Android Unit Testing. In the last two articles I discussed the general principles of having good tests and the way to run Android tests on JVM making them fast. This part will show how to make your Android code less heavily coupled. This is a preparation step to ensure that your tests are isolated from each other. We want to test each unit of work... <a href="/blog/2015/04/14/android-unit-testing-part-3">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/blog/page/3/index.html
+++ b/blog/page/3/index.html
@@ -45,6 +45,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/blog/page/3/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="blog">
@@ -109,7 +113,7 @@
     <div class="wrap blog">
         
             
-            <section >
+            <section>
   <div class="wrap">
     <article class="post-block">
       <header class="post-title-block">
@@ -137,6 +141,7 @@
 	    <section class="post-content">
 	     This is the second of a four part series on Android Unit Testing. In these posts, we’ll walk through the key steps engineers should take to make Android test fast by running them on JVM (versus running them on emulator). For background information on the importance of Android testing, visit Part I of the series. It appears that the need to run tests on an Android device or an emulator has concerned Android engineers for... <a href="/blog/2015/04/07/android-unit-testing-part-2">Read more</a> 
 	    </section>
+      
 	  </article>
   </div>
 </section>

--- a/cla/index.html
+++ b/cla/index.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/cla/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/dotnet/index.html
+++ b/code/dotnet/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="">
   <link rel="canonical" href="http://developer.okta.com/code/dotnet/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/dotnet/okta-oauth-aspnet-codeflow.html
+++ b/code/dotnet/okta-oauth-aspnet-codeflow.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Code sample demonstrating the use of OpenID Connect with Okta and the Microsoft.Owin.Security.OpenIdConnect library.">
   <link rel="canonical" href="http://developer.okta.com/code/dotnet/okta-oauth-aspnet-codeflow">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/dotnet/okta-oauth-spa-authjs-osw.html
+++ b/code/dotnet/okta-oauth-spa-authjs-osw.html
@@ -37,6 +37,10 @@
   <meta name="description" content="OpenID Connect/OAuth code sample (implicit flow) with Okta Authentication JS SDK, Okta Sign In Widget and ASP.NET resource server.">
   <link rel="canonical" href="http://developer.okta.com/code/dotnet/okta-oauth-spa-authjs-osw">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/dotnet/okta-oidc-spa-osw-aspnet.html
+++ b/code/dotnet/okta-oidc-spa-osw-aspnet.html
@@ -37,6 +37,10 @@
   <meta name="description" content="OpenID Connect code sample with Okta using an ASP.NET MVC Single Page Application calling an ASP.NET Web API.">
   <link rel="canonical" href="http://developer.okta.com/code/dotnet/okta-oidc-spa-osw-aspnet">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/dotnet/powershell.html
+++ b/code/dotnet/powershell.html
@@ -37,6 +37,10 @@
   <meta name="description" content="PowerShell bindings for the Okta API. Get started now.">
   <link rel="canonical" href="http://developer.okta.com/code/dotnet/powershell">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/dotnet/sample_application.html
+++ b/code/dotnet/sample_application.html
@@ -37,6 +37,10 @@
   <meta name="description" content="The Okta Music Store is a sample application written in .NET and is a demonstration of how to add Okta as an identity provider for an existing application.">
   <link rel="canonical" href="http://developer.okta.com/code/dotnet/sample_application">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/dotnet/sdk.html
+++ b/code/dotnet/sdk.html
@@ -37,6 +37,10 @@
   <meta name="description" content=".NET bindings for the Okta API. Get started now.">
   <link rel="canonical" href="http://developer.okta.com/code/dotnet/sdk">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/index.html
+++ b/code/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="                                          ">
   <link rel="canonical" href="http://developer.okta.com/code/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/java/index.html
+++ b/code/java/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="">
   <link rel="canonical" href="http://developer.okta.com/code/java/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/java/okta-aws-cli-assume-role.html
+++ b/code/java/okta-aws-cli-assume-role.html
@@ -37,6 +37,10 @@
   <meta name="description" content="The Okta AWS-CLI Tool allows Okta customers to take advantage of Okta to use the AWS Command Line Interface without relying on permanent AWS keys.">
   <link rel="canonical" href="http://developer.okta.com/code/java/okta-aws-cli-assume-role">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/java/okta-openidconnect-appauth-sample-android.html
+++ b/code/java/okta-openidconnect-appauth-sample-android.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Sample application for communicating with OAuth 2.0 and OpenID Connect providers. Demonstrates single-sign-on (SSO) with AppAuth for Android.">
   <link rel="canonical" href="http://developer.okta.com/code/java/okta-openidconnect-appauth-sample-android">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/java/oktasdk-java.html
+++ b/code/java/oktasdk-java.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Java bindings for the Okta API. Documentation here.">
   <link rel="canonical" href="http://developer.okta.com/code/java/oktasdk-java">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/java/spring_security_saml.html
+++ b/code/java/spring_security_saml.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Guidance on how to SAML-enable your application using open source Spring Security library.">
   <link rel="canonical" href="http://developer.okta.com/code/java/spring_security_saml">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/javascript/index.html
+++ b/code/javascript/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="">
   <link rel="canonical" href="http://developer.okta.com/code/javascript/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/javascript/okta_auth_sdk.html
+++ b/code/javascript/okta_auth_sdk.html
@@ -37,6 +37,10 @@
   <meta name="description" content="A Javascript wrapper for Okta's Authentication APIs. Build your own branded UI and power sign-in with Okta.">
   <link rel="canonical" href="http://developer.okta.com/code/javascript/okta_auth_sdk">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/javascript/okta_auth_sdk_external_ref.html
+++ b/code/javascript/okta_auth_sdk_external_ref.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Reference information for customizing the Okta Auth SDK.">
   <link rel="canonical" href="http://developer.okta.com/code/javascript/okta_auth_sdk_external_ref">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/javascript/okta_sign-in_widget.html
+++ b/code/javascript/okta_sign-in_widget.html
@@ -37,6 +37,10 @@
   <meta name="description" content="A drop-in widget with custom UI capabilities to power sign-in with Okta. An in-depth reference is also available.">
   <link rel="canonical" href="http://developer.okta.com/code/javascript/okta_sign-in_widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/javascript/okta_sign-in_widget_external_ref.html
+++ b/code/javascript/okta_sign-in_widget_external_ref.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Reference information for customizing the Okta Sign-In Widget.">
   <link rel="canonical" href="http://developer.okta.com/code/javascript/okta_sign-in_widget_external_ref">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/javascript/okta_sign-in_widget_ref.html
+++ b/code/javascript/okta_sign-in_widget_ref.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Reference information for customizing the Okta Sign-In Widget.">
   <link rel="canonical" href="http://developer.okta.com/code/javascript/okta_sign-in_widget_ref">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/php/index.html
+++ b/code/php/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="">
   <link rel="canonical" href="http://developer.okta.com/code/php/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/php/quickstart-signin-widget.html
+++ b/code/php/quickstart-signin-widget.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Quickstart guide for using the Okta Sign-In Widget with PHP.">
   <link rel="canonical" href="http://developer.okta.com/code/php/quickstart-signin-widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/php/simplesamlphp.html
+++ b/code/php/simplesamlphp.html
@@ -37,6 +37,10 @@
   <meta name="description" content="How to use SimpleSAMLphp to add support for Okta via SAML.">
   <link rel="canonical" href="http://developer.okta.com/code/php/simplesamlphp">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/python/index.html
+++ b/code/python/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="">
   <link rel="canonical" href="http://developer.okta.com/code/python/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/python/pysaml2.html
+++ b/code/python/pysaml2.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Guidance on how to SAML-enable your Python application using open source PySAML2.">
   <link rel="canonical" href="http://developer.okta.com/code/python/pysaml2">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/code/python/sdk.html
+++ b/code/python/sdk.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Python bindings for the Okta API. Documentation here.">
   <link rel="canonical" href="http://developer.okta.com/code/python/sdk">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/discussion/index.html
+++ b/discussion/index.html
@@ -45,6 +45,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/discussion/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
     <body id="discussion">

--- a/docs/api/getting_started/api_test_client.html
+++ b/docs/api/getting_started/api_test_client.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Overview">
   <link rel="canonical" href="http://developer.okta.com/docs/api/getting_started/api_test_client.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/getting_started/design_principles.html
+++ b/docs/api/getting_started/design_principles.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Versioning">
   <link rel="canonical" href="http://developer.okta.com/docs/api/getting_started/design_principles.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/getting_started/enabling_cors.html
+++ b/docs/api/getting_started/enabling_cors.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Overview">
   <link rel="canonical" href="http://developer.okta.com/docs/api/getting_started/enabling_cors.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/getting_started/getting_a_token.html
+++ b/docs/api/getting_started/getting_a_token.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Create an API token">
   <link rel="canonical" href="http://developer.okta.com/docs/api/getting_started/getting_a_token.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/getting_started/releases-at-okta.html
+++ b/docs/api/getting_started/releases-at-okta.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Okta Release Lifecycle">
   <link rel="canonical" href="http://developer.okta.com/docs/api/getting_started/releases-at-okta.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/apps.html
+++ b/docs/api/resources/apps.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Apps API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/apps.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/authn.html
+++ b/docs/api/resources/authn.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Authentication API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/authn.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/events.html
+++ b/docs/api/resources/events.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Events API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/events.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/factor_admin.html
+++ b/docs/api/resources/factor_admin.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Factors Administration API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/factor_admin.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/factors.html
+++ b/docs/api/resources/factors.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Factors API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/factors.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/groups.html
+++ b/docs/api/resources/groups.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Groups API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/groups.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/idps.html
+++ b/docs/api/resources/idps.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Identity Providers API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/idps.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/oauth-clients.html
+++ b/docs/api/resources/oauth-clients.html
@@ -37,6 +37,10 @@
   <meta name="description" content="OAuth 2.0 Clients API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/oauth-clients.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/oauth2.html
+++ b/docs/api/resources/oauth2.html
@@ -37,6 +37,10 @@
   <meta name="description" content="OAuth 2.0 API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/oauth2.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/oidc.html
+++ b/docs/api/resources/oidc.html
@@ -37,6 +37,10 @@
   <meta name="description" content="OpenID Connect API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/oidc.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/policy.html
+++ b/docs/api/resources/policy.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Policy API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/policy.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/resource-server-beta/required-config-changes-for-auth-server.html
+++ b/docs/api/resources/resource-server-beta/required-config-changes-for-auth-server.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Configuration Changes Required for API Access Management Beta Update">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/resource-server-beta/required-config-changes-for-auth-server.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/roles.html
+++ b/docs/api/resources/roles.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Admin Roles API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/roles.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/schemas.html
+++ b/docs/api/resources/schemas.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Schemas API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/schemas.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/sessions.html
+++ b/docs/api/resources/sessions.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Sessions API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/sessions.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/social_authentication.html
+++ b/docs/api/resources/social_authentication.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Setting up an Okta Social Authentication provider">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/social_authentication.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/system_log.html
+++ b/docs/api/resources/system_log.html
@@ -37,6 +37,10 @@
   <meta name="description" content="System Log API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/system_log.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/templates.html
+++ b/docs/api/resources/templates.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Custom Templates API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/templates.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/tokens.html
+++ b/docs/api/resources/tokens.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Overiew">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/tokens.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/users.html
+++ b/docs/api/resources/users.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Users API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/users.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/api/resources/zones.html
+++ b/docs/api/resources/zones.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Zones API">
   <link rel="canonical" href="http://developer.okta.com/docs/api/resources/zones.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/how-to/beta-auth-service/api-access-management-troubleshooting.html
+++ b/docs/how-to/beta-auth-service/api-access-management-troubleshooting.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Troubleshooting for API Access Management">
   <link rel="canonical" href="http://developer.okta.com/docs/how-to/beta-auth-service/api-access-management-troubleshooting.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/how-to/byo_saml.html
+++ b/docs/how-to/byo_saml.html
@@ -37,6 +37,10 @@
   <meta name="description" content="How to use a custom SAML certificate for apps">
   <link rel="canonical" href="http://developer.okta.com/docs/how-to/byo_saml.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/how-to/set-up-auth-server.html
+++ b/docs/how-to/set-up-auth-server.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Set Up an Authorization Service">
   <link rel="canonical" href="http://developer.okta.com/docs/how-to/set-up-auth-server.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/how-to/sharing-cert.html
+++ b/docs/how-to/sharing-cert.html
@@ -37,6 +37,10 @@
   <meta name="description" content="How to share application key credentials between apps">
   <link rel="canonical" href="http://developer.okta.com/docs/how-to/sharing-cert.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/how-to/updating_saml_cert.html
+++ b/docs/how-to/updating_saml_cert.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Upgrade SAML Apps to SHA256">
   <link rel="canonical" href="http://developer.okta.com/docs/how-to/updating_saml_cert.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes.html
+++ b/docs/platform-release-notes/platform-release-notes.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.18">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-23.html
+++ b/docs/platform-release-notes/platform-release-notes2016-23.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Release 2016.23">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-23.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-24.html
+++ b/docs/platform-release-notes/platform-release-notes2016-24.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Release 2016.24">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-24.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-25.html
+++ b/docs/platform-release-notes/platform-release-notes2016-25.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Release 2016.25">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-25.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-26.html
+++ b/docs/platform-release-notes/platform-release-notes2016-26.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Release 2016.26">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-26.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-27.html
+++ b/docs/platform-release-notes/platform-release-notes2016-27.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Release 2016.27">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-27.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-28.html
+++ b/docs/platform-release-notes/platform-release-notes2016-28.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Release 2016.28">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-28.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-29.html
+++ b/docs/platform-release-notes/platform-release-notes2016-29.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Release 2016.29">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-29.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-30.html
+++ b/docs/platform-release-notes/platform-release-notes2016-30.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Release 2016.30">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-30.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-31.html
+++ b/docs/platform-release-notes/platform-release-notes2016-31.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to Okta Platform since Release 2016.30">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-31.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-33.html
+++ b/docs/platform-release-notes/platform-release-notes2016-33.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.31">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-33.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-34.html
+++ b/docs/platform-release-notes/platform-release-notes2016-34.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.34">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-34.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-35.html
+++ b/docs/platform-release-notes/platform-release-notes2016-35.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.34">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-35.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-36.html
+++ b/docs/platform-release-notes/platform-release-notes2016-36.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.35">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-36.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-37.html
+++ b/docs/platform-release-notes/platform-release-notes2016-37.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.36">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-37.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-39.html
+++ b/docs/platform-release-notes/platform-release-notes2016-39.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.37">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-39.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-40.html
+++ b/docs/platform-release-notes/platform-release-notes2016-40.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.39">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-40.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-41.html
+++ b/docs/platform-release-notes/platform-release-notes2016-41.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.40">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-41.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-43.html
+++ b/docs/platform-release-notes/platform-release-notes2016-43.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.41">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-43.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-45.html
+++ b/docs/platform-release-notes/platform-release-notes2016-45.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.43">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-45.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-46.html
+++ b/docs/platform-release-notes/platform-release-notes2016-46.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.45">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-46.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-47.html
+++ b/docs/platform-release-notes/platform-release-notes2016-47.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.46">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-47.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-49.html
+++ b/docs/platform-release-notes/platform-release-notes2016-49.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.47">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-49.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-50.html
+++ b/docs/platform-release-notes/platform-release-notes2016-50.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.49">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-50.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-51.html
+++ b/docs/platform-release-notes/platform-release-notes2016-51.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.50">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-51.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-52.html
+++ b/docs/platform-release-notes/platform-release-notes2016-52.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.51">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-52.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2016-index.html
+++ b/docs/platform-release-notes/platform-release-notes2016-index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="List of changes to the Okta Platform">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2016-">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-02.html
+++ b/docs/platform-release-notes/platform-release-notes2017-02.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2016.51">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-02.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-03.html
+++ b/docs/platform-release-notes/platform-release-notes2017-03.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.02">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-03.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-04.html
+++ b/docs/platform-release-notes/platform-release-notes2017-04.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.03">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-04.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-05.html
+++ b/docs/platform-release-notes/platform-release-notes2017-05.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.04">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-05.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-09.html
+++ b/docs/platform-release-notes/platform-release-notes2017-09.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.05">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-09.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-10.html
+++ b/docs/platform-release-notes/platform-release-notes2017-10.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.09">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-10.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-11.html
+++ b/docs/platform-release-notes/platform-release-notes2017-11.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.10">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-11.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-12.html
+++ b/docs/platform-release-notes/platform-release-notes2017-12.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.11">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-12.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-15.html
+++ b/docs/platform-release-notes/platform-release-notes2017-15.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.12">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-15.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-16.html
+++ b/docs/platform-release-notes/platform-release-notes2017-16.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.15">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-16.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-17.html
+++ b/docs/platform-release-notes/platform-release-notes2017-17.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.16">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-17.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-18.html
+++ b/docs/platform-release-notes/platform-release-notes2017-18.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.17">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-18.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/docs/platform-release-notes/platform-release-notes2017-19.html
+++ b/docs/platform-release-notes/platform-release-notes2017-19.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Summary of changes to the Okta Platform since Release 2017.18">
   <link rel="canonical" href="http://developer.okta.com/docs/platform-release-notes/platform-release-notes2017-19.html">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/documentation/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/documentation/stormpath-import.html
+++ b/documentation/stormpath-import.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/documentation/stormpath-import">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/error.html
+++ b/error.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/error">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/feed.xml
+++ b/feed.xml
@@ -819,7 +819,7 @@ For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
 &lt;/ul&gt;
 
 </description>
-        <pubDate>Wed, 17 May 2017 00:00:00 -0400</pubDate>
+        <pubDate>Wed, 17 May 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot</guid>
       </item>
@@ -924,7 +924,7 @@ For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
 &lt;h3 id=&quot;more-containers-to-come&quot;&gt;More Containers to Come!&lt;/h3&gt;
 &lt;p&gt;Keep an eye out for future posts about Docker where we’ll look at creating images and containers from a &lt;code class=&quot;highlighter-rouge&quot;&gt;Dockerfile&lt;/code&gt; and how to coordinate an environment of containers (API, database and UI) with Docker-Compose.&lt;/p&gt;
 </description>
-        <pubDate>Wed, 10 May 2017 00:00:00 -0400</pubDate>
+        <pubDate>Wed, 10 May 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1</guid>
       </item>
@@ -1428,7 +1428,7 @@ cf push -p target/&lt;span class=&quot;k&quot;&gt;*&lt;/span&gt;jar pwa-server
   &lt;li&gt;&lt;a href=&quot;https://github.com/tastejs/hacker-news-pwas&quot;&gt;Hacker News Readers as Progressive Web Apps&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;
 </description>
-        <pubDate>Tue, 09 May 2017 00:00:00 -0400</pubDate>
+        <pubDate>Tue, 09 May 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot</guid>
       </item>
@@ -1475,7 +1475,7 @@ cf push -p target/&lt;span class=&quot;k&quot;&gt;*&lt;/span&gt;jar pwa-server
 &lt;p&gt;Visual Studio has always been the editor of choice for those writing .NET applications and tapping into the Microsoft ecosystem. It has always had all the tools developers need to be their best, most productive selves. Now Microsoft has done some outstanding work to include and integrate with non-Microsoft tools that developers love to use, as well as help developers discover problems in their code, and improve the performance of their IDE. With the new additions and improvements in Visual Studio 2017, developers should love it even more!&lt;/p&gt;
 
 </description>
-        <pubDate>Wed, 03 May 2017 00:00:00 -0400</pubDate>
+        <pubDate>Wed, 03 May 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/05/03/seven-new-vs-features</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/05/03/seven-new-vs-features</guid>
       </item>
@@ -1930,7 +1930,7 @@ is present on the requested resource. Origin 'http://localhost:4200' is therefor
 
 &lt;p&gt;You can find the source code associated with this article &lt;a href=&quot;https://github.com/oktadeveloper/spring-boot-angular-example&quot;&gt;on GitHub&lt;/a&gt;. If you find any bugs, please file an issue on GitHub, or ask your question on Stack Overflow with an &lt;a href=&quot;http://stackoverflow.com/questions/tagged/okta&quot;&gt;okta tag&lt;/a&gt;. Of course, you can always &lt;a href=&quot;https://twitter.com/mraible&quot;&gt;ping me on Twitter&lt;/a&gt; too.&lt;/p&gt;
 </description>
-        <pubDate>Wed, 26 Apr 2017 00:00:00 -0400</pubDate>
+        <pubDate>Wed, 26 Apr 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular</guid>
       </item>
@@ -2927,7 +2927,7 @@ Example 2: &amp;lt;input [(ngModel)]=&quot;person.firstName&quot; [ngModelOption
 &lt;/div&gt;
 
 </description>
-        <pubDate>Mon, 17 Apr 2017 00:00:00 -0400</pubDate>
+        <pubDate>Mon, 17 Apr 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/04/17/angular-authentication-with-oidc</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/04/17/angular-authentication-with-oidc</guid>
       </item>
@@ -3194,7 +3194,7 @@ npm start
 
 &lt;p&gt;I hope you’ve enjoyed this quick tour of our React support. If you have questions about Okta’s features, or what we’re building next, please hit me up on Twitter &lt;a href=&quot;https://twitter.com/leebrandt&quot;&gt;@leebrandt&lt;/a&gt;, leave a comment below, or open an issue on GitHub.&lt;/p&gt;
 </description>
-        <pubDate>Thu, 30 Mar 2017 00:00:00 -0400</pubDate>
+        <pubDate>Thu, 30 Mar 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/03/30/react-okta-sign-in-widget</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/03/30/react-okta-sign-in-widget</guid>
       </item>
@@ -3505,7 +3505,7 @@ Chrome 56.0.2924 &lt;span class=&quot;o&quot;&gt;(&lt;/span&gt;Mac OS X 10.11.6&
 
 &lt;p&gt;I hope you’ve enjoyed this quick tour of our Angular support. If you have questions about Okta’s features, or what we’re building next, please hit me up &lt;a href=&quot;https://twitter.com/mraible&quot;&gt;on Twitter&lt;/a&gt;, &lt;a href=&quot;http://stackoverflow.com/questions/tagged/okta&quot;&gt;post a question to Stack Overflow with an “okta” tag&lt;/a&gt;, or &lt;a href=&quot;https://github.com/oktadeveloper/okta-angular-sign-in-widget-example/issues/new&quot;&gt;open a new issue on GitHub&lt;/a&gt;.&lt;/p&gt;
 </description>
-        <pubDate>Mon, 27 Mar 2017 00:00:00 -0400</pubDate>
+        <pubDate>Mon, 27 Mar 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/03/27/angular-okta-sign-in-widget</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/03/27/angular-okta-sign-in-widget</guid>
       </item>
@@ -3714,7 +3714,7 @@ brew install springboot
 &lt;p&gt;In a future tutorial, I’ll show you how to develop one of these fancy UIs in Angular and use the access token retrieved to talk to a Spring Boot API that’s secured by Spring Security and does JWT validation.&lt;/p&gt;
 
 </description>
-        <pubDate>Tue, 21 Mar 2017 00:00:00 -0400</pubDate>
+        <pubDate>Tue, 21 Mar 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/03/21/spring-boot-oauth</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/03/21/spring-boot-oauth</guid>
       </item>
@@ -3960,7 +3960,7 @@ Hello SAML!
 &lt;p&gt;&lt;strong&gt;Update:&lt;/strong&gt; Thanks to &lt;a href=&quot;https://github.com/AlexeySoshin&quot;&gt;Alexey Soshin&lt;/a&gt; for contributing a &lt;a href=&quot;https://github.com/oktadeveloper/okta-spring-boot-saml-example/pull/2&quot;&gt;pull request&lt;/a&gt; to make the code in this blog post more bootiful!&lt;/p&gt;
 
 </description>
-        <pubDate>Thu, 16 Mar 2017 00:00:00 -0400</pubDate>
+        <pubDate>Thu, 16 Mar 2017 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2017/03/16/spring-boot-saml</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2017/03/16/spring-boot-saml</guid>
       </item>
@@ -4041,7 +4041,7 @@ Hello SAML!
 
 &lt;p&gt;&lt;strong&gt;Happy Okta’ing!&lt;/strong&gt;&lt;/p&gt;
 </description>
-        <pubDate>Tue, 22 Mar 2016 00:00:00 -0400</pubDate>
+        <pubDate>Tue, 22 Mar 2016 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2016/03/22/use-kentor-authservices-with-okta</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2016/03/22/use-kentor-authservices-with-okta</guid>
       </item>
@@ -4071,7 +4071,7 @@ services within an application.&lt;/p&gt;
 
 &lt;iframe src=&quot;https://player.vimeo.com/video/150714428&quot; width=&quot;500&quot; height=&quot;281&quot; frameborder=&quot;0&quot; webkitallowfullscreen=&quot;&quot; mozallowfullscreen=&quot;&quot; allowfullscreen=&quot;&quot;&gt;&lt;/iframe&gt;
 </description>
-        <pubDate>Tue, 05 Jan 2016 00:00:00 -0500</pubDate>
+        <pubDate>Tue, 05 Jan 2016 00:00:00 -0700</pubDate>
         <link>http://developer.okta.com/blog/2016/01/05/rest-service-auth-jwt</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2016/01/05/rest-service-auth-jwt</guid>
       </item>
@@ -4086,7 +4086,7 @@ services within an application.&lt;/p&gt;
 
 &lt;iframe src=&quot;https://player.vimeo.com/video/148164438&quot; width=&quot;500&quot; height=&quot;281&quot; frameborder=&quot;0&quot; webkitallowfullscreen=&quot;&quot; mozallowfullscreen=&quot;&quot; allowfullscreen=&quot;&quot;&gt;&lt;/iframe&gt;
 </description>
-        <pubDate>Mon, 07 Dec 2015 00:00:00 -0500</pubDate>
+        <pubDate>Mon, 07 Dec 2015 00:00:00 -0700</pubDate>
         <link>http://developer.okta.com/blog/2015/12/07/oauth</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/12/07/oauth</guid>
       </item>
@@ -4503,7 +4503,7 @@ you implement these authentication concepts in your applications.&lt;/p&gt;
   &lt;li&gt;&lt;a href=&quot;https://jersey.java.net/documentation/latest/client.html#d0e5128&quot;&gt;Jersey client documentation&lt;/a&gt;&lt;/li&gt;
 &lt;/ol&gt;
 </description>
-        <pubDate>Wed, 02 Dec 2015 00:00:00 -0500</pubDate>
+        <pubDate>Wed, 02 Dec 2015 00:00:00 -0700</pubDate>
         <link>http://developer.okta.com/blog/2015/12/02/tls-client-authentication-for-services</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/12/02/tls-client-authentication-for-services</guid>
       </item>
@@ -4564,7 +4564,7 @@ you implement these authentication concepts in your applications.&lt;/p&gt;
 
 &lt;p&gt;&lt;em&gt;The Trust Page is the work of an amazing team that includes Tim Gu, Shawn Gupta, Nathan Tate, Wendy Liao, and myself.&lt;/em&gt;&lt;/p&gt;
 </description>
-        <pubDate>Thu, 11 Jun 2015 00:00:00 -0400</pubDate>
+        <pubDate>Thu, 11 Jun 2015 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2015/06/11/trustpage</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/06/11/trustpage</guid>
       </item>
@@ -4650,7 +4650,7 @@ compared to the amount of available RAM, which meant that we were sacrificing bo
 
 &lt;p&gt;Beyond the technical lessons we learned during this period, we were reminded that sometimes the best thing to do is stay the course. At times we were tempted to pull back, but moving forward ultimately paid off as each improvement we made exposed the inadequacy (for our platform) of a downstream component.&lt;/p&gt;
 </description>
-        <pubDate>Fri, 22 May 2015 00:00:00 -0400</pubDate>
+        <pubDate>Fri, 22 May 2015 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2015/05/22/tcmalloc</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/05/22/tcmalloc</guid>
       </item>
@@ -4869,7 +4869,7 @@ enforce limits and design for infinity.&lt;/li&gt;
   &lt;/ol&gt;
 &lt;/div&gt;
 </description>
-        <pubDate>Fri, 08 May 2015 00:00:00 -0400</pubDate>
+        <pubDate>Fri, 08 May 2015 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2015/05/08/software-engineering-design-principles</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/05/08/software-engineering-design-principles</guid>
       </item>
@@ -4975,7 +4975,7 @@ where we were last fall, our goal is &lt;strong&gt;zero failover time&lt;/strong
 their hands dirty tackling product issues? Our CTO doesn’t code very often, but when
 he does, he patches the JVM.&lt;/p&gt;
 </description>
-        <pubDate>Fri, 08 May 2015 00:00:00 -0400</pubDate>
+        <pubDate>Fri, 08 May 2015 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2015/05/08/productionalizing-active-mq</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/05/08/productionalizing-active-mq</guid>
       </item>
@@ -5137,7 +5137,7 @@ steps in writing on our wiki. Thanks guys!&lt;/p&gt;
   &lt;/li&gt;
 &lt;/ul&gt;
 </description>
-        <pubDate>Thu, 23 Apr 2015 00:00:00 -0400</pubDate>
+        <pubDate>Thu, 23 Apr 2015 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2015/04/23/android-unit-testing-part-4</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/04/23/android-unit-testing-part-4</guid>
       </item>
@@ -5296,7 +5296,7 @@ dependency, not a real one.&lt;/p&gt;
 how to make tests isolated. You can also check out the full code at
 &lt;a href=&quot;https://github.com/vronin-okta/okta_blog_samples/tree/master/android_unit_testing&quot;&gt;GitHub&lt;/a&gt;.&lt;/p&gt;
 </description>
-        <pubDate>Tue, 14 Apr 2015 00:00:00 -0400</pubDate>
+        <pubDate>Tue, 14 Apr 2015 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2015/04/14/android-unit-testing-part-3</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/04/14/android-unit-testing-part-3</guid>
       </item>
@@ -5490,7 +5490,7 @@ because of a bad network connection.&lt;/p&gt;
 to achieve test isolation using dependency injection. You can also
 check out the full code at &lt;a href=&quot;https://github.com/vronin-okta/okta_blog_samples/tree/master/android_unit_testing&quot;&gt;GitHub&lt;/a&gt;.&lt;/p&gt;
 </description>
-        <pubDate>Tue, 07 Apr 2015 00:00:00 -0400</pubDate>
+        <pubDate>Tue, 07 Apr 2015 00:00:00 -0600</pubDate>
         <link>http://developer.okta.com/blog/2015/04/07/android-unit-testing-part-2</link>
         <guid isPermaLink="true">http://developer.okta.com/blog/2015/04/07/android-unit-testing-part-2</guid>
       </item>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/integrate_with_okta/index.html
+++ b/integrate_with_okta/index.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/integrate_with_okta/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/oidc_playground/index.html
+++ b/oidc_playground/index.html
@@ -40,6 +40,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/oidc_playground/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/pricing-preview/index.html
+++ b/pricing-preview/index.html
@@ -40,6 +40,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/pricing-preview/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/privacy/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/product/index.html
+++ b/product/index.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/product/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/reference/api_reference.html
+++ b/reference/api_reference.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Documentation for all available Okta REST API endpoints. Includes sample requests and responses.">
   <link rel="canonical" href="http://developer.okta.com/reference/api_reference">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/reference/authentication_reference.html
+++ b/reference/authentication_reference.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Documentation describing how to use Okta APIs to authenticate users. Includes sample requests and responses.">
   <link rel="canonical" href="http://developer.okta.com/reference/authentication_reference">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/reference/error_codes/index.html
+++ b/reference/error_codes/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Information about the errors that the Okta API returns.">
   <link rel="canonical" href="http://developer.okta.com/reference/error_codes/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/reference/getting_started.html
+++ b/reference/getting_started.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Understand the basics of the Okta API. Includes details on design principles, error codes and CORS to help you quickly get started.">
   <link rel="canonical" href="http://developer.okta.com/reference/getting_started">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/reference/okta_expression_language/index.html
+++ b/reference/okta_expression_language/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="The features and syntax of Okta's Expression Language which can be used throughout the Okta Admin Console and API.">
   <link rel="canonical" href="http://developer.okta.com/reference/okta_expression_language/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/reference/platform_release_notes.html
+++ b/reference/platform_release_notes.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Information on the changes and updates in the Okta platform.">
   <link rel="canonical" href="http://developer.okta.com/reference/platform_release_notes">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/search/index.html
+++ b/search/index.html
@@ -40,6 +40,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/search/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,7 +5,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot</loc>
       
-        <lastmod>2017-05-17T00:00:00-04:00</lastmod>
+        <lastmod>2017-05-17T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -20,7 +20,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1</loc>
       
-        <lastmod>2017-05-10T00:00:00-04:00</lastmod>
+        <lastmod>2017-05-10T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -35,7 +35,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot</loc>
       
-        <lastmod>2017-05-09T00:00:00-04:00</lastmod>
+        <lastmod>2017-05-09T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -50,7 +50,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/05/03/seven-new-vs-features</loc>
       
-        <lastmod>2017-05-03T00:00:00-04:00</lastmod>
+        <lastmod>2017-05-03T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -65,7 +65,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular</loc>
       
-        <lastmod>2017-04-26T00:00:00-04:00</lastmod>
+        <lastmod>2017-04-26T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -80,7 +80,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/04/17/angular-authentication-with-oidc</loc>
       
-        <lastmod>2017-04-17T00:00:00-04:00</lastmod>
+        <lastmod>2017-04-17T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -95,7 +95,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/03/30/react-okta-sign-in-widget</loc>
       
-        <lastmod>2017-03-30T00:00:00-04:00</lastmod>
+        <lastmod>2017-03-30T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -110,7 +110,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/03/27/angular-okta-sign-in-widget</loc>
       
-        <lastmod>2017-03-27T00:00:00-04:00</lastmod>
+        <lastmod>2017-03-27T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -125,7 +125,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/03/21/spring-boot-oauth</loc>
       
-        <lastmod>2017-03-21T00:00:00-04:00</lastmod>
+        <lastmod>2017-03-21T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -140,7 +140,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2017/03/16/spring-boot-saml</loc>
       
-        <lastmod>2017-03-16T00:00:00-04:00</lastmod>
+        <lastmod>2017-03-16T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -155,7 +155,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2016/03/22/use-kentor-authservices-with-okta</loc>
       
-        <lastmod>2016-03-22T00:00:00-04:00</lastmod>
+        <lastmod>2016-03-22T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -170,7 +170,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2016/01/05/rest-service-auth-jwt</loc>
       
-        <lastmod>2016-01-05T00:00:00-05:00</lastmod>
+        <lastmod>2016-01-05T00:00:00-07:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -185,7 +185,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/12/07/oauth</loc>
       
-        <lastmod>2015-12-07T00:00:00-05:00</lastmod>
+        <lastmod>2015-12-07T00:00:00-07:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -200,7 +200,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/12/02/tls-client-authentication-for-services</loc>
       
-        <lastmod>2015-12-02T00:00:00-05:00</lastmod>
+        <lastmod>2015-12-02T00:00:00-07:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -215,7 +215,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/06/11/trustpage</loc>
       
-        <lastmod>2015-06-11T00:00:00-04:00</lastmod>
+        <lastmod>2015-06-11T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -230,7 +230,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/05/22/tcmalloc</loc>
       
-        <lastmod>2015-05-22T00:00:00-04:00</lastmod>
+        <lastmod>2015-05-22T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -245,7 +245,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/05/08/software-engineering-design-principles</loc>
       
-        <lastmod>2015-05-08T00:00:00-04:00</lastmod>
+        <lastmod>2015-05-08T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -260,7 +260,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/05/08/productionalizing-active-mq</loc>
       
-        <lastmod>2015-05-08T00:00:00-04:00</lastmod>
+        <lastmod>2015-05-08T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -275,7 +275,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/04/23/android-unit-testing-part-4</loc>
       
-        <lastmod>2015-04-23T00:00:00-04:00</lastmod>
+        <lastmod>2015-04-23T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -290,7 +290,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/04/14/android-unit-testing-part-3</loc>
       
-        <lastmod>2015-04-14T00:00:00-04:00</lastmod>
+        <lastmod>2015-04-14T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>
@@ -305,7 +305,7 @@
     <url>
       <loc>http://developer.okta.com/blog/2015/04/07/android-unit-testing-part-2</loc>
       
-        <lastmod>2015-04-07T00:00:00-04:00</lastmod>
+        <lastmod>2015-04-07T00:00:00-06:00</lastmod>
       
       
         <changefreq>monthly</changefreq>

--- a/standards/OAuth/index.html
+++ b/standards/OAuth/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="The next evolution of the OAuth protocol focuses on client developer simplicity">
   <link rel="canonical" href="http://developer.okta.com/standards/OAuth/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/standards/OIDC/index.html
+++ b/standards/OIDC/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="A simple identity layer on top of the OAuth 2.0 protocol">
   <link rel="canonical" href="http://developer.okta.com/standards/OIDC/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/standards/SAML/configuring_a_saml_application_in_okta.html
+++ b/standards/SAML/configuring_a_saml_application_in_okta.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Here is how to configure Okta:">
   <link rel="canonical" href="http://developer.okta.com/standards/SAML/configuring_a_saml_application_in_okta">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/standards/SAML/index.html
+++ b/standards/SAML/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Enable single sign-on for your web and mobile application">
   <link rel="canonical" href="http://developer.okta.com/standards/SAML/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/standards/SAML/saml_tracer.html
+++ b/standards/SAML/saml_tracer.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Testing SAML with SAML tracer">
   <link rel="canonical" href="http://developer.okta.com/standards/SAML/saml_tracer">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/standards/SAML/setting_up_a_saml_application_in_okta.html
+++ b/standards/SAML/setting_up_a_saml_application_in_okta.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Setting Up a SAML Application in Okta">
   <link rel="canonical" href="http://developer.okta.com/standards/SAML/setting_up_a_saml_application_in_okta">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/standards/SCIM/index.html
+++ b/standards/SCIM/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Enable SCIM-based provisioning from Okta to your application.">
   <link rel="canonical" href="http://developer.okta.com/standards/SCIM/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/templates/api-endpoint.html
+++ b/templates/api-endpoint.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Pithy phrase describing problem that customer solves with this API">
   <link rel="canonical" href="http://developer.okta.com/templates/api-endpoint">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/terms/index.html
+++ b/terms/index.html
@@ -38,6 +38,10 @@
 ">
   <link rel="canonical" href="http://developer.okta.com/terms/">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/api_access_management/index.html
+++ b/use_cases/api_access_management/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Secure your APIs with Okta's implementation of the OAuth 2.0 standard.">
   <link rel="canonical" href="http://developer.okta.com/use_cases/api_access_management/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/authentication/index.html
+++ b/use_cases/authentication/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Overview of the various ways Okta can be used to authenticate users depending on your needs.">
   <link rel="canonical" href="http://developer.okta.com/use_cases/authentication/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/authentication/session_cookie.html
+++ b/use_cases/authentication/session_cookie.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Overview">
   <link rel="canonical" href="http://developer.okta.com/use_cases/authentication/session_cookie">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/integrate_with_okta/index.html
+++ b/use_cases/integrate_with_okta/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Make your app enterprise ready and connect with thousands of customers with the Okta Application Network.">
   <link rel="canonical" href="http://developer.okta.com/use_cases/integrate_with_okta/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/integrate_with_okta/oan-faqs.html
+++ b/use_cases/integrate_with_okta/oan-faqs.html
@@ -37,6 +37,10 @@
   <meta name="description" content="OAN FAQs">
   <link rel="canonical" href="http://developer.okta.com/use_cases/integrate_with_okta/oan-faqs">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/integrate_with_okta/promotion.html
+++ b/use_cases/integrate_with_okta/promotion.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Tell the world about your Okta integration to accelerate adoption, differentiate your app, and drive new business.">
   <link rel="canonical" href="http://developer.okta.com/use_cases/integrate_with_okta/promotion">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/integrate_with_okta/provisioning.html
+++ b/use_cases/integrate_with_okta/provisioning.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Make your app enterprise ready and connect with thousands of customers with the Okta Application Network.">
   <link rel="canonical" href="http://developer.okta.com/use_cases/integrate_with_okta/provisioning">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/integrate_with_okta/sso-with-saml.html
+++ b/use_cases/integrate_with_okta/sso-with-saml.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Support single sign-on in your app and join the Okta Application Network.">
   <link rel="canonical" href="http://developer.okta.com/use_cases/integrate_with_okta/sso-with-saml">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/mfa/index.html
+++ b/use_cases/mfa/index.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Using Okta's Multi-Factor Authentication API to add MFA to an existing application.">
   <link rel="canonical" href="http://developer.okta.com/use_cases/mfa/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/mobile/okta_mobile_connect.html
+++ b/use_cases/mobile/okta_mobile_connect.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Learn how to Single Sign-On enable your native mobile app.">
   <link rel="canonical" href="http://developer.okta.com/use_cases/mobile/okta_mobile_connect">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/sso_and_provisioning/draft.html
+++ b/use_cases/sso_and_provisioning/draft.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Integrating your application with Okta">
   <link rel="canonical" href="http://developer.okta.com/use_cases/sso_and_provisioning/draft">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/users_groups_applications/draft.html
+++ b/use_cases/users_groups_applications/draft.html
@@ -37,6 +37,10 @@
   <meta name="description" content="Storing user, group, and application information">
   <link rel="canonical" href="http://developer.okta.com/use_cases/users_groups_applications/draft">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>

--- a/use_cases/web_development/draft.html
+++ b/use_cases/web_development/draft.html
@@ -37,6 +37,10 @@
   <meta name="description" content="How to build your web application on top of Okta">
   <link rel="canonical" href="http://developer.okta.com/use_cases/web_development/draft">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="http://developer.okta.com/feed.xml"><!-- GA -->
+  <script type="text/javascript">
+    var disqus_shortname = 'oktadevblog';
+  </script>
+  </head>
 </head>
 
 <body>


### PR DESCRIPTION
## Description:

Implementing Disqus with Jekyll for blog post comments. Used tutorial at: http://vcabbage.com/development/2015/06/21/implementing-disqus-with-jekyll.html

I tried to implement comment count on the blog index page, but couldn't get it working right.

## Type of Pull Request:
<!--- What types of PR is this? Put an `x` in all the boxes that apply: -->
- [ ] Content (Documentation updates or typo-fixes)
- [ ] Blog Post
- [x] Functional (CSS changes, JS updates, or layout modifications)

### Resolves:
* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

## How Has This Been Tested?
- [x] I have built this locally and verified that it does not break existing functionality.
- [x] For functional changes, I have tested against Chrome, Firefox, and Safari, and mobile.
- [ ] For functional changes, I have added tests.

## Primary Reviewers:

DevEx
