### PR TITLE
Disable Beta tag test

### DIFF
--- a/tests/selenium/spec/api-tags-spec.js
+++ b/tests/selenium/spec/api-tags-spec.js
@@ -12,7 +12,8 @@ describe('API tags check spec', () => {
   it('shows the Beta and Early Access lifecycle tags', () => {
     const docsPage = new DocsPage('/docs/api/resources/oauth2.html');
     docsPage.load();
-    expect(docsPage.hasBetaTags()).toBe(true);
+    // TODO - Look for beta tags in other pages. Beta tag on this page updated to EA (OKTA-124731)
+    //expect(docsPage.hasBetaTags()).toBe(true);
     expect(docsPage.hasEATags()).toBe(true);
     expect(docsPage.hasDeprecatedTags()).toBe(false);
   });


### PR DESCRIPTION
## Description:
Removing the beta tag validation on “/docs/api/resources/oauth2.html" page.
This is failing travis test on Mysti's doc change (OKTA-124731)

## Type of Pull Request:
<!--- What types of PR is this? Put an `x` in all the boxes that apply: -->
- [x] Content (Documentation updates or typo-fixes)
- [ ] Blog Post
- [ ] Functional (CSS changes, JS updates, or layout modifications)

### Resolves:
* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

## How Has This Been Tested?
- [x] I have built this locally and verified that it does not break existing functionality.
- [ ] For functional changes, I have tested against Chrome, Firefox, and Safari, and mobile.
- [ ] For functional changes, I have added tests.

## Primary Reviewers:
<!--- Blog: DevBlog team + DevEx -->
<!--- Content: Doc + home team -->
<!--- Functional: DevEx -->
- *Tag reviewer(s)*
<!--- For Blog posts, add the Google Docs link below -->
@mystiberry-okta 
@rchild-okta 
- [Blog Post Google Doc](https://docs.google.com)
