### PR TITLE
Adding check for support link on navigation bar

### DIFF
--- a/tests/selenium/framework/page-objects/NavPage.js
+++ b/tests/selenium/framework/page-objects/NavPage.js
@@ -13,6 +13,8 @@ class NavPage extends BasePage {
     this.$searchIcon = $('.SearchIcon');
     this.$searchInput = $('#st-search-input-auto');
     this.$resultsBox = $('.SearchResults');
+    this.$supportLink = element(by.cssContainingText('span', 'Support'));
+    this.$$menus = $$('.menu');
     this.setPageLoad(this.$header);
   }
 
@@ -52,6 +54,13 @@ class NavPage extends BasePage {
     return util.wait(this.$resultsBox);
   }
 
+  clickSupportLink() {
+    return this.$supportLink.click()
+  }
+
+  isSupportMenuDisplayed() {
+    return this.$$menus.get(1).isDisplayed();
+  }
 }
 
 module.exports = NavPage;

--- a/tests/selenium/spec/page-layout-browser-size-spec.js
+++ b/tests/selenium/spec/page-layout-browser-size-spec.js
@@ -14,6 +14,10 @@ describe('page layout and browser size spec', () => {
     expect(navPage.isDesktopNavDisplayed()).toBe(true);
     expect(navPage.isMobileNavDisplayed()).toBe(false);
 
+    // Verify that support link dropdown is visible
+    expect(navPage.isSupportMenuDisplayed()).toBe(false);
+    navPage.clickSupportLink();
+    expect(navPage.isSupportMenuDisplayed()).toBe(true);
   });
 
   // PhantomJS does not support the CSS transform we use to hide the top nav


### PR DESCRIPTION
## Description:
- Added a check that ensures that support dropdown menu is visible on click
- This is to catch bugs where the page content overlays the drop-down navigation for the "Support" navbar item

### Resolves:
* [Issue #X](#X)
<!-- Required for Okta-generated PRs -->
* [OKTA-138751](https://oktainc.atlassian.net/browse/OKTA-138751)

