### PR TITLE
remove EA from SHA doc

### DIFF
--- a/_source/_docs/how-to/sharing-cert.md
+++ b/_source/_docs/how-to/sharing-cert.md
@@ -19,10 +19,6 @@ Sharing certificates is useful for Okta orgs that have apps with [sign-on modes]
 When configuring multiple apps, you might need them to accept the same identity provider (IdP).
 In that case, the assertions from the two apps must be signed by the same key.
 
-### Prerequisite
-
-The key rollover feature must be enabled. It's an Early Access feature; contact Support to enable it.
-
 ### How to Share the Certificate
 
 For this example, assume that you want to share a certificate between two instances of an app: `app1` is the source app, the app from

--- a/_source/_docs/how-to/updating_saml_cert.md
+++ b/_source/_docs/how-to/updating_saml_cert.md
@@ -26,7 +26,7 @@ To take advantage of the additional security features of SHA256 certificates.
 ### New SAML 2.0 App Integrations
 
 New SAML 2.0 app integrations automatically use SHA256 certificates.
-To upgrade a new SAML 2.0 app, upload the SHA256 certificate to the ISV as instructed.
+As instructed, upload the SHA256 certificate to the ISV.
 
 ### Existing SAML 2.0 App Integrations
 

--- a/_source/_docs/how-to/updating_saml_cert.md
+++ b/_source/_docs/how-to/updating_saml_cert.md
@@ -26,7 +26,7 @@ To take advantage of the additional security features of SHA256 certificates.
 ### New SAML 2.0 App Integrations
 
 New SAML 2.0 app integrations automatically use SHA256 certificates.
-To upgrade a new SAML 2.0 app, upload the SHA256 certificate to the ISV when instructed.
+To upgrade a new SAML 2.0 app, upload the SHA256 certificate to the ISV as instructed.
 
 ### Existing SAML 2.0 App Integrations
 

--- a/_source/_docs/how-to/updating_saml_cert.md
+++ b/_source/_docs/how-to/updating_saml_cert.md
@@ -25,8 +25,8 @@ To take advantage of the additional security features of SHA256 certificates.
 
 ### New SAML 2.0 App Integrations
 
-New SAML 2.0 app integrations automatically use SHA256 certificates when the key rollover feature is enabled.
-As instructed, upload the SHA256 certificate to the ISV.
+New SAML 2.0 app integrations automatically use SHA256 certificates.
+To upgrade a new SAML 2.0 app, upload the SHA256 certificate to the ISV when instructed.
 
 ### Existing SAML 2.0 App Integrations
 

--- a/_source/_docs/how-to/updating_saml_cert.md
+++ b/_source/_docs/how-to/updating_saml_cert.md
@@ -23,10 +23,6 @@ This How To contains six sections:
 
 To take advantage of the additional security features of SHA256 certificates.
 
-## Prerequisite
-
-SHA256 certificate creation and key rollover are **Early Access** (EA) features; contact Okta support to enable them.
-
 ### New SAML 2.0 App Integrations
 
 New SAML 2.0 app integrations automatically use SHA256 certificates when the key rollover feature is enabled.


### PR DESCRIPTION
## Description:
- Remove EA blurb from SHA how-to doc. Since key rollover is GA, and SHA is becoming GA in preview (prod delay marked in RN), no need for pre-req section at all.

### Resolves:

* [OKTA-135126](https://oktainc.atlassian.net/browse/OKTA-135126)

