### PR TITLE
Add Documentation for App User Schemas API

### DIFF
--- a/_source/_docs/api/resources/schemas.md
+++ b/_source/_docs/api/resources/schemas.md
@@ -635,13 +635,418 @@ curl -v -X POST \
 }
 ~~~
 
+## App User Schema Operations
+
+{% api_lifecycle beta %}
+
+### Get App User Schema
+{:.api .api-operation}
+
+{% api_operation get /api/v1/meta/schemas/apps/*:instanceId*/default %}
+
+Fetches the default schema for an App User
+
+##### Request Parameters
+{:.api .api-request .api-request-params}
+
+Parameter   | Description                                          | Param Type | DataType                                                       | Required | Default
+----------- | ---------------------------------------------------- | ---------- | -------------------------------------------------------------- | -------- | -------
+instanceId  | The id of the target App Instance                    | Path       | String                                                         | TRUE     |
+
+
+##### Response Parameters
+{:.api .api-response .api-response-params}
+
+[App User Schema](#app-user-schema-model)
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://${org}.okta.com/api/v1/meta/schemas/apps/{instanceId}/default"
+~~~
+
+##### Response Example
+{:.api .api-response .api-response-example}
+
+~~~json
+{
+  "id": "https://example.okta.com/meta/schemas/apps/0oa25gejWwdXNnFH90g4/default",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "name": "Example App",
+  "title": "Example App User",
+  "lastUpdated": "2017-07-18T23:18:43.000Z",
+  "created": "2017-07-18T22:35:30.000Z",
+  "definitions": {
+    "base": {
+      "id": "#base",
+      "type": "object",
+      "properties": {
+        "userName": {
+          "title": "Username",
+          "type": "string",
+          "required": true,
+          "scope": "NONE",
+          "maxLength": 100
+        }
+      },
+      "required": [
+        "userName"
+      ]
+    },
+    "custom": {
+      "id": "#custom",
+      "type": "object",
+      "properties": {
+      },
+      "required": []
+    }
+  },
+  "type": "object",
+  "properties": {
+    "profile": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        },
+        {
+          "$ref": "#/definitions/custom"
+        }
+      ]
+    }
+  }
+}
+~~~
+
+### Add Property to App User Profile Schema
+{:.api .api-operation}
+
+{% api_operation post /api/v1/meta/schemas/apps/*:instanceId*/default %}
+
+Adds one or more [custom app user profile properties](#app-user-profile-schema-property-object) to the app user schema
+
+##### Request Parameters
+{:.api .api-request .api-request-params}
+
+Parameter   | Description                                          | Param Type | DataType                                                       | Required | Default
+----------- | ---------------------------------------------------- | ---------- | -------------------------------------------------------------- | -------- | -------
+instanceId  | The id of the target App Instance                    | Path       | String                                                         | TRUE     |        |
+definitions | Subschema with one or more custom profile properties | Body       | [App User Profile Custom Subschema](#app-user-profile-custom-subschema) | TRUE     |
+
+##### Response Parameters
+{:.api .api-response .api-response-params}
+
+[App User Schema](#app-user-schema-model)
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+  {
+    "definitions": {
+      "custom": {
+        "id": "#custom",
+        "type": "object",
+        "properties": {
+          "twitterUserName": {
+            "title": "Twitter username",
+            "description": "User'\''s username for twitter.com",
+            "type": "string",
+            "required": false,
+            "minLength": 1,
+            "maxLength": 20,
+          }
+        },
+        "required": []
+      }
+    }
+  }
+}' "https://${org}.okta.com/api/v1/meta/schemas/apps/{instanceId}/default"
+~~~
+
+##### Response Example
+{:.api .api-response .api-response-example}
+
+~~~json
+{
+  "id": "https://example.okta.com/meta/schemas/apps/0oa25gejWwdXNnFH90g4/default",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "name": "Example App",
+  "title": "Example App User",
+  "lastUpdated": "2017-07-18T23:18:43.000Z",
+  "created": "2017-07-18T22:35:30.000Z",
+  "definitions": {
+    "base": {
+      "id": "#base",
+      "type": "object",
+      "properties": {
+        "userName": {
+          "title": "Username",
+          "type": "string",
+          "required": true,
+          "scope": "NONE",
+          "maxLength": 100
+        }
+      },
+      "required": [
+        "userName"
+      ]
+    },
+    "custom": {
+      "id": "#custom",
+      "type": "object",
+      "properties": {
+        "twitterUserName": {
+          "title": "Twitter username",
+          "description": "User's username for twitter.com",
+          "type": "string",
+          "scope": "NONE",
+          "minLength": 1,
+          "maxLength": 20
+        }
+      },
+      "required": []
+    }
+  },
+  "type": "object",
+  "properties": {
+    "profile": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        },
+        {
+          "$ref": "#/definitions/custom"
+        }
+      ]
+    }
+  }
+}
+~~~
+
+### Update App User Profile Schema Property
+{:.api .api-operation}
+
+{% api_operation post /api/v1/meta/schemas/apps/*:instanceId*/default %}
+
+Updates one or more [custom app user profile properties](#app-user-profile-schema-property-object) in the schema.
+
+##### Request Parameters
+{:.api .api-request .api-request-params}
+
+Parameter   | Description                                          | Param Type | DataType                                                       | Required | Default
+----------- | ---------------------------------------------------- | ---------- | -------------------------------------------------------------- | -------- | -------
+instanceId  | The id of the target App Instance                    | Path       | String                                                         | TRUE     |        |
+definitions | Subschema with one or more custom profile properties | Body       | [App User Profile Custom Subschema](#app-user-profile-custom-subschema) | TRUE     |
+
+##### Response Parameters
+{:.api .api-response .api-response-params}
+
+[App User Schema](#app-user-schema-model)
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+  {
+    "definitions": {
+      "custom": {
+        "id": "#custom",
+        "type": "object",
+        "properties": {
+          "twitterUserName": {
+            "title": "Twitter username",
+            "description": "User'\''s username for twitter.com",
+            "type": "string",
+            "required": false,
+            "minLength": 1,
+            "maxLength": 10,
+          }
+        },
+        "required": []
+      }
+    }
+  }
+}' "https://${org}.okta.com/api/v1/meta/schemas/apps/{instanceId}/default"
+~~~
+
+##### Response Example
+{:.api .api-response .api-response-example}
+
+~~~json
+{
+  "id": "https://example.okta.com/meta/schemas/apps/0oa25gejWwdXNnFH90g4/default",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "name": "Example App",
+  "title": "Example App User",
+  "lastUpdated": "2017-07-19T17:01:05.000Z",
+  "created": "2017-07-18T22:35:30.000Z",
+  "definitions": {
+    "base": {
+      "id": "#base",
+      "type": "object",
+      "properties": {
+        "userName": {
+          "title": "Username",
+          "type": "string",
+          "required": true,
+          "scope": "NONE",
+          "maxLength": 100
+        }
+      },
+      "required": [
+        "userName"
+      ]
+    },
+    "custom": {
+      "id": "#custom",
+      "type": "object",
+      "properties": {
+        "twitterUserName": {
+          "title": "Twitter username",
+          "description": "User's username for twitter.com",
+          "type": "string",
+          "scope": "NONE",
+          "minLength": 1,
+          "maxLength": 10
+        }
+      },
+      "required": []
+    }
+  },
+  "type": "object",
+  "properties": {
+    "profile": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        },
+        {
+          "$ref": "#/definitions/custom"
+        }
+      ]
+    }
+  }
+}
+~~~
+
+### Remove Property from App User Profile Schema
+{:.api .api-operation}
+
+{% api_operation post /api/v1/meta/schemas/apps/*:instanceId*/default %}
+
+Removes one or more [custom app user profile properties](#app-user-profile-schema-property-object) from the user schema.
+
+##### Request Parameters
+{:.api .api-request .api-request-params}
+
+Parameter   | Description                                                    | Param Type | DataType                                                       | Required | Default
+----------- | -------------------------------------------------------------- | ---------- | -------------------------------------------------------------- | -------- | -------
+instanceId  | The id of the target App Instance                              | Path       | String                                                         | TRUE     |        |
+definitions | Subschema with one or more custom profile properties to remove | Body       | [App User Profile Custom Subschema](#app-user-profile-custom-subschema) | TRUE     |
+
+> Properties must be explicitly set to `null` to be removed from schema, otherwise the `POST` will be interpreted as a partial update.
+
+##### Response Parameters
+{:.api .api-response .api-response-params}
+
+[App User Schema](#app-user-schema-model)
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+  {
+    "definitions": {
+      "custom": {
+        "id": "#custom",
+        "type": "object",
+        "properties": {
+          "twitterUserName": null
+        },
+        "required": []
+      }
+    }
+  }
+}' "https://${org}.okta.com/api/v1/meta/schemas/apps/{instanceId}/default"
+~~~
+
+##### Response Example
+{:.api .api-response .api-response-example}
+
+~~~json
+{
+  "id": "https://example.okta.com/meta/schemas/apps/0oa25gejWwdXNnFH90g4/default",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "name": "Example App",
+  "title": "Example App User",
+  "lastUpdated": "2017-07-19T17:11:22.000Z",
+  "created": "2017-07-18T22:35:30.000Z",
+  "definitions": {
+    "base": {
+      "id": "#base",
+      "type": "object",
+      "properties": {
+        "userName": {
+          "title": "Username",
+          "type": "string",
+          "required": true,
+          "scope": "NONE",
+          "maxLength": 100
+        }
+      },
+      "required": [
+        "userName"
+      ]
+    },
+    "custom": {
+      "id": "#custom",
+      "type": "object",
+      "properties": {}
+    }
+  },
+  "type": "object",
+  "properties": {
+    "profile": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        },
+        {
+          "$ref": "#/definitions/custom"
+        }
+      ]
+    }
+  }
+}
+~~~
+
 ## User Schema Model
 
 The [User Model](./users.html#user-model) schema is defined using [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04).
 
 > The schema currently only defines the [profile object](./users.html#profile-object).
 
-### Example
+### Example User Schema
 
 ~~~json
 {
@@ -762,12 +1167,12 @@ The user schema is a valid [JSON Schema Draft 4](https://tools.ietf.org/html/dra
 | ------------- | ---------------------------------------- | ------------------------------------------------------ |--------- | ------ | -------- | --------- | --------- | ----------  |
 | id            | URI of user schema                       | String                                                 | FALSE    | TRUE   | TRUE     |           |           |             |
 | $schema       | JSON Schema version identifier           | String                                                 | FALSE    | FALSE  | TRUE     |           |           |             |
-| name          | name for the schema                      | `user`                                                 | FALSE    | TRUE   | TRUE     |           |           |             |
+| name          | name for the schema                      | String                                                 | FALSE    | TRUE   | TRUE     |           |           |             |
 | title         | user-defined display name for the schema | String                                                 | FALSE    | FALSE  | FALSE    |           |           |             |
 | created       | timestamp when schema was created        | [ISO 8601 String](https://tools.ietf.org/html/rfc3339) | FALSE    | FALSE  | TRUE     |           |           |             |
 | lastUpdated   | timestamp when schema was last updated   | [ISO 8601 String](https://tools.ietf.org/html/rfc3339) | FALSE    | FALSE  | TRUE     |           |           |             |
 | definitions   | user profile subschemas                  | [User Profile Subschemas](#user-profile-subschemas)    | FALSE    | FALSE  | FALSE    |           |           | JSON Schema |
-| type          | type of root schema                      | `object`                                               | FALSE    | FALSE  | TRUE     |           |           |             |
+| type          | type of [root schema](https://tools.ietf.org/html/draft-zyp-json-schema-04#section-3.4)| String   | FALSE    | FALSE  | TRUE     |           |           |             |
 | properties    | user model properties                    | [User Model](./users.html#user-model) property set     | FALSE    | FALSE  | TRUE     |           |           |             |
 |---------------+------------------------------------------+--------------------------------------------------------+-----------+-------+----------+-----------+-----------+-------------|
 
@@ -960,3 +1365,224 @@ A given schema property can be assigned a permission for a principal that restri
 | principal | security principal                                               | `SELF` (end-user)                                                  | FALSE    | TRUE   | FALSE    |           |           |             |
 | action    | determines whether the principal can view or modify the property | `HIDE`, `READ_ONLY`, `READ_WRITE`                                  | FALSE    | FALSE  | FALSE    |           |           |             |
 |-----------+------------------------------------------------------------------+--------------------------------------------------------------------+----------+--------+----------+-----------+-----------+-------------|
+
+
+## App User Schema Model
+
+The [App User Model](./apps.html#application-user-model) schema is defined using [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04).
+
+> The schema currently only defines the [profile object](./apps.html#application-user-profile-object).
+
+### Example App User Schema
+
+~~~json
+{
+  "id": "https://example.okta.com/meta/schemas/apps/0oa25gejWwdXNnFH90g4/default",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "name": "Example App",
+  "title": "Example App User",
+  "lastUpdated": "2017-07-18T22:37:55.000Z",
+  "created": "2017-07-18T22:35:30.000Z",
+  "definitions": {
+    "base": {
+      "id": "#base",
+      "type": "object",
+      "properties": {
+        "userName": {
+          "title": "Username",
+          "type": "string",
+          "required": true,
+          "scope": "NONE",
+          "maxLength": 100
+        }
+      },
+      "required": [
+        "userName"
+      ]
+    },
+    "custom": {
+      "id": "#custom",
+      "type": "object",
+      "properties": {
+        "twitterUserName": {
+          "title": "Twitter username",
+          "description": "User's username for twitter.com",
+          "type": "string",
+          "scope": "NONE",
+          "minLength": 1,
+          "maxLength": 20
+        }
+      },
+      "required": []
+    }
+  },
+  "type": "object",
+  "properties": {
+    "profile": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        },
+        {
+          "$ref": "#/definitions/custom"
+        }
+      ]
+    }
+  }
+}
+~~~
+
+### Schema Properties
+
+The app user schema is a valid [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04) document with the following properties :
+
+|---------------+------------------------------------------+--------------------------------------------------------+-----------+-------+----------+-----------+-----------+------------ |
+| Property      | Description                              | DataType                                               | Nullable | Unique | Readonly | MinLength | MaxLength | Validation  |
+| ------------- | ---------------------------------------- | ------------------------------------------------------ |--------- | ------ | -------- | --------- | --------- | ----------  |
+| id            | URI of app user schema                   | String                                                 | FALSE    | TRUE   | TRUE     |           |           |             |
+| $schema       | JSON Schema version identifier           | String                                                 | FALSE    | FALSE  | TRUE     |           |           |             |
+| name          | name for the schema                      | String                                                 | FALSE    | TRUE   | TRUE     |           |           |             |
+| title         | user-defined display name for the schema | String                                                 | FALSE    | FALSE  | FALSE    |           |           |             |
+| created       | timestamp when schema was created        | [ISO 8601 String](https://tools.ietf.org/html/rfc3339) | FALSE    | FALSE  | TRUE     |           |           |             |
+| lastUpdated   | timestamp when schema was last updated   | [ISO 8601 String](https://tools.ietf.org/html/rfc3339) | FALSE    | FALSE  | TRUE     |           |           |             |
+| definitions   | app user profile subschemas              | [App User Profile Subschemas](#app-user-profile-subschemas)| FALSE    | FALSE  | FALSE    |           |           | JSON Schema |
+| type          | type of [root schema](https://tools.ietf.org/html/draft-zyp-json-schema-04#section-3.4)| String   | FALSE    | FALSE  | TRUE     |           |           |             |
+| properties    | user model properties                    | [App User Model](./apps.html#application-user-model) property set| FALSE    | FALSE  | TRUE     |           |           |             |
+|---------------+------------------------------------------+--------------------------------------------------------+-----------+-------+----------+-----------+-----------+-------------|
+
+### App User Profile Subschemas
+
+The [profile object](./apps.html#application-user-profile-object) for a user is defined by a composite schema of base and custom properties using JSON Path to reference subschemas.  The `#base` properties are defined and versioned by Okta while `#custom` properties are extensible.
+
+- [App User Profile Base Subschema](#app-user-profile-base-subschema)
+- [App User Profile Custom Subschema](#app-user-profile-custom-subschema)
+
+Custom property names for the [profile object](./apps.html#application-user-profile-object) must be unique and cannot conflict with a property name defined in the `#base` subschema.
+
+~~~json
+{
+  "definitions": {
+    "base": {
+      "id": "#base",
+      "type": "object",
+      "properties": {},
+      "required": []
+    },
+    "custom": {
+      "id": "#custom",
+      "type": "object",
+      "properties": {},
+      "required": []
+    }
+  },
+  "type": "object",
+  "properties": {
+    "profile": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        },
+        {
+          "$ref": "#/definitions/custom"
+        }
+      ]
+    }
+  }
+}
+~~~
+
+#### App User Profile Base Subschema
+
+All Okta-defined profile properties are defined in a profile sub-schema with the resolution scope `#base`.  These properties cannot be removed or edited (except for permission).
+
+The base app user profile varies substantially depending on the application. The following properties are required for all app user profiles:
+
+|-------------------+------------------------------------------------------------------------------------------------------------------------------+----------+----------+--------+----------+-----------+-----------+-------------------------------------------------------------------------------------------------------------------|
+| Property          | Description                                                                                                                  | DataType | Nullable | Unique | Readonly | MinLength | MaxLength | Validation                                                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | ------ | -------- | --------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
+| userName          | unique identifier for the user                                                                                               | String   | FALSE    | TRUE   | FALSE    |           | 100       |                                                                                                                   |
+|-------------------+------------------------------------------------------------------------------------------------------------------------------+----------+----------+--------+----------+-----------+-----------+-------------------------------------------------------------------------------------------------------------------|
+
+#### App User Profile Custom Subschema
+
+All custom profile properties are defined in a profile sub-schema with the resolution scope `#custom`.
+
+~~~json
+{
+  "definitions": {
+    "custom": {
+        "id": "#custom",
+        "type": "object",
+        "properties": {
+            "customPropertyName": {
+                "title": "Title of custom property",
+                "description": "Description of custom property",
+                "type": "string"
+            }
+        },
+        "required": []
+    }
+  }
+}
+~~~
+
+#### App User Profile Schema Property Object
+
+User profile schema properties have the following standard [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04) keywords:
+
+|---------------+-------------------------------------------------+--------------------------------------------------------------------+-----------+-------+----------+-----------+-----------+------------ |
+| Property      | Description                                     | DataType                                                           | Nullable | Unique | Readonly | MinLength | MaxLength | Validation  |
+| ------------- | ----------------------------------------------- | ------------------------------------------------------------------ |--------- | ------ | -------- | --------- | --------- | ----------  |
+| title         | user-defined display name for the property      | String                                                             | FALSE    | FALSE  | FALSE    |           |           |             |
+| description   | description of the property                     | String                                                             | TRUE     | FALSE  | FALSE    |           |           |             |
+| type          | type of property                                | `string`, `boolean`, `number`, `integer`, `array`                  | FALSE    | FALSE  | FALSE    |           |           |             |
+|---------------+-------------------------------------------------+--------------------------------------------------------------------+-----------+-------+----------+-----------+-----------+-------------|
+
+Okta has also extended [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04) with the following keywords:
+
+|---------------+-------------------------------------------------+---------------------------------------------------------------------------+-----------+-------+----------+-----------+-----------+------------ |
+| Property      | Description                                     | DataType                                                                  | Nullable | Unique | Readonly | MinLength | MaxLength | Validation  |
+| ------------- | ----------------------------------------------- | ------------------------------------------------------------------------- |--------- | ------ | -------- | --------- | --------- | ----------  |
+| required      | determines whether the property is required     | Boolean                                                                   | FALSE    | FALSE  | FALSE    |           |           |             |
+| scope         | determines whether an appuser attribute can be set at the Individual or Group Level | `SELF`, `NONE`                        | FALSE    | FALSE  | TRUE     |           |           |             |
+|---------------+-------------------------------------------------+---------------------------------------------------------------------------+-----------+-------+----------+-----------+-----------+-----------
+
+> A read-only [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04) compliant `required` property is also available on the [App User Profile Subschemas](#app-user-profile-subschemas).
+
+~~~json
+{
+  "definitions": {
+    "custom": {
+      "id": "#custom",
+      "type": "object",
+      "properties": {
+        "twitterUserName": {
+          "title": "Twitter username",
+          "description": "User's username for twitter.com",
+          "type": "string",
+          "required": false,
+          "scope": "NONE",
+          "minLength": 1,
+          "maxLength": 20
+        }
+      },
+      "required": []
+    }
+  }
+}
+~~~
+
+##### App User Schema Property Types and Validation
+
+Specific property types support a **subset** of [JSON Schema validations](https://tools.ietf.org/html/draft-fge-json-schema-validation-00).
+
+|---------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------|
+| Property Type | Description                                                                                                                         | Validation Keywords         |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `string`      | [JSON String](https://tools.ietf.org/html/rfc7159#section-7)                                                                        | `minLength` and `maxLength` |
+| `boolean`     | `false`, `true`, or `null`                                                                                                          |                             |
+| `number`      | [JSON Number](https://tools.ietf.org/html/rfc7159#section-6) with double-precision 64-bit IEEE 754 floating point number constraint | `minimum` and `maximum`     |
+| `integer`     | [JSON Number](https://tools.ietf.org/html/rfc7159#section-6) with 32-bit signed two's complement integer constraint                 | `minimum` and `maximum`     |
+| `array`       | [JSON Array](https://tools.ietf.org/html/rfc7159#section-5)                                                                         |                             |
+|---------------+-------------------------------------------------------------------------------------------------------------------------------------+-----------------------------|
+


### PR DESCRIPTION
## Description:
- Add documentation for App User Schemas API to existing Schemas API page.
Add App User Schema Model documentation to go along with API documentation.

### Resolves:
* [OKTA-134020](https://oktainc.atlassian.net/browse/OKTA-134020)

### Requested Reviewers:
- @okta/ud-core 
- @mystiberry-okta 
- @richardmateosian-okta 
- @georgekwon-okta 