### PR TITLE
Updated feed to include description, instead of the entire post.

### DIFF
--- a/_source/feed.xml
+++ b/_source/feed.xml
@@ -11,7 +11,7 @@ layout: null
     {% for post in site.posts %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
+        <description>{{ post.description | xml_escape }}</description>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
         <link>{{ site.url }}{{ post.url }}</link>
         <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>


### PR DESCRIPTION
## Description:
- fixes feed.xml to be of a normal size so that it can be used on feedburner and properly represents a post's description.

### Resolves:
* [1110](https://github.com/okta/okta.github.io/issues/1110)

