### PR TITLE
Fix okta-auth-js CDN link

### DIFF
--- a/_source/_code/javascript/okta_auth_sdk.md
+++ b/_source/_code/javascript/okta_auth_sdk.md
@@ -19,7 +19,7 @@ The Okta Auth SDK builds on top of our [Authentication API](/docs/api/resources/
 Include the following script tag in your target web page:
 
 ~~~ html
-<script src="https://ok1static.oktacdn.com/assets/js/sdk/okta-auth-js/1.8.0/OktaAuth.min.js" type="text/javascript"></script>
+<script src="https://ok1static.oktacdn.com/assets/js/sdk/okta-auth-js/1.8.0/okta-auth-js.min.js" type="text/javascript"></script>
 ~~~
 
 ## Authentication Flow

--- a/code/javascript/okta_auth_sdk.html
+++ b/code/javascript/okta_auth_sdk.html
@@ -201,7 +201,7 @@
 
 <p>Include the following script tag in your target web page:</p>
 
-<div class="language-html highlighter-rouge"><pre class="highlight"><code><span class="nt">&lt;script </span><span class="na">src=</span><span class="s">"https://ok1static.oktacdn.com/assets/js/sdk/okta-auth-js/1.8.0/OktaAuth.min.js"</span> <span class="na">type=</span><span class="s">"text/javascript"</span><span class="nt">&gt;&lt;/script&gt;</span>
+<div class="language-html highlighter-rouge"><pre class="highlight"><code><span class="nt">&lt;script </span><span class="na">src=</span><span class="s">"https://ok1static.oktacdn.com/assets/js/sdk/okta-auth-js/1.8.0/okta-auth-js.min.js"</span> <span class="na">type=</span><span class="s">"text/javascript"</span><span class="nt">&gt;&lt;/script&gt;</span>
 </code></pre>
 </div>
 


### PR DESCRIPTION
## Description:
- Fix okta-auth-js CDN link - it was pointing to an asset that didn't exist

## Type of Pull Request:
- [x] Content (Documentation updates or typo-fixes)
- [ ] Blog Post
- [ ] Functional (CSS changes, JS updates, or layout modifications)

### Resolves:
* [OKTA-132875](https://oktainc.atlassian.net/browse/OKTA-132875)

## How Has This Been Tested?
- [x] I have built this locally and verified that it does not break existing functionality.
- [ ] For functional changes, I have tested against Chrome, Firefox, and Safari, and mobile.
- [ ] For functional changes, I have added tests.

## Primary Reviewers:
@jmelberg-okta 
