### PR TITLE
:bug: Fixes incorrect link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ assets/.sprockets-manifest-*.json
 # Ignore node packages added for tests added via npm
 node_modules/*
 npm-debug.log*
+
+Gemfile.lock

--- a/3rd_party_notices/Android_Mobile.html
+++ b/3rd_party_notices/Android_Mobile.html
@@ -733,7 +733,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Android_Verify.html
+++ b/3rd_party_notices/Android_Verify.html
@@ -722,7 +722,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Connector_Agent_Tool.html
+++ b/3rd_party_notices/Connector_Agent_Tool.html
@@ -1050,7 +1050,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Framework_Tool.html
+++ b/3rd_party_notices/Framework_Tool.html
@@ -786,7 +786,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Office365.html
+++ b/3rd_party_notices/Office365.html
@@ -538,7 +538,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_AD_Agent_Setup.html
+++ b/3rd_party_notices/Okta_AD_Agent_Setup.html
@@ -991,7 +991,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_Auth_SDK.html
+++ b/3rd_party_notices/Okta_Auth_SDK.html
@@ -616,7 +616,7 @@ product. Alternatively, the open source may accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool.html
+++ b/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool.html
@@ -1303,7 +1303,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_Confluence.html
+++ b/3rd_party_notices/Okta_Confluence.html
@@ -1088,7 +1088,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_Jira.html
+++ b/3rd_party_notices/Okta_Jira.html
@@ -1088,7 +1088,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_LDAP_Agent.html
+++ b/3rd_party_notices/Okta_LDAP_Agent.html
@@ -1338,7 +1338,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_LDAP_Agent_Setup.html
+++ b/3rd_party_notices/Okta_LDAP_Agent_Setup.html
@@ -991,7 +991,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_Password_Sync_Setup.html
+++ b/3rd_party_notices/Okta_Password_Sync_Setup.html
@@ -1182,7 +1182,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_Radius_Agent_Setup.html
+++ b/3rd_party_notices/Okta_Radius_Agent_Setup.html
@@ -1064,7 +1064,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_Rsa_SecurID_Setup.html
+++ b/3rd_party_notices/Okta_Rsa_SecurID_Setup.html
@@ -1064,7 +1064,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_SAML_Toolkit.html
+++ b/3rd_party_notices/Okta_SAML_Toolkit.html
@@ -1088,7 +1088,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_SSO_IWA.html
+++ b/3rd_party_notices/Okta_SSO_IWA.html
@@ -809,7 +809,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_SWA_Chrome.html
+++ b/3rd_party_notices/Okta_SWA_Chrome.html
@@ -1334,7 +1334,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_SWA_Firefox.html
+++ b/3rd_party_notices/Okta_SWA_Firefox.html
@@ -1768,7 +1768,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_SWA_IE.html
+++ b/3rd_party_notices/Okta_SWA_IE.html
@@ -1334,7 +1334,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_SWA_Safari.html
+++ b/3rd_party_notices/Okta_SWA_Safari.html
@@ -1334,7 +1334,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Okta_Sign-In_Widget.html
+++ b/3rd_party_notices/Okta_Sign-In_Widget.html
@@ -1247,7 +1247,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/OpenID_Connect_Emulator.html
+++ b/3rd_party_notices/OpenID_Connect_Emulator.html
@@ -993,7 +993,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/SDK_Packaging.html
+++ b/3rd_party_notices/SDK_Packaging.html
@@ -774,7 +774,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Web_App_Client_JS.html
+++ b/3rd_party_notices/Web_App_Client_JS.html
@@ -1898,7 +1898,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Windows_Shared.html
+++ b/3rd_party_notices/Windows_Shared.html
@@ -613,7 +613,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/Windows_Verify.html
+++ b/3rd_party_notices/Windows_Verify.html
@@ -560,7 +560,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/iOS_Mobile.html
+++ b/3rd_party_notices/iOS_Mobile.html
@@ -978,7 +978,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/iOS_Verify.html
+++ b/3rd_party_notices/iOS_Verify.html
@@ -787,7 +787,7 @@ accompany the Okta product.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/3rd_party_notices/index.html
+++ b/3rd_party_notices/index.html
@@ -250,7 +250,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/404.html
+++ b/404.html
@@ -180,7 +180,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/_source/_includes/footer.html
+++ b/_source/_includes/footer.html
@@ -26,7 +26,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="{{ site.external_domain }}/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/04/07/android-unit-testing-part-2.html
+++ b/blog/2015/04/07/android-unit-testing-part-2.html
@@ -390,7 +390,7 @@ check out the full code at <a href="https://github.com/vronin-okta/okta_blog_sam
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/04/14/android-unit-testing-part-3.html
+++ b/blog/2015/04/14/android-unit-testing-part-3.html
@@ -355,7 +355,7 @@ how to make tests isolated. You can also check out the full code at
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/04/23/android-unit-testing-part-4.html
+++ b/blog/2015/04/23/android-unit-testing-part-4.html
@@ -358,7 +358,7 @@ steps in writing on our wiki. Thanks guys!</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/05/08/productionalizing-active-mq.html
+++ b/blog/2015/05/08/productionalizing-active-mq.html
@@ -298,7 +298,7 @@ he does, he patches the JVM.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/05/08/software-engineering-design-principles.html
+++ b/blog/2015/05/08/software-engineering-design-principles.html
@@ -417,7 +417,7 @@ enforce limits and design for infinity.</li>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/05/22/tcmalloc.html
+++ b/blog/2015/05/22/tcmalloc.html
@@ -278,7 +278,7 @@ compared to the amount of available RAM, which meant that we were sacrificing bo
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/06/11/trustpage.html
+++ b/blog/2015/06/11/trustpage.html
@@ -259,7 +259,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/12/02/tls-client-authentication-for-services.html
+++ b/blog/2015/12/02/tls-client-authentication-for-services.html
@@ -615,7 +615,7 @@ you implement these authentication concepts in your applications.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2015/12/07/oauth.html
+++ b/blog/2015/12/07/oauth.html
@@ -213,7 +213,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2016/01/05/rest-service-auth-jwt.html
+++ b/blog/2016/01/05/rest-service-auth-jwt.html
@@ -220,7 +220,7 @@ services within an application.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2016/03/22/use-kentor-authservices-with-okta.html
+++ b/blog/2016/03/22/use-kentor-authservices-with-okta.html
@@ -271,7 +271,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/03/16/spring-boot-saml.html
+++ b/blog/2017/03/16/spring-boot-saml.html
@@ -444,7 +444,7 @@ Hello SAML!
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/03/21/spring-boot-oauth.html
+++ b/blog/2017/03/21/spring-boot-oauth.html
@@ -407,7 +407,7 @@ brew install springboot
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/03/27/angular-okta-sign-in-widget.html
+++ b/blog/2017/03/27/angular-okta-sign-in-widget.html
@@ -509,7 +509,7 @@ Chrome 56.0.2924 <span class="o">(</span>Mac OS X 10.11.6<span class="o">)</span
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/03/30/react-okta-sign-in-widget.html
+++ b/blog/2017/03/30/react-okta-sign-in-widget.html
@@ -465,7 +465,7 @@ npm start
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/04/17/angular-authentication-with-oidc.html
+++ b/blog/2017/04/17/angular-authentication-with-oidc.html
@@ -1195,7 +1195,7 @@ Example 2: &lt;input [(ngModel)]="person.firstName" [ngModelOptions]="{standalon
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html
+++ b/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html
@@ -653,7 +653,7 @@ is present on the requested resource. Origin 'http://localhost:4200' is therefor
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/05/03/seven-new-vs-features.html
+++ b/blog/2017/05/03/seven-new-vs-features.html
@@ -245,7 +245,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html
+++ b/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html
@@ -709,7 +709,7 @@ cf push -p target/<span class="k">*</span>jar pwa-server
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/05/10/developers-guide-to-docker-part-1.html
+++ b/blog/2017/05/10/developers-guide-to-docker-part-1.html
@@ -303,7 +303,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html
+++ b/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html
@@ -1015,7 +1015,7 @@ For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/06/13/add-authentication-angular-pwa.html
+++ b/blog/2017/06/13/add-authentication-angular-pwa.html
@@ -1033,7 +1033,7 @@ No 'Access-Control-Allow-Origin' header is present on the requested resource. Or
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/06/15/build-microservices-architecture-spring-boot.html
+++ b/blog/2017/06/15/build-microservices-architecture-spring-boot.html
@@ -818,7 +818,7 @@ or <a href="https://github.com/oktadeveloper/spring-boot-microservices-example/i
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/06/20/develop-microservices-with-jhipster.html
+++ b/blog/2017/06/20/develop-microservices-with-jhipster.html
@@ -1203,7 +1203,7 @@ Stack Overflow with the <a href="http://stackoverflow.com/questions/tagged/jhips
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/06/21/what-the-heck-is-oauth.html
+++ b/blog/2017/06/21/what-the-heck-is-oauth.html
@@ -605,7 +605,7 @@ code=MsCeLvIaQm6bTrgtp7&amp;client_id=812741506391&amp;
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/06/27/seven-tools-net-developers.html
+++ b/blog/2017/06/27/seven-tools-net-developers.html
@@ -241,7 +241,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/06/29/oidc-user-auth-aspnet-core.html
+++ b/blog/2017/06/29/oidc-user-auth-aspnet-core.html
@@ -366,7 +366,7 @@ If you do, congratulations! You just set up OpenID Connect for authenticating in
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/07/13/apache-shiro-spring-boot.html
+++ b/blog/2017/07/13/apache-shiro-spring-boot.html
@@ -512,7 +512,7 @@ Transfer-Encoding: chunked
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html
+++ b/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html
@@ -439,7 +439,7 @@ vue init pwa my-pwa-project
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/07/25/oidc-primer-part-1.html
+++ b/blog/2017/07/25/oidc-primer-part-1.html
@@ -436,7 +436,7 @@ HTTP/1.1 200 OK
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/07/25/oidc-primer-part-2.html
+++ b/blog/2017/07/25/oidc-primer-part-2.html
@@ -375,7 +375,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/08/01/oidc-primer-part-3.html
+++ b/blog/2017/08/01/oidc-primer-part-3.html
@@ -671,7 +671,7 @@ Verified Access Token
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/08/08/secure-spring-microservices.html
+++ b/blog/2017/08/08/secure-spring-microservices.html
@@ -865,7 +865,7 @@ git checkout okta
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/2017/08/09/jax-rs-vs-spring-rest-endpoints.html
+++ b/blog/2017/08/09/jax-rs-vs-spring-rest-endpoints.html
@@ -698,7 +698,7 @@ Server: Jetty<span class="o">(</span>9.3.12.v20160915<span class="o">)</span>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/index.html
+++ b/blog/index.html
@@ -528,7 +528,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/page/2/index.html
+++ b/blog/page/2/index.html
@@ -530,7 +530,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/page/3/index.html
+++ b/blog/page/3/index.html
@@ -526,7 +526,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/blog/page/4/index.html
+++ b/blog/page/4/index.html
@@ -324,7 +324,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/cla/index.html
+++ b/cla/index.html
@@ -245,7 +245,7 @@ before we merge your pull request.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/dotnet/index.html
+++ b/code/dotnet/index.html
@@ -229,7 +229,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/dotnet/jwt-validation.html
+++ b/code/dotnet/jwt-validation.html
@@ -438,7 +438,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/dotnet/okta-oauth-aspnet-codeflow.html
+++ b/code/dotnet/okta-oauth-aspnet-codeflow.html
@@ -186,7 +186,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/dotnet/okta-oauth-spa-authjs-osw.html
+++ b/code/dotnet/okta-oauth-spa-authjs-osw.html
@@ -186,7 +186,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/dotnet/okta-oidc-spa-osw-aspnet.html
+++ b/code/dotnet/okta-oidc-spa-osw-aspnet.html
@@ -186,7 +186,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/dotnet/sample_application.html
+++ b/code/dotnet/sample_application.html
@@ -264,7 +264,7 @@ introduction to the <a href="https://www.asp.net/open-source">open source</a> <a
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/dotnet/sdk.html
+++ b/code/dotnet/sdk.html
@@ -186,7 +186,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/index.html
+++ b/code/index.html
@@ -301,7 +301,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/java/index.html
+++ b/code/java/index.html
@@ -207,7 +207,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/java/okta-openidconnect-appauth-sample-android.html
+++ b/code/java/okta-openidconnect-appauth-sample-android.html
@@ -186,7 +186,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/java/oktasdk-java.html
+++ b/code/java/oktasdk-java.html
@@ -186,7 +186,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/java/spring_security_saml.html
+++ b/code/java/spring_security_saml.html
@@ -613,7 +613,7 @@ methods above, then you’re done.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/index.html
+++ b/code/javascript/index.html
@@ -249,7 +249,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/okta_angular_auth_js.html
+++ b/code/javascript/okta_angular_auth_js.html
@@ -545,7 +545,7 @@ The easiest, and most secure way is to use the <strong>default login page</stron
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/okta_angular_sign-in_widget.html
+++ b/code/javascript/okta_angular_sign-in_widget.html
@@ -524,7 +524,7 @@ To provide a fully-featured and customizable login experience, the <a href="okta
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/okta_auth_sdk.html
+++ b/code/javascript/okta_auth_sdk.html
@@ -486,7 +486,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/okta_auth_sdk_ref.html
+++ b/code/javascript/okta_auth_sdk_ref.html
@@ -1764,7 +1764,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/okta_react.html
+++ b/code/javascript/okta_react.html
@@ -590,7 +590,7 @@ To provide a fully featured and customizable login experience, the <a href="okta
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/okta_react_sign-in_widget.html
+++ b/code/javascript/okta_react_sign-in_widget.html
@@ -589,7 +589,7 @@ To provide a fully featured and customizable login experience, the <a href="okta
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/okta_sign-in_widget.html
+++ b/code/javascript/okta_sign-in_widget.html
@@ -684,7 +684,7 @@ web browser.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/javascript/okta_sign-in_widget_ref.html
+++ b/code/javascript/okta_sign-in_widget_ref.html
@@ -1290,7 +1290,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/php/index.html
+++ b/code/php/index.html
@@ -209,7 +209,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/php/jwt-validation.html
+++ b/code/php/jwt-validation.html
@@ -386,7 +386,7 @@ enough time to prevent most issues in regards to expire time and issued at time.
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/php/quickstart-signin-widget.html
+++ b/code/php/quickstart-signin-widget.html
@@ -664,7 +664,7 @@ However, in an emergency situation you can still stay in sync with Okta’s key 
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/php/simplesamlphp.html
+++ b/code/php/simplesamlphp.html
@@ -587,7 +587,7 @@ please reach out to us at: <a href="mailto:developers@okta.com">developers@okta.
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/python/index.html
+++ b/code/python/index.html
@@ -200,7 +200,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/python/pysaml2.html
+++ b/code/python/pysaml2.html
@@ -477,7 +477,7 @@ please reach out to me at: joel.franusic@okta.com.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/python/sdk.html
+++ b/code/python/sdk.html
@@ -186,7 +186,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/swift/index.html
+++ b/code/swift/index.html
@@ -193,7 +193,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/code/swift/quickstart-appauth-swift.html
+++ b/code/swift/quickstart-appauth-swift.html
@@ -425,7 +425,7 @@ The easiest, and most secure way is to use the <strong>default login page</stron
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/contact/index.html
+++ b/contact/index.html
@@ -177,7 +177,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/getting_started/api_test_client.html
+++ b/docs/api/getting_started/api_test_client.html
@@ -439,7 +439,7 @@ Replace URL and body variables with the IDs of the resources you wish to specify
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/getting_started/design_principles.html
+++ b/docs/api/getting_started/design_principles.html
@@ -772,7 +772,7 @@ For all endpoints not listed, the API rate limit is a combined 10,000 requests p
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/getting_started/enabling_cors.html
+++ b/docs/api/getting_started/enabling_cors.html
@@ -487,7 +487,7 @@ SCRIPT7002: XMLHttpRequest: Network Error 0x80070005, Access is denied.
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/getting_started/getting_a_token.html
+++ b/docs/api/getting_started/getting_a_token.html
@@ -305,7 +305,7 @@ user with only the permission levels you need for the token to perform the API t
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/getting_started/releases-at-okta.html
+++ b/docs/api/getting_started/releases-at-okta.html
@@ -451,7 +451,7 @@ Such features may spend more than one month between preview and production for t
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/apps.html
+++ b/docs/api/resources/apps.html
@@ -8161,7 +8161,7 @@ MIIC4DCCAcgCAQAwcTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNh
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/authn.html
+++ b/docs/api/resources/authn.html
@@ -8156,7 +8156,7 @@ Currently this is available only during [step-up authentication] (#step-up-authe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/events.html
+++ b/docs/api/resources/events.html
@@ -1611,7 +1611,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/factor_admin.html
+++ b/docs/api/resources/factor_admin.html
@@ -842,7 +842,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/factors.html
+++ b/docs/api/resources/factors.html
@@ -4542,7 +4542,7 @@ Or, you can pass the existing phone number in a profile object.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/groups.html
+++ b/docs/api/resources/groups.html
@@ -2856,7 +2856,7 @@ The maximum value for limit is 300.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/idps.html
+++ b/docs/api/resources/idps.html
@@ -8418,7 +8418,7 @@ This object is used for dynamic discovery of related resources and lifecycle ope
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/oauth-clients.html
+++ b/docs/api/resources/oauth-clients.html
@@ -1110,7 +1110,7 @@ then no redirect URI or response type is necessary. In these cases you can pass 
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/oauth2.html
+++ b/docs/api/resources/oauth2.html
@@ -3923,7 +3923,7 @@ Token expiration times depend on how they are defined in the rules, and which po
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/oidc.html
+++ b/docs/api/resources/oidc.html
@@ -1723,7 +1723,7 @@ Generally speaking, the scopes specified in a request are included in the Access
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/policy.html
+++ b/docs/api/resources/policy.html
@@ -2478,7 +2478,7 @@ Application sign-on policy can’t be configured via the API.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/roles.html
+++ b/docs/api/resources/roles.html
@@ -1126,7 +1126,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/schemas.html
+++ b/docs/api/resources/schemas.html
@@ -2770,7 +2770,7 @@ A property cannot be removed if it is being referenced as a <a href="./idps.html
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/sessions.html
+++ b/docs/api/resources/sessions.html
@@ -1246,7 +1246,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/social_authentication.html
+++ b/docs/api/resources/social_authentication.html
@@ -859,7 +859,7 @@ ok -> ua: 302 to redirect_uri
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/system_log.html
+++ b/docs/api/resources/system_log.html
@@ -1634,7 +1634,7 @@ can use the following <code class="highlighter-rouge">curl</code> command to see
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/templates.html
+++ b/docs/api/resources/templates.html
@@ -943,7 +943,7 @@ provided in pairs: the language and translated template text.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/tokens.html
+++ b/docs/api/resources/tokens.html
@@ -313,7 +313,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/users.html
+++ b/docs/api/resources/users.html
@@ -4421,7 +4421,7 @@ For more information about <code class="highlighter-rouge">login</code>, see <a 
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/api/resources/zones.html
+++ b/docs/api/resources/zones.html
@@ -969,7 +969,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/how-to/beta-auth-service/api-access-management-troubleshooting.html
+++ b/docs/how-to/beta-auth-service/api-access-management-troubleshooting.html
@@ -323,7 +323,7 @@ Token expiration times depend on how they are defined in the rules, and which po
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/how-to/byo_saml.html
+++ b/docs/how-to/byo_saml.html
@@ -615,7 +615,7 @@ Content-Type: application/json;charset=UTF-8
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/how-to/inbound-saml-with-oidc.html
+++ b/docs/how-to/inbound-saml-with-oidc.html
@@ -314,7 +314,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/how-to/set-up-auth-server.html
+++ b/docs/how-to/set-up-auth-server.html
@@ -551,7 +551,7 @@ Be sure to check that your expression returns the results expected–the express
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/how-to/sharing-cert.html
+++ b/docs/how-to/sharing-cert.html
@@ -476,7 +476,7 @@ using the same certificate to sign assertions.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/how-to/updating_saml_cert.html
+++ b/docs/how-to/updating_saml_cert.html
@@ -569,7 +569,7 @@ sure to note the certificate format that the decoder service requires.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes.html
+++ b/docs/platform-release-notes/platform-release-notes.html
@@ -308,7 +308,7 @@ Dates for preview and production release are the earliest possible release date.
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-23.html
+++ b/docs/platform-release-notes/platform-release-notes2016-23.html
@@ -262,7 +262,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-24.html
+++ b/docs/platform-release-notes/platform-release-notes2016-24.html
@@ -273,7 +273,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-25.html
+++ b/docs/platform-release-notes/platform-release-notes2016-25.html
@@ -280,7 +280,7 @@ If more than 100 groups match the filter, then the request fails.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-26.html
+++ b/docs/platform-release-notes/platform-release-notes2016-26.html
@@ -279,7 +279,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-27.html
+++ b/docs/platform-release-notes/platform-release-notes2016-27.html
@@ -300,7 +300,7 @@ after <a href="https://support.okta.com/help/articles/Knowledge_Article/Current-
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-28.html
+++ b/docs/platform-release-notes/platform-release-notes2016-28.html
@@ -326,7 +326,7 @@ and <a href="/docs/api/resources/authn#answer-recovery-question">Answer Recovery
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-29.html
+++ b/docs/platform-release-notes/platform-release-notes2016-29.html
@@ -276,7 +276,7 @@ Existing SAML IdP instances will continue to use the certificate they currently 
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-30.html
+++ b/docs/platform-release-notes/platform-release-notes2016-30.html
@@ -298,7 +298,7 @@ and specify the value <code class="highlighter-rouge">CUSTOM_ATTRIBUTE</code> in
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-31.html
+++ b/docs/platform-release-notes/platform-release-notes2016-31.html
@@ -281,7 +281,7 @@ see <a href="https://github.com/okta/okta-auth-js/releases/tag/okta-auth-js-1.4.
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-33.html
+++ b/docs/platform-release-notes/platform-release-notes2016-33.html
@@ -264,7 +264,7 @@ failed to receive <code class="highlighter-rouge">expires_in</code> and <code cl
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-34.html
+++ b/docs/platform-release-notes/platform-release-notes2016-34.html
@@ -272,7 +272,7 @@ This failure occurred if the username was in both the username and email and a s
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-35.html
+++ b/docs/platform-release-notes/platform-release-notes2016-35.html
@@ -290,7 +290,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-36.html
+++ b/docs/platform-release-notes/platform-release-notes2016-36.html
@@ -260,7 +260,7 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-37.html
+++ b/docs/platform-release-notes/platform-release-notes2016-37.html
@@ -261,7 +261,7 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-39.html
+++ b/docs/platform-release-notes/platform-release-notes2016-39.html
@@ -277,7 +277,7 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-40.html
+++ b/docs/platform-release-notes/platform-release-notes2016-40.html
@@ -262,7 +262,7 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-41.html
+++ b/docs/platform-release-notes/platform-release-notes2016-41.html
@@ -322,7 +322,7 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-43.html
+++ b/docs/platform-release-notes/platform-release-notes2016-43.html
@@ -320,7 +320,7 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-45.html
+++ b/docs/platform-release-notes/platform-release-notes2016-45.html
@@ -296,7 +296,7 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-46.html
+++ b/docs/platform-release-notes/platform-release-notes2016-46.html
@@ -261,7 +261,7 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-47.html
+++ b/docs/platform-release-notes/platform-release-notes2016-47.html
@@ -259,7 +259,7 @@ scroll to the bottom of the Admin <strong>Dashboard</strong> page to see the ver
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-49.html
+++ b/docs/platform-release-notes/platform-release-notes2016-49.html
@@ -279,7 +279,7 @@ scroll to the bottom of the Admin <strong>Dashboard</strong> page to see the ver
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-50.html
+++ b/docs/platform-release-notes/platform-release-notes2016-50.html
@@ -278,7 +278,7 @@ scroll to the bottom of the Admin <strong>Dashboard</strong> page to see the ver
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-51.html
+++ b/docs/platform-release-notes/platform-release-notes2016-51.html
@@ -275,7 +275,7 @@ As of 2016.51, HAL links for these three operations are returned only if the pol
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-52.html
+++ b/docs/platform-release-notes/platform-release-notes2016-52.html
@@ -264,7 +264,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2016-index.html
+++ b/docs/platform-release-notes/platform-release-notes2016-index.html
@@ -274,7 +274,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-02.html
+++ b/docs/platform-release-notes/platform-release-notes2017-02.html
@@ -278,7 +278,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-03.html
+++ b/docs/platform-release-notes/platform-release-notes2017-03.html
@@ -321,7 +321,7 @@ but is now 401. (OKTA-111888)</li>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-04.html
+++ b/docs/platform-release-notes/platform-release-notes2017-04.html
@@ -280,7 +280,7 @@ the pre-filled default values include all grant types and the <code class="highl
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-05.html
+++ b/docs/platform-release-notes/platform-release-notes2017-05.html
@@ -288,7 +288,7 @@ include <code class="highlighter-rouge">ID Tokens</code>, <code class="highlight
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-09.html
+++ b/docs/platform-release-notes/platform-release-notes2017-09.html
@@ -296,7 +296,7 @@ link. This feature will be in preview for at least a month.
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-10.html
+++ b/docs/platform-release-notes/platform-release-notes2017-10.html
@@ -287,7 +287,7 @@ point, the warnings in the System Log will change to error notifications.</li>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-11.html
+++ b/docs/platform-release-notes/platform-release-notes2017-11.html
@@ -307,7 +307,7 @@ returned the user’s status as ACTIVE rather than RECOVERY. (OKTA-109772)</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-12.html
+++ b/docs/platform-release-notes/platform-release-notes2017-12.html
@@ -291,7 +291,7 @@ point, the warnings in the System Log will change to error notifications.</li>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-15.html
+++ b/docs/platform-release-notes/platform-release-notes2017-15.html
@@ -334,7 +334,7 @@ for requests when the user is in a PROVISIONED state but doesn’t have a passwo
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-16.html
+++ b/docs/platform-release-notes/platform-release-notes2017-16.html
@@ -364,7 +364,7 @@ This feature is Generally Available in preview orgs for at least one month befor
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-17.html
+++ b/docs/platform-release-notes/platform-release-notes2017-17.html
@@ -399,7 +399,7 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-18.html
+++ b/docs/platform-release-notes/platform-release-notes2017-18.html
@@ -390,7 +390,7 @@ For more information, see the <a href="/docs/api/resources/idps.html#social-auth
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-19.html
+++ b/docs/platform-release-notes/platform-release-notes2017-19.html
@@ -385,7 +385,7 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-20.html
+++ b/docs/platform-release-notes/platform-release-notes2017-20.html
@@ -394,7 +394,7 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-21.html
+++ b/docs/platform-release-notes/platform-release-notes2017-21.html
@@ -369,7 +369,7 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-22.html
+++ b/docs/platform-release-notes/platform-release-notes2017-22.html
@@ -367,7 +367,7 @@ Okta expects to deliver this feature in production orgs (with the same Okta .NET
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-23.html
+++ b/docs/platform-release-notes/platform-release-notes2017-23.html
@@ -439,7 +439,7 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-24.html
+++ b/docs/platform-release-notes/platform-release-notes2017-24.html
@@ -375,7 +375,7 @@ Previously these notifications appeared only in the System Log (<code class="hig
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-25.html
+++ b/docs/platform-release-notes/platform-release-notes2017-25.html
@@ -349,7 +349,7 @@ encountered an invalid_client error, the response did not include the WWW­Authe
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-26.html
+++ b/docs/platform-release-notes/platform-release-notes2017-26.html
@@ -308,7 +308,7 @@ response code was 500 rather than 400. (OKTA-126223)</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-27.html
+++ b/docs/platform-release-notes/platform-release-notes2017-27.html
@@ -323,7 +323,7 @@ Okta SDK <code class="highlighter-rouge">EventsAPIClient</code>.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-28.html
+++ b/docs/platform-release-notes/platform-release-notes2017-28.html
@@ -364,7 +364,7 @@ To enable an EA feature, contact Okta Support.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-29.html
+++ b/docs/platform-release-notes/platform-release-notes2017-29.html
@@ -312,7 +312,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-30.html
+++ b/docs/platform-release-notes/platform-release-notes2017-30.html
@@ -317,7 +317,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-31.html
+++ b/docs/platform-release-notes/platform-release-notes2017-31.html
@@ -326,7 +326,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-32.html
+++ b/docs/platform-release-notes/platform-release-notes2017-32.html
@@ -334,7 +334,7 @@ Previously, application groups could only be retrieved with the Custom Authoriza
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/docs/platform-release-notes/platform-release-notes2017-index.html
+++ b/docs/platform-release-notes/platform-release-notes2017-index.html
@@ -275,7 +275,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -473,7 +473,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/documentation/stormpath-import.html
+++ b/documentation/stormpath-import.html
@@ -978,7 +978,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/error.html
+++ b/error.html
@@ -179,7 +179,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/integrate_with_okta/index.html
+++ b/integrate_with_okta/index.html
@@ -261,7 +261,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/oidc_playground/index.html
+++ b/oidc_playground/index.html
@@ -162,7 +162,7 @@ function loadPlayground (iframe) {
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/pricing-preview/index.html
+++ b/pricing-preview/index.html
@@ -388,7 +388,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -303,7 +303,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/product/index.html
+++ b/product/index.html
@@ -760,7 +760,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/quickstarts/index.html
+++ b/quickstarts/index.html
@@ -181,7 +181,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/reference/api_reference.html
+++ b/reference/api_reference.html
@@ -244,7 +244,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/reference/authentication_reference.html
+++ b/reference/authentication_reference.html
@@ -244,7 +244,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/reference/error_codes/index.html
+++ b/reference/error_codes/index.html
@@ -750,7 +750,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/reference/getting_started.html
+++ b/reference/getting_started.html
@@ -244,7 +244,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/reference/okta_expression_language/index.html
+++ b/reference/okta_expression_language/index.html
@@ -1279,7 +1279,7 @@ Note: At this time, only <strong>active_directory</strong> is supported for <em>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/reference/platform_release_notes.html
+++ b/reference/platform_release_notes.html
@@ -244,7 +244,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/search/index.html
+++ b/search/index.html
@@ -186,7 +186,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/signup/index.html
+++ b/signup/index.html
@@ -229,7 +229,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/signup/stormpath/index.html
+++ b/signup/stormpath/index.html
@@ -237,7 +237,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/signup/thank-you/index.html
+++ b/signup/thank-you/index.html
@@ -175,7 +175,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/standards/OAuth/index.html
+++ b/standards/OAuth/index.html
@@ -833,7 +833,7 @@ However, you can also use OpenID Connect with a Custom Authorization Server:</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/standards/OIDC/index.html
+++ b/standards/OIDC/index.html
@@ -772,7 +772,7 @@ For more information about configuring an app for OpenID Connect, including grou
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/standards/SAML/index.html
+++ b/standards/SAML/index.html
@@ -442,7 +442,7 @@ can help you build your applications and integrations:</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/standards/SAML/saml_tracer.html
+++ b/standards/SAML/saml_tracer.html
@@ -481,7 +481,7 @@ RKvwyyTfqfq9pgSmB9xNVJIeVZbbZGTlNGqJti24E0AiIPggtxg5NJ+HHnEQ5RxdSsR4fbMz9i0K
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/standards/SAML/setting_up_a_saml_application_in_okta.html
+++ b/standards/SAML/setting_up_a_saml_application_in_okta.html
@@ -336,7 +336,7 @@ opened in step #10 contains the information that you’ll need to configure SAML
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/standards/SCIM/index.html
+++ b/standards/SCIM/index.html
@@ -2114,7 +2114,7 @@ only happen if the User table isn’t defined.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/terms/index.html
+++ b/terms/index.html
@@ -260,7 +260,7 @@ DEVELOPER EDITION LICENSE AGREEMENT</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/test_page/index.html
+++ b/test_page/index.html
@@ -283,7 +283,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/api_access_management/index.html
+++ b/use_cases/api_access_management/index.html
@@ -331,7 +331,7 @@ This benefit depends, of course, on the level of security your apps require.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/authentication/index.html
+++ b/use_cases/authentication/index.html
@@ -354,7 +354,7 @@ secure your API as well as manage OpenID Connect for your customer app.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/authentication/session_cookie.html
+++ b/use_cases/authentication/session_cookie.html
@@ -417,7 +417,7 @@ that contains the the session token as query parameter <code class="highlighter-
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/integrate_with_okta/index.html
+++ b/use_cases/integrate_with_okta/index.html
@@ -260,7 +260,7 @@ Okta strongly recommends that you implement both. Once you have published in the
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/integrate_with_okta/oan-faqs.html
+++ b/use_cases/integrate_with_okta/oan-faqs.html
@@ -352,7 +352,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/integrate_with_okta/promotion.html
+++ b/use_cases/integrate_with_okta/promotion.html
@@ -367,7 +367,7 @@ Raising awareness for your integration among joint customers and new prospects h
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/integrate_with_okta/provisioning.html
+++ b/use_cases/integrate_with_okta/provisioning.html
@@ -260,7 +260,7 @@ Get started by reviewing the program process, SCIM docs, and applying to the pro
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/integrate_with_okta/sso-with-saml.html
+++ b/use_cases/integrate_with_okta/sso-with-saml.html
@@ -300,7 +300,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/mfa/index.html
+++ b/use_cases/mfa/index.html
@@ -499,7 +499,7 @@ These instructions only cover part of what is covered in the video.</li>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/mobile/okta_mobile_connect.html
+++ b/use_cases/mobile/okta_mobile_connect.html
@@ -380,7 +380,7 @@ which includes an example of how to add SAML support to an iOS app.</p>
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/sso_and_provisioning/draft.html
+++ b/use_cases/sso_and_provisioning/draft.html
@@ -244,7 +244,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/users_groups_applications/draft.html
+++ b/use_cases/users_groups_applications/draft.html
@@ -244,7 +244,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>

--- a/use_cases/web_development/draft.html
+++ b/use_cases/web_development/draft.html
@@ -244,7 +244,7 @@
             <div class="Column--3 Column--medium-6 Column--small-12">
                 <h4>More Info</h4>
                 <ul class="Footer-links">
-                    <li><a target="_blank" href="https://developer.okta.com/integrate/">Integrate with Okta</a></li>
+                    <li><a target="_blank" href="/use_cases/integrate_with_okta/">Integrate with Okta</a></li>
                     <li><a href="/blog/">Blog</a></li>
                     <li><a href="/docs/platform-release-notes/platform-release-notes.html">Release Notes</a></li>
                     <li><a href="/3rd_party_notices/">3rd Party Notes</a></li>


### PR DESCRIPTION
## Description:
- The new footer link "Integrate With Okta" points to `https://developer.okta.com/integrate`, a page that does not currently exist.
- This fix points to `/use_cases/integrate_with_okta` and removes the `https://developer.okta.com` prepend.

> **Note** Building the site locally only shows updates to the navigation and footer. It does not include the main product page. Is this expected? Do our build instructions need to be updated?

### Resolves:
* [OKTA-138144](https://oktainc.atlassian.net/browse/OKTA-138144)

@rchild-okta 