### PR TITLE
remove EA tags for OIDC, key rollover

### DIFF
--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -9,8 +9,6 @@ The OpenID Connect API endpoints enable clients to use [OIDC workflows](http://o
 With OpenID Connect, a client can use Okta as a broker. The user authenticates against identity providers like Google, Facebook, LinkedIn, or Microsoft,
 and the client obtains an Okta session.
 
-> This API is currently in **Early Access** status.  It has been tested as thoroughly as a Generally Available feature. Contact Support to enable this feature.
-
 ## Getting Started
 
 If you are new to OpenID Connect, read this topic before experimenting with the Postman collection. If you are familiar with

--- a/_source/_docs/api/resources/social_authentication.md
+++ b/_source/_docs/api/resources/social_authentication.md
@@ -6,7 +6,7 @@ excerpt: Setting up an Okta Social Login provider
 
 # Social Login
 
-## Overview
+{% api_lifecycle ea %}
 
 Okta allows your users to sign in to your app using their Facebook, Google, LinkedIn, and Microsoft credentials. Once the user has successfully authenticated, they are returned to your app, and their social profile information is pulled into your Okta directory.
 

--- a/_source/_standards/OAuth/index.md
+++ b/_source/_standards/OAuth/index.md
@@ -27,7 +27,7 @@ The OAuth 2.0 APIs provide API security via scoped access tokens, and OpenID Con
 There are several use cases and Okta product features built on top of the OAuth 2.0 APIs:
 
 * Social Authentication -- {% api_lifecycle ea %}
-* OpenID Connect -- {% api_lifecycle ea %}
+* OpenID Connect
 * API Access Management -- {% api_lifecycle ea %}
 
 It's important to understand which use case you are targeting and build your application according to the correct patterns for that use case.


### PR DESCRIPTION
## Description:
- Remove EA tags for OIDC, key rollover (there weren't any for key rollover in particular).
Asking team if Social Login (Social Authentication) should still be marked EA. it is in one place, but not the main place.

### Resolves:

* [OKTA-133154](https://oktainc.atlassian.net/browse/OKTA-133154)

