### PR TITLE
Limit number of posts contained in RSS feed to prevent FeedBurner error

### DIFF
--- a/_source/feed.xml
+++ b/_source/feed.xml
@@ -8,7 +8,7 @@ layout: null
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}</link>
     <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
-    {% for post in site.posts %}
+    {% for post in site.posts limit:15 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>


### PR DESCRIPTION
## Description:

Limit number of posts contained in RSS feed to prevent FeedBurner error

--

### Resolves:
Issue submitted to Okta Marketing queue filed by maziel.martinez@okta.com
FeedBurner will not process any feeds larger than 1MB
https://app.asana.com/0/370676378542055/398673129913955