### PR TITLE
Should say ID Token not Access Token

### DIFF
--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -87,7 +87,7 @@ OpenID Connect introduces an [ID Token](http://openid.net/specs/openid-connect-c
 which is a [JSON web token (JWT)](https://tools.ietf.org/html/rfc7519) that contains information about an authentication event
 and claims about the authenticated user that clients can rely on.
 
-Clients can use any of the following sequences of operations to obtain an Access Token:
+Clients can use any of the following sequences of operations to obtain an ID Token:
 * [Authorization code flow](http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth) -- the client obtains
 an authorization code from the authorization server's authentication endpoint and uses it to obtain an ID token and an access
 token from the authorization server's Token endpoint.
@@ -967,6 +967,3 @@ Content-Type: application/json;charset=UTF-8
     "error_description" : "No client credentials found."
 }
 ~~~
-
-
-


### PR DESCRIPTION
## Description:
- Docs say Access Token in a place where it should be ID Token

## Type of Pull Request:
<!--- What types of PR is this? Put an `x` in all the boxes that apply: -->
- [x] Content (Documentation updates or typo-fixes)
- [ ] Blog Post
- [ ] Functional (CSS changes, JS updates, or layout modifications)

### Resolves:
* #893 

## How Has This Been Tested?
- [x] I have built this locally and verified that it does not break existing functionality.
- [ ] For functional changes, I have tested against Chrome, Firefox, and Safari, and mobile.
- [ ] For functional changes, I have added tests.

## Primary Reviewers:
<!--- Blog: DevBlog team + DevEx -->
<!--- Content: Doc + home team -->
<!--- Functional: DevEx -->
- *Tag reviewer(s)*
<!--- For Blog posts, add the Google Docs link below -->
- [Blog Post Google Doc](https://docs.google.com)
