### PR TITLE
Add Quickstarts app and default content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -71,6 +71,8 @@ collections:
   docs:
     output: true
     permalink: /:collection/:path:output_ext
+  quickstarts:
+    output: true
 
 paginate: 10
 paginate_path: "/blog/page/:num"

--- a/_source/_assets/css/okta.scss
+++ b/_source/_assets/css/okta.scss
@@ -34,6 +34,7 @@
 	'okta/global/fontello',
 
 	'okta/pages/product',
+	'okta/pages/quickstarts',
 	'okta/pages/stormpath'
 
 

--- a/_source/_assets/css/okta/pages/_quickstarts.scss
+++ b/_source/_assets/css/okta/pages/_quickstarts.scss
@@ -1,0 +1,46 @@
+.code-selector {
+  background-color: rgb(32, 49, 59);
+  border-radius: 5px;
+  padding: 20px;
+  h3 {
+    color: #fff;
+    font-size: 18px;
+    font-weight: lighter;
+  }
+  a {
+    display: inline-block;
+    color: #fff;
+    padding: 0 10px;
+    &:hover{
+      cursor: pointer;
+      text-decoration: none;
+    }
+    &.active,
+    &:hover {
+      border-bottom: 1px solid #fff;
+    }
+  }
+  margin-bottom: 10px;
+}
+
+.example-content-well {
+  padding: 30px 0;
+}
+
+.quickstart-page {
+  padding-right: 300px;
+  h2 {
+    border-bottom: none;
+    font-size: 23px;
+    font-weight: lighter;
+  }
+  .TableOfContents-item{
+    &.active {
+      border-left-color: rgb(0, 125, 193);
+    }
+  }
+}
+
+#server-framework-selector {
+  background-color: rgb(54, 69, 78);
+}

--- a/_source/_assets/js/quickstart.js
+++ b/_source/_assets/js/quickstart.js
@@ -1,0 +1,275 @@
+(function($) {
+  /**
+   * linkState
+   *
+   * This object defines the links that will appear, and serves as a state object once
+   * the app begins.  If you need to add new libraries, add them to this object.  If
+   * you need to change the default active libraries, change the active states in this
+   * object.
+   *
+   * `active` links will be selected by default. As the user navigates, the active
+   * properties will be modified accordingly.
+   */
+  var linkState = {
+    clients: [
+      {
+        name: 'angular',
+        label: 'Angular',
+        serverExampleType: 'implicit'
+      },
+      {
+        name: 'ios',
+        label: 'iOS',
+        serverExampleType: 'implicit'
+      },
+      {
+        name: 'widget',
+        label: 'Sign-In Widget',
+        serverExampleType: 'auth-code',
+        active: true
+      }
+    ],
+    servers: [
+      {
+        active: true,
+        name: 'nodejs',
+        label: 'Node JS',
+        frameworks: [
+          {
+            active: true,
+            name: 'generic',
+            label: 'Generic Node'
+          },
+          {
+            name: 'express',
+            label: 'Express.js'
+          }
+        ]
+      },
+      {
+        name: 'java',
+        label: 'Java',
+        frameworks: [
+          {
+            name: 'generic',
+            label: 'Generic Java',
+            active: true
+          },
+          {
+            name: 'spring',
+            label: 'Spring'
+          }
+        ]
+      },
+      {
+        name: 'php',
+        label: 'PHP',
+        frameworks: [
+          {
+            name: 'generic',
+            label: 'Generic PHP',
+            active: true
+          }
+        ]
+      }
+    ]
+  }
+
+  /**
+   * Matches /client/server/framework
+   */
+  var urlExpression = '/([^\/]*)?\/?([^\/]*)?\/?([^\/]*)';
+
+  /**
+   * Iterate through the link state, render buttons and setup click handlers
+   */
+  function renderLinks() {
+    linkState.clients.forEach(function (client) {
+      var link = $('<a>', {
+        text: client.label,
+        class: client.active ? 'active' : '',
+        click: function () {
+          linkState.clients.forEach(function (client) {
+            client.link.removeClass('active');
+            client.active = false;
+          });
+          $(this).addClass('active');
+          client.active = true;
+          applySelectionTuple(getSelectionTupleFromLinkSate());
+        }
+      });
+      client.link = link;
+      $('#client-selector').append(link);
+    });
+
+    linkState.servers.forEach(function (server) {
+      var link = $('<a>', {
+        text: server.label,
+        class: server.active ? 'active' : '',
+        click: function () {
+          linkState.servers.forEach(function (server) {
+            server.link.removeClass('active');
+              server.active = false;
+          });
+          renderFrameworkLinks(server);
+          $(this).addClass('active');
+          server.active = true;
+          applySelectionTuple(getSelectionTupleFromLinkSate());
+        }
+      });
+      server.link = link;
+      $('#server-selector').append(link);
+      if (server.active) {
+        renderFrameworkLinks(server);
+      }
+    });
+
+    function renderFrameworkLinks(server) {
+      $('#framework-selector a').each(function (i, element) {
+        $(element).remove();
+      });
+
+      server.frameworks.forEach(function (framework) {
+        var link = $('<a>', {
+          text: framework.label,
+          class: framework.active ? 'active' : '',
+          click: function () {
+            server.frameworks.forEach(function (framework) {
+              framework.link.removeClass('active');
+              framework.active = false;
+            });
+            $(this).addClass('active');
+            framework.active = true;
+            applySelectionTuple(getSelectionTupleFromLinkSate());
+          }
+        });
+        framework.link = link;
+        $('#framework-selector').append(link);
+      });
+    }
+  }
+
+  /**
+   * Fetches the content for a given selection tuple
+   */
+  function loadContent(clientName, server, framework) {
+    var client = linkState.clients.filter(function(client) {
+      return client.name === clientName;
+    })[0];
+    var clientContentUrl = clientName + '/default-example.html';
+    var serverContentUrl = server + '/' + framework + '-' + client.serverExampleType + '.html';
+
+    $.ajax({
+      url: clientContentUrl
+    }).done(function( html ) {
+      $( "#client_content" ).html( html );
+    });
+    $.ajax({
+      url: serverContentUrl
+    }).done(function( html ) {
+      $( "#server_content" ).html( html );
+    });
+  };
+
+  /**
+   * Get the active selections from the window hash
+   *
+   * @returns [clientName, serverName, frameworkName]
+   */
+  function getSelectionTupleFromHash() {
+    var matches = window.location.hash.match(urlExpression);
+    var clientName = matches && matches[1];
+    var serverName = matches && matches[2];
+    var frameworkName = matches && matches[3];
+    return [clientName, serverName, frameworkName];
+  }
+
+  /**
+   * Get the active selections from the link sate
+   *
+   * @returns [clientName, serverName, frameworkName]
+   */
+  function getSelectionTupleFromLinkSate() {
+    var tuple = [];
+    linkState.clients.forEach(function (client) {
+      if (client.active) {
+        tuple.push(client.name);
+      }
+    });
+    linkState.servers.forEach(function (server) {
+      if (server.active) {
+        tuple.push(server.name)
+        server.frameworks.forEach(function (framework) {
+          if (framework.active) {
+            tuple.push(framework.name)
+          }
+        });
+      }
+    });
+    return tuple;
+  }
+
+  /**
+   * Apply a selection tuple to the application state (set new window hash and load content)
+   */
+  function applySelectionTuple(selectionTuple) {
+    window.location.replace('#/' + selectionTuple.join('/'));
+    loadContent.apply(null, selectionTuple);
+  }
+
+  /**
+   * Apply a selection tuple to the link state (will modify `active` properties)
+   */
+  function applySelectionTupleToLinkSate(selectionTuple) {
+    var activeClient = selectionTuple[0];
+    var activeServer = selectionTuple[1];
+    var activeFramework = selectionTuple[2];
+
+    linkState.clients.forEach(function (client) {
+      client.active = client.name === activeClient;
+    });
+    linkState.servers.forEach(function (server) {
+      server.active = server.name === activeServer;
+      server.frameworks.forEach(function (framework) {
+        framework.active = framework.name === activeFramework;
+      });
+    });
+  }
+
+
+  /**
+   * Begin application.  Fetch default selections from link state, and current
+   * selections from window hash.  Window hash overrides default link state.
+   */
+  function main() {
+    var hashTuple = getSelectionTupleFromHash();
+    var stateTuple = getSelectionTupleFromLinkSate();
+    var initialTuple = [
+      hashTuple[0] || stateTuple[0],
+      hashTuple[1] || stateTuple[1],
+      hashTuple[2] || stateTuple[2]
+    ];
+
+    applySelectionTupleToLinkSate(initialTuple);
+    renderLinks();
+    applySelectionTuple(initialTuple);
+    $('#client_setup_link').addClass('active');
+  }
+
+  // Used to scroll to the right place without anchors, 150 is to account for our header space
+  window.scrollToServer = function () {
+    $('body').animate({scrollTop: $('#server_setup').offset().top - 150});
+    $('#server_setup_link').addClass('active');
+    $('#client_setup_link').removeClass('active');
+  };
+  window.scrollToClient = function () {
+    $('body').animate({scrollTop: $('#client_setup').offset().top - 150});
+    $('#client_setup_link').addClass('active');
+    $('#server_setup_link').removeClass('active');
+  };
+
+  if (window.location.pathname.match('^/quickstarts')) {
+    main();
+  }
+
+})(jQuery);

--- a/_source/_includes/footer.html
+++ b/_source/_includes/footer.html
@@ -40,6 +40,7 @@
       </div>
     </footer>
     {% js master %}
+    {% js quickstart %}
     {% for script in page.scripts %}
       <script src="{{ script }}"></script>
     {% endfor %}

--- a/_source/_includes/quickstart-coming-soon.html
+++ b/_source/_includes/quickstart-coming-soon.html
@@ -1,0 +1,4 @@
+<p>
+  We're hard at work on this {{page.exampleDescription}} quickstart, please check back soon!
+  <i class="fa fa-coffee" aria-hidden="true"></i>
+</p>

--- a/_source/_layouts/quickstart.html
+++ b/_source/_layouts/quickstart.html
@@ -1,0 +1,14 @@
+---
+layout: base
+---
+<section class="PageContent quickstart-page">
+  <!-- START Page Content -->
+  <div class="PageContent-main" id="docs-body">
+    <a id="edit-link" href="{{ site.github_edit_url }}{{ page.relative_path }}">Edit Page</a>
+  {{ content }}
+  </div>
+  <div class="TableOfContents TableOfContentsPreload">
+    <a class="TableOfContents-item is-level2" style="display: block;" onclick="scrollToClient()" id="client_setup_link">Client Setup</a>
+    <a class="TableOfContents-item is-level2" style="display: block;" onclick="scrollToServer()" id="server_setup_link">Server Setup</a>
+  </div><!-- END Page Content -->
+</section><!-- END Page Center w/Sub Nav & Content -->

--- a/_source/_layouts/quickstart_partial.html
+++ b/_source/_layouts/quickstart_partial.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en" dir="ltr">
+<body>
+    {{ content }}
+</body>
+</html>

--- a/_source/quickstarts/android/default-example.md
+++ b/_source/quickstarts/android/default-example.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+libraryName: Native Android
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/angular/default-example.md
+++ b/_source/quickstarts/angular/default-example.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: Angular Implicit
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/dotnet/generic-auth-code.md
+++ b/_source/quickstarts/dotnet/generic-auth-code.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: .NET Auth Code Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/dotnet/generic-implicit.md
+++ b/_source/quickstarts/dotnet/generic-implicit.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: .NET Implicit Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/index.md
+++ b/_source/quickstarts/index.md
@@ -1,0 +1,27 @@
+---
+layout: quickstart
+weight: 4
+title: Authentication Quickstart Guide
+---
+
+<h1>{{ page.title }}</h1>
+
+<h2 id="client_setup">Client Setup</h2>
+
+<div class="code-selector" id="client-selector">
+  <h3>Client</h3>
+</div>
+
+<div id="client_content" class="example-content-well"></div>
+
+<h2 id="server_setup">Server Setup</h2>
+
+<div class="code-selector" id="server-selector">
+  <h3>Server</h3>
+</div>
+
+<div class="code-selector" id="framework-selector">
+  <h3>Framework</h3>
+</div>
+
+<div id="server_content" class="example-content-well"></div>

--- a/_source/quickstarts/ios/default-example.md
+++ b/_source/quickstarts/ios/default-example.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+libraryName: Native iOS
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/java/generic-auth-code.md
+++ b/_source/quickstarts/java/generic-auth-code.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: Java Auth Code Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/java/generic-implicit.md
+++ b/_source/quickstarts/java/generic-implicit.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: Java Implicit Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/java/spring-auth-code.md
+++ b/_source/quickstarts/java/spring-auth-code.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: Spring Auth Code Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/java/spring-implicit.md
+++ b/_source/quickstarts/java/spring-implicit.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: Spring Implicit Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/nodejs/express-auth-code.md
+++ b/_source/quickstarts/nodejs/express-auth-code.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: Express.js Auth Code Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/nodejs/express-implicit.md
+++ b/_source/quickstarts/nodejs/express-implicit.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: Express.js Implicit Flow Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/nodejs/generic-auth-code.md
+++ b/_source/quickstarts/nodejs/generic-auth-code.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: NodeJS Auth Code Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/nodejs/generic-implicit.md
+++ b/_source/quickstarts/nodejs/generic-implicit.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: NodeJS Implicit Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/php/generic-auth-code.md
+++ b/_source/quickstarts/php/generic-auth-code.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: PHP Auth Code Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/php/generic-implicit.md
+++ b/_source/quickstarts/php/generic-implicit.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+exampleDescription: PHP Implicit Example
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/react/default-example.md
+++ b/_source/quickstarts/react/default-example.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+libraryName: React
+---
+
+{% include quickstart-coming-soon.html %}

--- a/_source/quickstarts/widget/default-example.md
+++ b/_source/quickstarts/widget/default-example.md
@@ -1,0 +1,6 @@
+---
+layout: quickstart_partial
+libraryName: Sign-in Widget
+---
+
+{% include quickstart-coming-soon.html %}


### PR DESCRIPTION
## Description:

Added a simple JS app for the quickstarts page, including default markdown content where code examples will go.  View by visiting http://localhost:4000/quickstarts/.  Final styling (including icons) will be added after pending style PR.

### Resolves:
<!-- Required for Okta-generated PRs -->
* [OKTA-135962](https://oktainc.atlassian.net/browse/OKTA-135962)

