### PR TITLE
/logs docs fixes: Attributes section

### DIFF
--- a/_source/_docs/api/resources/system_log.md
+++ b/_source/_docs/api/resources/system_log.md
@@ -177,7 +177,7 @@ Each Log object describes a single action performed by a set of actors for a set
     }
   },
   "legacyEventType": "core.user_auth.login_success",
-  "authentication_context": {
+  "authenticationContext": {
     "authenticationStep": 0,
     "externalSessionId": "1013FfF-DKQSvCI4RVXChzX-w"
   }
@@ -305,7 +305,7 @@ Log objects are read-only. The following properties are available:
 |-----------+-----------------------------------------------------------------------+----------------------------------------------------------------+----------+--------+----------+-----------+-----------|
 | Property  | Description                                                           | DataType                                                       | Nullable | Unique | Readonly | MinLength | MaxLength |
 | -------   | --------------------------------------------------------------------- | ---------------------------------------------------------------| -------- | ------ | -------- | --------- | --------- |
-| eventId   | Unique key for an event                                               | String                                                         | FALSE    | TRUE   | TRUE     |           |           |
+| uuid      | Unique identifier for an individual event                             | String                                                         | FALSE    | TRUE   | TRUE     |           |           |
 | published | Timestamp when event was published                                    | Date                                                           | FALSE    | FALSE  | TRUE     | 1         | 255       |
 | eventType | Type of event that was published                                      | String                                                         | FALSE    | FALSE  | TRUE     | 1         | 255       |
 | version   | Versioning indicator                                                  | String                                                         | FALSE    | FALSE  | TRUE     | 1         | 255       |
@@ -324,7 +324,7 @@ Log objects are read-only. The following properties are available:
 
 > The actor and/or target of an event is dependent on the action performed. All events have actors. Not all events have targets.
 
-> The `sessionId` can identify multiple requests.  A single `requestId` can identify multiple events.  Use the `sessionId` to link events and requests that occurred in the same session.
+> The `authenticationContext.externalSessionId` identifies events that occurred in the same session.  A single `transaction.id` identifies events that occurred together as part of an operation (e.g. a request to Okta's servers). Use `authenticationContext.externalSessionId` to link events that occurred in the same session, and the `transaction.id` to link events that occurred as part of the same operation.
 
 ### Actor Object
 


### PR DESCRIPTION
## Description:
This changeset fixes a few errors in the "Attributes" section of our
`/logs` documentation:
  - In the table, `eventId` should be `uuid`.
  - There are references to `requestId` that should be `transaction.id`.
  - There are references to `sessionId` that should be
    `authenticationContext.externalSessionId`.

Also, in the "Example Log object" section, the reference to
`authentication_context` should be `authenticationContext`.

## Type of Pull Request:
<!--- What types of PR is this? Put an `x` in all the boxes that apply: -->
- [x] Content (Documentation updates or typo-fixes)
- [ ] Blog Post
- [ ] Functional (CSS changes, JS updates, or layout modifications)

### Resolves:
* [OKTA-127977](https://oktainc.atlassian.net/browse/OKTA-127977)

## How Has This Been Tested?
- [x] I have built this locally and verified that it does not break existing functionality.
- [n/a] For functional changes, I have tested against Chrome, Firefox, and Safari, and mobile.
- [n/a] For functional changes, I have added tests.

## Primary Reviewers:
<!--- Blog: DevBlog team + DevEx -->
<!--- Content: Doc + home team -->
<!--- Functional: DevEx -->
* @mystiberry-okta 
* @bobtiernay-okta 

- *Tag reviewer(s)*
* @aminjashki-okta
* @rpamidimarri-okta
* @ericzhou-okta
* @richardblaylock-okta
* @jeffpeeler-okta
* @guyzehavi-okta
* @chrismckerracher-okta