### PR TITLE
Using the lifecycle operations page for tag checks

### DIFF
--- a/tests/selenium/spec/api-tags-spec.js
+++ b/tests/selenium/spec/api-tags-spec.js
@@ -1,30 +1,18 @@
 const DocsPage = require('../framework/page-objects/DocsPage');
 
 describe('API tags check spec', () => {
-  it('shows the Deprecated lifecycle tags', () => {
-    const docsPage = new DocsPage('/docs/api/resources/sessions.html');
+  it('shows the Beta, Early Access and Deprecated lifecycle tags', () => {
+    const docsPage = new DocsPage('/docs/api/getting_started/releases-at-okta.html');
     docsPage.load();
-    expect(docsPage.hasDeprecatedTags()).toBe(true);
-    expect(docsPage.hasBetaTags()).toBe(false);
-    expect(docsPage.hasEATags()).toBe(false);
-  });
-
-  it('shows the Beta and Early Access lifecycle tags', () => {
-    const docsPage = new DocsPage('/docs/api/resources/oauth2.html');
-    docsPage.load();
-    // TODO - Look for beta tags in other pages. Beta tag on this page updated to EA (OKTA-124731)
-    //expect(docsPage.hasBetaTags()).toBe(true);
+    expect(docsPage.hasBetaTags()).toBe(true);
     expect(docsPage.hasEATags()).toBe(true);
-    expect(docsPage.hasDeprecatedTags()).toBe(false);
+    expect(docsPage.hasDeprecatedTags()).toBe(true);
   });
 
   it('shows the CORS tags', () => {
     const docsPage = new DocsPage('/docs/api/getting_started/enabling_cors.html ');
     docsPage.load();
     expect(docsPage.hasCORSTags()).toBe(true);
-    expect(docsPage.hasDeprecatedTags()).toBe(false);
-    expect(docsPage.hasBetaTags()).toBe(false);
-    expect(docsPage.hasEATags()).toBe(false);
   });
 
   it('shows the API URI tags', () => {


### PR DESCRIPTION


## Description:

- Using the lifecycle operations page for tag checks
- Removed checks from other pages, since these tags will be changed, eventually.

## Type of Pull Request:
<!--- What types of PR is this? Put an `x` in all the boxes that apply: -->
- [ ] Content (Documentation updates or typo-fixes)
- [ ] Blog Post
- [ ] Functional (CSS changes, JS updates, or layout modifications)

### Resolves:
* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

## How Has This Been Tested?
- [x] I have built this locally and verified that it does not break existing functionality.
- [ ] For functional changes, I have tested against Chrome, Firefox, and Safari, and mobile.
- [ ] For functional changes, I have added tests.

## Primary Reviewers:
<!--- Blog: DevBlog team + DevEx -->
<!--- Content: Doc + home team -->
<!--- Functional: DevEx -->
- *Tag reviewer(s)*
<!--- For Blog posts, add the Google Docs link below -->
- [Blog Post Google Doc](https://docs.google.com)
