### PR TITLE
Update policy api doc with new features

### DIFF
--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -1098,7 +1098,27 @@ minLowerCase | Indicates if a password must contain at least one lower case lett
 minUpperCase | Indicates if a password must contain at least one upper case letter: 0 indicates no, 1 indicates yes | integer | No | 1
 minNumber | Indicates if a password must contain at least one number: 0 indicates no, 1 indicates yes | integer | No | 1
 minSymbol | Indicates if a password must contain at least one symbol (e.g., !@#$%^&*): 0 indicates no, 1 indicates yes | integer | No | 1
-excludeUserName | Indicates if the user name must be excluded from the password | boolean | no | true
+excludeUserName | Indicates if the user name must be excluded from the password | boolean | No | true
+dictionary {%api_lifecycle beta %} | Weak password dictionary lookup settings | <a href="#WeakPasswordDictionaryObject">Weak Password Dictionary Object</a> | No | N/A
+
+###### Weak Password Dictionary Object
+{: #WeakPasswordDictionaryObject }
+
+> Weak password dictionary lookup is an {% api_lifecycle beta %} feature. Contact Support to enable it.
+
+Specifies settings for dictionaries of weak passwords against which lookups of users' passwords may be done, in order to help verify password strength. Designed to be extensible with multiple possible dictionary types against which to do lookups.
+
+Property | Description | Data Type | Required
+| --- | --- | --- | ---
+common | Lookup settings for commonly used passwords  | <a href="#CommonPasswordLookupObject">Common Password Lookup Object</a> | No
+
+Common Password Lookup Object
+
+{: #CommonPasswordLookupObject }
+
+Property | Description | Data Type | Required | Default
+| --- | --- | ---| --- | ---
+exclude | Indicates whether to check passwords against common password dictionary | Boolean | No | false
 
 ##### Age Object
 {: #PasswordAgeObject }
@@ -1140,7 +1160,7 @@ okta_sms | Settings for SMS factor | <a href="#SMSFactorObject">SMS Factor Objec
 
 Property | Description | Data Type | Required |
 | --- | --- | --- | ---
-status | Indicates if the factor is enabled.  This property is read-only | `ACTIVE` | Yes |
+status | Indicates if the factor is enabled. | `ACTIVE`, `INACTIVE` (EA) | Yes |
 properties | Configuration settings for security question factor | <a href="#RecoveryQuestionFactorPropertiesObject">Recovery Question Factor Properties Object</a> | No
 
 ###### Recovery Question Factor Properties Object

--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -1098,15 +1098,15 @@ minLowerCase | Indicates if a password must contain at least one lower case lett
 minUpperCase | Indicates if a password must contain at least one upper case letter: 0 indicates no, 1 indicates yes | integer | No | 1
 minNumber | Indicates if a password must contain at least one number: 0 indicates no, 1 indicates yes | integer | No | 1
 minSymbol | Indicates if a password must contain at least one symbol (e.g., !@#$%^&*): 0 indicates no, 1 indicates yes | integer | No | 1
-excludeUserName | Indicates if the user name must be excluded from the password | boolean | No | true
+excludeUsername | Indicates if the user name must be excluded from the password | boolean | No | true
 dictionary {%api_lifecycle beta %} | Weak password dictionary lookup settings | <a href="#WeakPasswordDictionaryObject">Weak Password Dictionary Object</a> | No | N/A
 
 ###### Weak Password Dictionary Object
 {: #WeakPasswordDictionaryObject }
 
-> Weak password dictionary lookup is an {% api_lifecycle beta %} feature. Contact Support to enable it.
+> Weak password lookup is a {% api_lifecycle beta %} feature.
 
-Specifies settings for dictionaries of weak passwords against which lookups of users' passwords may be done, in order to help verify password strength. Designed to be extensible with multiple possible dictionary types against which to do lookups.
+Specifies how lookups for weak passwords are done. Designed to be extensible with multiple possible dictionary types against which to do lookups.
 
 Property | Description | Data Type | Required
 | --- | --- | --- | ---


### PR DESCRIPTION
## Description:
- Update Policy API with weak password dictionary and optional recovery question changes

### Resolves:
<!-- Required for Okta-generated PRs -->
* [OKTA-135946](https://oktainc.atlassian.net/browse/OKTA-135946)

## Screenshots
### Password Complexity (Weak Password Dictionary added)
![image](https://user-images.githubusercontent.com/28875915/28803013-785e3bb2-760e-11e7-8648-ed64e355ce2e.png)

![image](https://user-images.githubusercontent.com/28875915/28803024-826b578e-760e-11e7-9abb-53a20f2464e1.png)

### Question Recovery Factor (Optional Status)
 ![image](https://user-images.githubusercontent.com/28875915/28803145-3de30e94-760f-11e7-959c-b18a94b4d267.png)

I ran out of possible subhheadings, so there's insufficient nesting available. (maximum 6 hashes) For that reason, Weak Password Dictionary Object is in the document structure, but Common Password Lookup Object isn't, like so:
![image](https://user-images.githubusercontent.com/28875915/28803182-8e65742e-760f-11e7-8b5f-6c461cdffc36.png)

Let me know if you have any suggestions for the naming/phrasing/structure of this doc.