### PR TITLE
Remove references to EA designation for key rollover (and OIDC)

### DIFF
--- a/_source/_docs/api/resources/apps.md
+++ b/_source/_docs/api/resources/apps.md
@@ -971,8 +971,6 @@ curl -v -X POST \
 
 Adds an OAuth 2.0 client application. This application is only available to the org that creates it.
 
-> You must enable the OpenID Connect feature to create an OAuth 2.0 client. OpenId Connect is an {% api_lifecycle ea %} feature.
-
 ##### Credentials
 {:.api .api-request .api-request-params}
 
@@ -1329,8 +1327,6 @@ Filter                 | Description
 `credentials.signing.kid eq ":kid"`   | Apps using a particular key such as `SIMcCQNY3uwXoW3y0vf6VxiBb5n9pf8L2fK8d-FIbm4`
 
 > Only a single expression is supported as this time. The only supported filter type is `eq`.
-
-> To use `credentials.signing.kid` as a filter, you must enable the key rollover feature. Key rollover is an Early Access feature; contact Customer Support to enable it.
 
 ###### Link Expansions
 
@@ -2586,8 +2582,6 @@ curl -v -X PUT \
 
 Update [application key credential](#application-key-credential-model) by `kid`
 
-> You must enable the key rollover feature to perform this operation. Key rollover is an Early Access feature; contact Customer Support to enable it.
-
 ##### Request Parameters
 {:.api .api-request .api-request-params}
 
@@ -3633,8 +3627,6 @@ curl -v -X DELETE \
 ~~~
 
 ## Application Key Store Operations
-
-> You must enable the key rollover feature to perform the following operations. Key rollover is an Early Access feature; contact Customer Support to enable it.
 
 ### Generate New Application Key Credential
 {:.api .api-operation}
@@ -4738,8 +4730,6 @@ Determines the [key](#application-key-credential-model) used for signing asserti
 | ---------- | ------------------------------------------------------------------------------------------- | -------- |
 | kid        | Reference for [key credential for the app](#application-key-store-operations)    | String   | FALSE    |
 |------------+----------------------------------------------------------------------------------+----------+----------|
-
-> You must enable the key rollover feature to view `kid`. Key rollover is an {% api_lifecycle ea %} feature.
 
 > Only apps with `SAML_2_0`, `SAML_1_1`, `WS_FEDERATION` or `OPENID_CONNECT` `signOnMode` support the key rollover feature.
 

--- a/_source/_docs/api/resources/idps.md
+++ b/_source/_docs/api/resources/idps.md
@@ -2876,8 +2876,6 @@ HTTP/1.1 204 No Content
 
 ## Identity Provider Signing Key Store Operations
 
-> You must enable the key rollover feature to perform the following operations. Key rollover is an {% api_lifecycle ea %} feature; contact Customer Support to enable it.
-
 > EA feature constraint: Okta currently uses the same key for both request signing and decrypting SAML Assertions that have been encrypted by the IdP. Changing your signing key also changes your decryption key.
 
 ### Generate New IdP Signing Key Credential
@@ -4294,8 +4292,6 @@ Federation trust credentials for verifying assertions from the IdP:
 ###### SAML 2.0 Signing Credentials Object
 
 Determines the [IdP Key Credential](#identity-provider-key-credential-model) used to sign requests sent to the IdP.
-
-> You must enable the key rollover feature to perform [Signing Key Operations](#identity-provider-signing-key-store-operations). Key rollover is an {% api_lifecycle ea %} feature; contact Customer Support to enable it.
 
 |---------+----------------------------------------------------------------------------------------------------------------+----------+----------+----------+-----------+-----------+--------------------------------------------|
 | Property | Description                                                                                                   | DataType | Nullable | Readonly | MinLength | MaxLength | Validation                                 |

--- a/_source/_docs/how-to/byo_saml.md
+++ b/_source/_docs/how-to/byo_saml.md
@@ -13,9 +13,7 @@ Okta Admins can upload their own SAML certificates to sign the assertion for Out
 
 ## Prerequisite
 
-{% api_lifecycle ea %}
-
-To use your own SAML certificate, update the key credential for the affected apps or IdPs. Key rollover is an **Early Access** (EA) feature; contact Okta support to enable it.
+To use your own SAML certificate, update the key credential for the affected apps or IdPs.
 
 ### Outbound and Inbound SAML Applications
 

--- a/_source/_docs/how-to/set-up-auth-server.md
+++ b/_source/_docs/how-to/set-up-auth-server.md
@@ -8,7 +8,7 @@ excerpt: Set Up an Authorization Service
 
 {% api_lifecycle ea %}
 
-API Access Management is an **Early Access** (EA) feature; contact Okta support to enable it.
+API Access Management is an Early Access (EA) feature; contact Okta support to enable it.
 
 API Access Management allows you to build custom authorization servers in Okta which can be used to protect your own API endpoints.
 An authorization server defines your security boundary, for example "staging" or "production."

--- a/_source/_docs/how-to/sharing-cert.md
+++ b/_source/_docs/how-to/sharing-cert.md
@@ -19,10 +19,6 @@ Sharing certificates is useful for Okta orgs that have apps with [sign-on modes]
 When configuring multiple apps, you might need them to accept the same identity provider (IdP).
 In that case, the assertions from the two apps must be signed by the same key.
 
-### Prerequisite
-
-The key rollover feature must be enabled. It's an Early Access feature; contact Support to enable it.
-
 ### How to Share the Certificate
 
 For this example, assume that you want to share a certificate between two instances of an app: `app1` is the source app, the app from

--- a/_source/_docs/how-to/updating_saml_cert.md
+++ b/_source/_docs/how-to/updating_saml_cert.md
@@ -25,12 +25,13 @@ To take advantage of the additional security features of SHA256 certificates.
 
 ## Prerequisite
 
-SHA256 certificate creation and key rollover are **Early Access** (EA) features; contact Okta support to enable them.
+{% api_lifecycle ea %}
+
+SHA256 certificate creation is an Early Access (EA) feature; contact Okta support to enable it.
 
 ### New SAML 2.0 App Integrations
 
-New SAML 2.0 app integrations automatically use SHA256 certificates when the key rollover feature is enabled.
-As instructed, upload the SHA256 certificate to the ISV.
+New SAML 2.0 app integrations automatically use SHA256 certificates. As instructed, upload the SHA256 certificate to the ISV.
 
 ### Existing SAML 2.0 App Integrations
 


### PR DESCRIPTION
## Description:
Remove references to EA designation for key rollover (and OIDC)

### Resolves:
https://oktainc.atlassian.net/browse/OKTA-135065
