### PR TITLE
Remove references to import_external_markdown

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -95,7 +95,6 @@ function generate_html() {
 
     if [ ! -d $GENERATED_SITE_LOCATION ]; then
         check_for_npm_dependencies
-        import_external_markdown
         bundle exec jekyll build
         local status=$?
         interject 'Done generating HTML'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,6 @@ if [[ -z "${SUCCESS}" ]]; then
 fi
 
 source "${0%/*}/helpers.sh"
-source "${0%/*}/import_external_markdown.sh"
 
 # Print an easily visible line, useful for log files.
 function interject() {
@@ -69,7 +68,6 @@ function generate_html() {
 
     if [ ! -d $GENERATED_SITE_LOCATION ]; then
         check_for_npm_dependencies
-        import_external_markdown
         bundle exec jekyll build
         local status=$?
         interject 'Done generating HTML'


### PR DESCRIPTION
## Description:
Remove all references to import_external_markdown
We use the npm command 'import-external' which now happens to be part of the build

## Type of Pull Request:
<!--- What types of PR is this? Put an `x` in all the boxes that apply: -->
- [ ] Content (Documentation updates or typo-fixes)
- [ ] Blog Post
- [ ] Functional (CSS changes, JS updates, or layout modifications)

### Resolves:
* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

## How Has This Been Tested?
- [ ] I have built this locally and verified that it does not break existing functionality.
- [ ] For functional changes, I have tested against Chrome, Firefox, and Safari, and mobile.
- [ ] For functional changes, I have added tests.

## Primary Reviewers:
<!--- Blog: DevBlog team + DevEx -->
<!--- Content: Doc + home team -->
<!--- Functional: DevEx -->
- *Tag reviewer(s)*
<!--- For Blog posts, add the Google Docs link below -->
- [Blog Post Google Doc](https://docs.google.com)
