### PR TITLE
OKTA-132974 Fixed wrong formatting of '?' character

### DIFF
--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -497,7 +497,7 @@ Parameter | Description                                                        |
 --------- | ------------------------------------------------------------------ | ---------- | -------- | -------- |
 id        | `id`, `login`, or *login shortname* (as long as it is unambiguous) | URL        | String   | TRUE     |
 
-> When fetching a user by `login` or `login shortname`, you should [URL encode](http://en.wikipedia.org/wiki/Percent-encoding) the request parameter to ensure special characters are escaped properly.  Logins with a `/` or '?'  character can only be fetched by `id` due to URL issues with escaping the `/` and '?' characters.
+> When fetching a user by `login` or `login shortname`, you should [URL encode](http://en.wikipedia.org/wiki/Percent-encoding) the request parameter to ensure special characters are escaped properly.  Logins with a `/` or `?`  character can only be fetched by `id` due to URL issues with escaping the `/` and `?` characters.
 
 >Hint: you can substitute `me` for the `id` to fetch the current user linked to an API token or session cookie.
 


### PR DESCRIPTION
## Description:
Had used ' instead of ` earlier while fixing a different bug. This just fixes that.

### Resolves:

<!-- Required for Okta-generated PRs -->
* [OKTA-132974](https://oktainc.atlassian.net/browse/OKTA-132974)
