### PR TITLE
Change global JS links location

### DIFF
--- a/3rd_party_notices/Android_Mobile.html
+++ b/3rd_party_notices/Android_Mobile.html
@@ -765,8 +765,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Android_Verify.html
+++ b/3rd_party_notices/Android_Verify.html
@@ -754,8 +754,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Connector_Agent_Tool.html
+++ b/3rd_party_notices/Connector_Agent_Tool.html
@@ -1082,8 +1082,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Framework_Tool.html
+++ b/3rd_party_notices/Framework_Tool.html
@@ -818,8 +818,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Office365.html
+++ b/3rd_party_notices/Office365.html
@@ -570,8 +570,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_AD_Agent_Setup.html
+++ b/3rd_party_notices/Okta_AD_Agent_Setup.html
@@ -1023,8 +1023,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_Auth_SDK.html
+++ b/3rd_party_notices/Okta_Auth_SDK.html
@@ -648,8 +648,6 @@ product. Alternatively, the open source may accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool.html
+++ b/3rd_party_notices/Okta_Cloud_Provisioning_Connector_Tool.html
@@ -1335,8 +1335,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_Confluence.html
+++ b/3rd_party_notices/Okta_Confluence.html
@@ -1120,8 +1120,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_Jira.html
+++ b/3rd_party_notices/Okta_Jira.html
@@ -1120,8 +1120,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_LDAP_Agent.html
+++ b/3rd_party_notices/Okta_LDAP_Agent.html
@@ -1370,8 +1370,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_LDAP_Agent_Setup.html
+++ b/3rd_party_notices/Okta_LDAP_Agent_Setup.html
@@ -1023,8 +1023,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_Password_Sync_Setup.html
+++ b/3rd_party_notices/Okta_Password_Sync_Setup.html
@@ -1214,8 +1214,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_Radius_Agent_Setup.html
+++ b/3rd_party_notices/Okta_Radius_Agent_Setup.html
@@ -1096,8 +1096,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_Rsa_SecurID_Setup.html
+++ b/3rd_party_notices/Okta_Rsa_SecurID_Setup.html
@@ -1096,8 +1096,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_SAML_Toolkit.html
+++ b/3rd_party_notices/Okta_SAML_Toolkit.html
@@ -1120,8 +1120,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_SSO_IWA.html
+++ b/3rd_party_notices/Okta_SSO_IWA.html
@@ -841,8 +841,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_SWA_Chrome.html
+++ b/3rd_party_notices/Okta_SWA_Chrome.html
@@ -1366,8 +1366,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_SWA_Firefox.html
+++ b/3rd_party_notices/Okta_SWA_Firefox.html
@@ -1800,8 +1800,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_SWA_IE.html
+++ b/3rd_party_notices/Okta_SWA_IE.html
@@ -1366,8 +1366,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_SWA_Safari.html
+++ b/3rd_party_notices/Okta_SWA_Safari.html
@@ -1366,8 +1366,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Okta_Sign-In_Widget.html
+++ b/3rd_party_notices/Okta_Sign-In_Widget.html
@@ -1279,8 +1279,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/OpenID_Connect_Emulator.html
+++ b/3rd_party_notices/OpenID_Connect_Emulator.html
@@ -1025,8 +1025,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/SDK_Packaging.html
+++ b/3rd_party_notices/SDK_Packaging.html
@@ -806,8 +806,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Web_App_Client_JS.html
+++ b/3rd_party_notices/Web_App_Client_JS.html
@@ -1930,8 +1930,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Windows_Shared.html
+++ b/3rd_party_notices/Windows_Shared.html
@@ -645,8 +645,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/Windows_Verify.html
+++ b/3rd_party_notices/Windows_Verify.html
@@ -592,8 +592,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/iOS_Mobile.html
+++ b/3rd_party_notices/iOS_Mobile.html
@@ -1010,8 +1010,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/iOS_Verify.html
+++ b/3rd_party_notices/iOS_Verify.html
@@ -819,8 +819,6 @@ accompany the Okta product.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/3rd_party_notices/index.html
+++ b/3rd_party_notices/index.html
@@ -282,8 +282,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/404.html
+++ b/404.html
@@ -212,8 +212,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/_source/_assets/js/docsIndex.js
+++ b/_source/_assets/js/docsIndex.js
@@ -35,7 +35,6 @@
     $('#docs-languages').append(ul);
   }
 
-  if (window.location.pathname.match('^/documentation/')) {
-    renderCodeLinks();
-  }
+  // Load documentation icons
+  renderCodeLinks();
 })(jQuery);

--- a/_source/_assets/js/quickstart.js
+++ b/_source/_assets/js/quickstart.js
@@ -313,8 +313,7 @@
     $('#server_setup_link').removeClass('active');
   };
 
-  if (window.location.pathname.match('^/quickstart')) {
-    main();
-  }
+  // Load the quickstart partials
+  main();
 
 })(jQuery);

--- a/_source/_code/java/index.md
+++ b/_source/_code/java/index.md
@@ -10,7 +10,7 @@ New to Okta? Our Quick Start Guide will walk you through adding user authenticat
 
 <ul class='code-list'>
   <li>
-    <a href='/quickstart/#/okta-sign-in-page/java/generic/' class='code-button inverse'>
+    <a href='/quickstart/#/okta-sign-in-page/java/spring/' class='code-button inverse'>
       <span class='code-icon launch-16'></span><span>Authentication Quick Start Guide</span>
     </a>
   </li>

--- a/_source/_includes/footer.html
+++ b/_source/_includes/footer.html
@@ -47,8 +47,6 @@
 </footer>
 
     {% js master %}
-    {% js quickstart %}
-    {% js docsIndex %}    
     {% for script in page.scripts %}
       <script src="{{ script }}"></script>
     {% endfor %}

--- a/_source/_layouts/docs_index.html
+++ b/_source/_layouts/docs_index.html
@@ -1,6 +1,7 @@
 ---
 layout: master
 show_bottom_cta: true
+js: docsIndex
 ---
 
 <section class="Docs u-Justify u-alignCenter">

--- a/_source/_layouts/quickstart.html
+++ b/_source/_layouts/quickstart.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+js: quickstart
 ---
 <section class="PageContent quickstart-page">
   <!-- START Page Content -->

--- a/assets/docsIndex-546112c9ccd98aac94c723bd879eaf56c04eecab1db2ede2e00d1e721f6de5af.js
+++ b/assets/docsIndex-546112c9ccd98aac94c723bd879eaf56c04eecab1db2ede2e00d1e721f6de5af.js
@@ -1,0 +1,40 @@
+(function($) {    
+  // Handle building the icons and code languages
+  var code = [
+    { name: 'angular', label: 'Angular' },
+    { name: 'react',label: 'React' },
+    { name: 'ios',  label: 'iOS' },
+    { name: 'nodejs', label: 'Node.js' },
+    { name: 'java', label: 'Java' },
+    { name: 'dotnet', label: '.NET' },
+    { name: 'php', label: 'PHP' },
+    { name: 'python', label: 'Python' }
+  ]
+
+  function renderCodeLinks() {
+    var ul = $('<ul>', {});
+    code.forEach(function (language) {
+      var li = $('<li>');
+
+      var icon = $('<i>', {
+        class: 'icon code-' + language.name + '-32',
+      });
+
+      var link = $('<a>', {
+        text: language.label + ' ›',
+        href: '/code/' + language.name + '/',
+      });      
+      link.prepend($('<br />'));
+      link.prepend(icon);
+      li.append(link);
+      
+      // li.append(icon);
+      // li.append(link);
+      ul.append(li);
+    });
+    $('#docs-languages').append(ul);
+  }
+
+  // Load documentation icons
+  renderCodeLinks();
+})(jQuery);

--- a/assets/quickstart-5d853038b86916fba9048db44f99ab97f96facb97b3106518a345e7f1d277f79.js
+++ b/assets/quickstart-5d853038b86916fba9048db44f99ab97f96facb97b3106518a345e7f1d277f79.js
@@ -1,0 +1,319 @@
+(function($) {
+  /**
+   * linkState
+   *
+   * This object defines the links that will appear, and serves as a state object once
+   * the app begins.  If you need to add new libraries, add them to this object.  If
+   * you need to change the default active libraries, change the active states in this
+   * object.
+   *
+   * `active` links will be selected by default. As the user navigates, the active
+   * properties will be modified accordingly.
+   */
+  var linkState = {
+    clients: [
+      {
+        name: 'okta-sign-in-page',
+        label: 'Okta Sign-In Page',
+        serverExampleType: 'auth-code',
+        active: true
+      },
+      {
+        name: 'angular',
+        label: 'Angular',
+        serverExampleType: 'implicit'
+      },{
+        name: 'react',
+        label: 'React',
+        serverExampleType: 'implicit'
+      },
+      {
+        name: 'widget',
+        label: 'Sign-In Widget',
+        serverExampleType: 'implicit',
+      },
+      {
+        name: 'ios',
+        label: 'iOS',
+        serverExampleType: 'implicit'
+      },
+      {
+        name: 'android',
+        label: 'Android',
+        serverExampleType: 'implicit'
+      },
+    ],
+    servers: [
+      {
+        active: true,
+        name: 'nodejs',
+        label: 'Node JS',
+        frameworks: [
+          {
+            active: true,
+            name: 'generic',
+            label: 'Generic Node'
+          },
+          {
+            name: 'express',
+            label: 'Express.js'
+          }
+        ]
+      },
+      {
+        name: 'java',
+        label: 'Java',
+        frameworks: [
+          {
+            name: 'spring',
+            label: 'Spring',
+            active: true
+          },
+          {
+            name: 'generic',
+            label: 'Generic Java'
+          }
+        ]
+      },
+      {
+        name: 'php',
+        label: 'PHP',
+        frameworks: [
+          {
+            name: 'generic',
+            label: 'Generic PHP',
+            active: true
+          }
+        ]
+      },
+      {
+        name: 'dotnet',
+        label: '.NET',
+        frameworks: [
+          {
+            name: 'aspnetcore',
+            label: 'ASP.NET Core',
+            active: true
+          },
+          {
+            name: 'aspnet4',
+            label: 'ASP.NET 4.x',
+          }
+        ]
+      }
+    ]
+  }
+
+  /**
+   * Matches /client/server/framework
+   */
+  var urlExpression = '/([^\/]*)?\/?([^\/]*)?\/?([^\/]*)';
+
+  /**
+   * Iterate through the link state, render buttons and setup click handlers
+   */
+  function renderLinks() {
+    linkState.clients.forEach(function (client) {
+      var link = $('<a>', {
+        text: client.label,
+        class: client.active ? 'active' : '',
+        click: function () {
+          linkState.clients.forEach(function (client) {
+            client.link.removeClass('active');
+            client.active = false;
+          });
+          $(this).addClass('active');
+          client.active = true;
+          applySelectionTuple(getSelectionTupleFromLinkSate());
+        }
+      });
+      var listItem = $('<li>', {
+        class: 'with-icon'
+      });
+      var icon = $('<i>', {
+        class: 'icon code-' + client.name + '-32'
+      });
+      link.prepend(icon);
+      listItem.append(link);
+      client.link = link;
+      $('#client-selector ul').append(listItem);
+    });
+
+    linkState.servers.forEach(function (server) {
+      var link = $('<a>', {
+        text: server.label,
+        class: server.active ? 'active' : '',
+        click: function () {
+          linkState.servers.forEach(function (server) {
+            server.link.removeClass('active');
+              server.active = false;
+          });
+          renderFrameworkLinks(server);
+          $(this).addClass('active');
+          server.active = true;
+          applySelectionTuple(getSelectionTupleFromLinkSate());
+        }
+      });
+      var listItem = $('<li>', {
+        class: 'with-icon'
+      });
+      var icon = $('<i>', {
+        class: 'icon code-' + server.name + '-32'
+      });
+      link.prepend(icon);
+      listItem.append(link);
+      server.link = link;
+      $('#server-selector ul').append(listItem);
+      if (server.active) {
+        renderFrameworkLinks(server);
+      }
+    });
+
+    function renderFrameworkLinks(server) {
+      $('#framework-selector a').each(function (i, element) {
+        $(element).remove();
+      });
+
+      server.frameworks.forEach(function (framework) {
+        var link = $('<a>', {
+          text: framework.label,
+          class: framework.active ? 'active' : '',
+          click: function () {
+            server.frameworks.forEach(function (framework) {
+              framework.link.removeClass('active');
+              framework.active = false;
+            });
+            $(this).addClass('active');
+            framework.active = true;
+            applySelectionTuple(getSelectionTupleFromLinkSate());
+          }
+        });
+        framework.link = link;
+        $('#framework-selector ul').append(link);
+      });
+    }
+  }
+
+  /**
+   * Fetches the content for a given selection tuple
+   */
+  function loadContent(clientName, server, framework) {
+    var client = linkState.clients.filter(function(client) {
+      return client.name === clientName;
+    })[0];
+    var clientContentUrl = clientName + '/default-example.html';
+    var serverContentUrl = server + '/' + framework + '-' + client.serverExampleType + '.html';
+
+    $.ajax({
+      url: clientContentUrl
+    }).done(function( html ) {
+      $( "#client_content" ).html( html );
+    });
+    $.ajax({
+      url: serverContentUrl
+    }).done(function( html ) {
+      $( "#server_content" ).html( html );
+    });
+  };
+
+  /**
+   * Get the active selections from the window hash
+   *
+   * @returns [clientName, serverName, frameworkName]
+   */
+  function getSelectionTupleFromHash() {
+    var matches = window.location.hash.match(urlExpression);
+    var clientName = matches && matches[1];
+    var serverName = matches && matches[2];
+    var frameworkName = matches && matches[3];
+    return [clientName, serverName, frameworkName];
+  }
+
+  /**
+   * Get the active selections from the link sate
+   *
+   * @returns [clientName, serverName, frameworkName]
+   */
+  function getSelectionTupleFromLinkSate() {
+    var tuple = [];
+    linkState.clients.forEach(function (client) {
+      if (client.active) {
+        tuple.push(client.name);
+      }
+    });
+    linkState.servers.forEach(function (server) {
+      if (server.active) {
+        tuple.push(server.name)
+        server.frameworks.forEach(function (framework) {
+          if (framework.active) {
+            tuple.push(framework.name)
+          }
+        });
+      }
+    });
+    return tuple;
+  }
+
+  /**
+   * Apply a selection tuple to the application state (set new window hash and load content)
+   */
+  function applySelectionTuple(selectionTuple) {
+    window.location.replace('#/' + selectionTuple.join('/'));
+    loadContent.apply(null, selectionTuple);
+  }
+
+  /**
+   * Apply a selection tuple to the link state (will modify `active` properties)
+   */
+  function applySelectionTupleToLinkSate(selectionTuple) {
+    var activeClient = selectionTuple[0];
+    var activeServer = selectionTuple[1];
+    var activeFramework = selectionTuple[2];
+
+    linkState.clients.forEach(function (client) {
+      client.active = client.name === activeClient;
+    });
+    linkState.servers.forEach(function (server) {
+      server.active = server.name === activeServer;
+      server.frameworks.forEach(function (framework) {
+        framework.active = framework.name === activeFramework;
+      });
+    });
+  }
+
+
+  /**
+   * Begin application.  Fetch default selections from link state, and current
+   * selections from window hash.  Window hash overrides default link state.
+   */
+  function main() {
+    var hashTuple = getSelectionTupleFromHash();
+    var stateTuple = getSelectionTupleFromLinkSate();
+    var initialTuple = [
+      hashTuple[0] || stateTuple[0],
+      hashTuple[1] || stateTuple[1],
+      hashTuple[2] || stateTuple[2]
+    ];
+
+    applySelectionTupleToLinkSate(initialTuple);
+    renderLinks();
+    applySelectionTuple(initialTuple);
+    $('#client_setup_link').addClass('active');
+  }
+
+  // Used to scroll to the right place without anchors, 150 is to account for our header space
+  window.scrollToServer = function () {
+    $('body').animate({scrollTop: $('#server_setup').offset().top - 150});
+    $('#server_setup_link').addClass('active');
+    $('#client_setup_link').removeClass('active');
+  };
+  window.scrollToClient = function () {
+    $('body').animate({scrollTop: $('#client_setup').offset().top - 150});
+    $('#client_setup_link').addClass('active');
+    $('#server_setup_link').removeClass('active');
+  };
+
+  // Load the quickstart partials
+  main();
+
+})(jQuery);

--- a/blog/2015/04/07/android-unit-testing-part-2.html
+++ b/blog/2015/04/07/android-unit-testing-part-2.html
@@ -422,8 +422,6 @@ check out the full code at <a href="https://github.com/vronin-okta/okta_blog_sam
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2015/04/14/android-unit-testing-part-3.html
+++ b/blog/2015/04/14/android-unit-testing-part-3.html
@@ -387,8 +387,6 @@ how to make tests isolated. You can also check out the full code at
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2015/04/23/android-unit-testing-part-4.html
+++ b/blog/2015/04/23/android-unit-testing-part-4.html
@@ -390,8 +390,6 @@ steps in writing on our wiki. Thanks guys!</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2015/05/08/productionalizing-active-mq.html
+++ b/blog/2015/05/08/productionalizing-active-mq.html
@@ -330,8 +330,6 @@ he does, he patches the JVM.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2015/05/08/software-engineering-design-principles.html
+++ b/blog/2015/05/08/software-engineering-design-principles.html
@@ -449,8 +449,6 @@ enforce limits and design for infinity.</li>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2015/05/22/tcmalloc.html
+++ b/blog/2015/05/22/tcmalloc.html
@@ -310,8 +310,6 @@ compared to the amount of available RAM, which meant that we were sacrificing bo
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2015/06/11/trustpage.html
+++ b/blog/2015/06/11/trustpage.html
@@ -291,8 +291,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2015/12/02/tls-client-authentication-for-services.html
+++ b/blog/2015/12/02/tls-client-authentication-for-services.html
@@ -647,8 +647,6 @@ you implement these authentication concepts in your applications.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2015/12/07/oauth.html
+++ b/blog/2015/12/07/oauth.html
@@ -245,8 +245,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2016/01/05/rest-service-auth-jwt.html
+++ b/blog/2016/01/05/rest-service-auth-jwt.html
@@ -252,8 +252,6 @@ services within an application.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2016/03/22/use-kentor-authservices-with-okta.html
+++ b/blog/2016/03/22/use-kentor-authservices-with-okta.html
@@ -303,8 +303,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/03/16/spring-boot-saml.html
+++ b/blog/2017/03/16/spring-boot-saml.html
@@ -476,8 +476,6 @@ Hello SAML!
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/03/21/spring-boot-oauth.html
+++ b/blog/2017/03/21/spring-boot-oauth.html
@@ -439,8 +439,6 @@ brew install springboot
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/03/27/angular-okta-sign-in-widget.html
+++ b/blog/2017/03/27/angular-okta-sign-in-widget.html
@@ -541,8 +541,6 @@ Chrome 56.0.2924 <span class="o">(</span>Mac OS X 10.11.6<span class="o">)</span
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/03/30/react-okta-sign-in-widget.html
+++ b/blog/2017/03/30/react-okta-sign-in-widget.html
@@ -497,8 +497,6 @@ npm start
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/04/17/angular-authentication-with-oidc.html
+++ b/blog/2017/04/17/angular-authentication-with-oidc.html
@@ -1331,8 +1331,6 @@ using <code class="highlighter-rouge">OAuthService.getIdToken()</code> and <code
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html
+++ b/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html
@@ -687,8 +687,6 @@ is present on the requested resource. Origin 'http://localhost:4200' is therefor
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/05/03/seven-new-vs-features.html
+++ b/blog/2017/05/03/seven-new-vs-features.html
@@ -277,8 +277,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html
+++ b/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html
@@ -743,8 +743,6 @@ cf push -p target/<span class="k">*</span>jar pwa-server
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/05/10/developers-guide-to-docker-part-1.html
+++ b/blog/2017/05/10/developers-guide-to-docker-part-1.html
@@ -335,8 +335,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html
+++ b/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html
@@ -1047,8 +1047,6 @@ For command-line tools, use tools/bin/sdkmanager and tools/bin/avdmanager
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/06/13/add-authentication-angular-pwa.html
+++ b/blog/2017/06/13/add-authentication-angular-pwa.html
@@ -1065,8 +1065,6 @@ No 'Access-Control-Allow-Origin' header is present on the requested resource. Or
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/06/15/build-microservices-architecture-spring-boot.html
+++ b/blog/2017/06/15/build-microservices-architecture-spring-boot.html
@@ -852,8 +852,6 @@ or <a href="https://github.com/oktadeveloper/spring-boot-microservices-example/i
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/06/20/develop-microservices-with-jhipster.html
+++ b/blog/2017/06/20/develop-microservices-with-jhipster.html
@@ -1235,8 +1235,6 @@ Stack Overflow with the <a href="http://stackoverflow.com/questions/tagged/jhips
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/06/21/what-the-heck-is-oauth.html
+++ b/blog/2017/06/21/what-the-heck-is-oauth.html
@@ -637,8 +637,6 @@ code=MsCeLvIaQm6bTrgtp7&amp;client_id=812741506391&amp;
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/06/27/seven-tools-net-developers.html
+++ b/blog/2017/06/27/seven-tools-net-developers.html
@@ -273,8 +273,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/06/29/oidc-user-auth-aspnet-core.html
+++ b/blog/2017/06/29/oidc-user-auth-aspnet-core.html
@@ -398,8 +398,6 @@ If you do, congratulations! You just set up OpenID Connect for authenticating in
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/07/13/apache-shiro-spring-boot.html
+++ b/blog/2017/07/13/apache-shiro-spring-boot.html
@@ -544,8 +544,6 @@ Transfer-Encoding: chunked
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html
+++ b/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html
@@ -471,8 +471,6 @@ vue init pwa my-pwa-project
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/07/25/oidc-primer-part-1.html
+++ b/blog/2017/07/25/oidc-primer-part-1.html
@@ -468,8 +468,6 @@ HTTP/1.1 200 OK
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/07/25/oidc-primer-part-2.html
+++ b/blog/2017/07/25/oidc-primer-part-2.html
@@ -407,8 +407,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/01/oidc-primer-part-3.html
+++ b/blog/2017/08/01/oidc-primer-part-3.html
@@ -703,8 +703,6 @@ Verified Access Token
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/08/secure-spring-microservices.html
+++ b/blog/2017/08/08/secure-spring-microservices.html
@@ -897,8 +897,6 @@ git checkout okta
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/09/jax-rs-vs-spring-rest-endpoints.html
+++ b/blog/2017/08/09/jax-rs-vs-spring-rest-endpoints.html
@@ -728,8 +728,6 @@ Server: Jetty<span class="o">(</span>9.3.12.v20160915<span class="o">)</span>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/17/why-jwts-suck-as-session-tokens.html
+++ b/blog/2017/08/17/why-jwts-suck-as-session-tokens.html
@@ -606,8 +606,6 @@ mobile apps, and API services, and makes web security fun again.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/21/what-is-developer-relations-at-okta.html
+++ b/blog/2017/08/21/what-is-developer-relations-at-okta.html
@@ -372,8 +372,6 @@ are the most valuable resource in business.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/22/build-an-ionic-app-with-user-authentication.html
+++ b/blog/2017/08/22/build-an-ionic-app-with-user-authentication.html
@@ -925,8 +925,6 @@ What Progressive Web Apps can do for you</a>.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/23/five-java-tips.html
+++ b/blog/2017/08/23/five-java-tips.html
@@ -365,8 +365,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/28/developers-guide-to-docker-part-2.html
+++ b/blog/2017/08/28/developers-guide-to-docker-part-2.html
@@ -363,8 +363,6 @@ CMD ["npm", "start"]
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/08/29/meet-the-new-okta-identity-platform.html
+++ b/blog/2017/08/29/meet-the-new-okta-identity-platform.html
@@ -299,8 +299,6 @@ on the subject.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/09/06/build-a-cryptocurrency-comparison-site-with-vuejs.html
+++ b/blog/2017/09/06/build-a-cryptocurrency-comparison-site-with-vuejs.html
@@ -1081,8 +1081,6 @@ account</a>.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/2017/09/08/nosql-options-for-java-developers.html
+++ b/blog/2017/09/08/nosql-options-for-java-developers.html
@@ -532,8 +532,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/index.html
+++ b/blog/index.html
@@ -564,8 +564,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/page/2/index.html
+++ b/blog/page/2/index.html
@@ -566,8 +566,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/page/3/index.html
+++ b/blog/page/3/index.html
@@ -566,8 +566,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/page/4/index.html
+++ b/blog/page/4/index.html
@@ -562,8 +562,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/blog/page/5/index.html
+++ b/blog/page/5/index.html
@@ -292,8 +292,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/cla/index.html
+++ b/cla/index.html
@@ -277,8 +277,6 @@ before we merge your pull request.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/angular/index.html
+++ b/code/angular/index.html
@@ -462,8 +462,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/angular/okta_angular_auth_js.html
+++ b/code/angular/okta_angular_auth_js.html
@@ -743,8 +743,6 @@ The easiest, and most secure way is to use the <strong>default login page</stron
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/angular/okta_angular_sign-in_widget.html
+++ b/code/angular/okta_angular_sign-in_widget.html
@@ -722,8 +722,6 @@ To provide a fully-featured and customizable login experience, the <a href="/cod
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/dotnet/index.html
+++ b/code/dotnet/index.html
@@ -483,8 +483,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/dotnet/jwt-validation.html
+++ b/code/dotnet/jwt-validation.html
@@ -640,8 +640,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/dotnet/okta-oauth-aspnet-codeflow.html
+++ b/code/dotnet/okta-oauth-aspnet-codeflow.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/dotnet/okta-oauth-spa-authjs-osw.html
+++ b/code/dotnet/okta-oauth-spa-authjs-osw.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/dotnet/okta-oidc-spa-osw-aspnet.html
+++ b/code/dotnet/okta-oidc-spa-osw-aspnet.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/dotnet/quickstart.html
+++ b/code/dotnet/quickstart.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/dotnet/sample_application.html
+++ b/code/dotnet/sample_application.html
@@ -465,8 +465,6 @@ introduction to the <a href="https://www.asp.net/open-source">open source</a> <a
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/dotnet/sdk.html
+++ b/code/dotnet/sdk.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/ios/index.html
+++ b/code/ios/index.html
@@ -460,8 +460,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/ios/quickstart-appauth-swift.html
+++ b/code/ios/quickstart-appauth-swift.html
@@ -626,8 +626,6 @@ The easiest, and most secure way is to use the <strong>default login page</stron
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/java/index.html
+++ b/code/java/index.html
@@ -395,7 +395,7 @@
 
 <ul class="code-list">
   <li>
-    <a href="/quickstart/#/okta-sign-in-page/java/generic/" class="code-button inverse">
+    <a href="/quickstart/#/okta-sign-in-page/java/spring/" class="code-button inverse">
       <span class="code-icon launch-16"></span><span>Authentication Quick Start Guide</span>
     </a>
   </li>
@@ -480,8 +480,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/java/jwt-validation.html
+++ b/code/java/jwt-validation.html
@@ -523,8 +523,6 @@ you could plug in the <code class="highlighter-rouge">okta-jwt-verifier</code> i
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/java/okta-openidconnect-appauth-sample-android.html
+++ b/code/java/okta-openidconnect-appauth-sample-android.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/java/oktasdk-java.html
+++ b/code/java/oktasdk-java.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/java/spring_security_saml.html
+++ b/code/java/spring_security_saml.html
@@ -814,8 +814,6 @@ methods above, then you’re done.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/javascript/index.html
+++ b/code/javascript/index.html
@@ -480,8 +480,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/javascript/okta_auth_sdk.html
+++ b/code/javascript/okta_auth_sdk.html
@@ -687,8 +687,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/javascript/okta_auth_sdk_ref.html
+++ b/code/javascript/okta_auth_sdk_ref.html
@@ -1965,8 +1965,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/javascript/okta_sign-in_widget.html
+++ b/code/javascript/okta_sign-in_widget.html
@@ -885,8 +885,6 @@ web browser.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/javascript/okta_sign-in_widget_ref.html
+++ b/code/javascript/okta_sign-in_widget_ref.html
@@ -1491,8 +1491,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/nodejs/index.html
+++ b/code/nodejs/index.html
@@ -473,8 +473,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/php/index.html
+++ b/code/php/index.html
@@ -481,8 +481,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/php/jwt-validation.html
+++ b/code/php/jwt-validation.html
@@ -587,8 +587,6 @@ enough time to prevent most issues in regards to expire time and issued at time.
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/php/quickstart-signin-widget.html
+++ b/code/php/quickstart-signin-widget.html
@@ -725,8 +725,6 @@ However, in an emergency situation you can still stay in sync with Okta’s key 
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/php/simplesamlphp.html
+++ b/code/php/simplesamlphp.html
@@ -788,8 +788,6 @@ please reach out to us at: <a href="mailto:developers@okta.com">developers@okta.
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/python/index.html
+++ b/code/python/index.html
@@ -479,8 +479,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/python/pysaml2.html
+++ b/code/python/pysaml2.html
@@ -678,8 +678,6 @@ please reach out to me at: joel.franusic@okta.com.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/python/quickstart.html
+++ b/code/python/quickstart.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/python/sdk.html
+++ b/code/python/sdk.html
@@ -445,8 +445,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/react/index.html
+++ b/code/react/index.html
@@ -462,8 +462,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/react/okta_react.html
+++ b/code/react/okta_react.html
@@ -788,8 +788,6 @@ To provide a fully featured and customizable login experience, the <a href="/cod
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/code/react/okta_react_sign-in_widget.html
+++ b/code/react/okta_react_sign-in_widget.html
@@ -787,8 +787,6 @@ To provide a fully featured and customizable login experience, the <a href="/cod
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/contact/index.html
+++ b/contact/index.html
@@ -209,8 +209,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/getting_started/api_test_client.html
+++ b/docs/api/getting_started/api_test_client.html
@@ -471,8 +471,6 @@ Replace URL and body variables with the IDs of the resources you wish to specify
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/getting_started/design_principles.html
+++ b/docs/api/getting_started/design_principles.html
@@ -804,8 +804,6 @@ For all endpoints not listed, the API rate limit is a combined 10,000 requests p
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/getting_started/enabling_cors.html
+++ b/docs/api/getting_started/enabling_cors.html
@@ -519,8 +519,6 @@ SCRIPT7002: XMLHttpRequest: Network Error 0x80070005, Access is denied.
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
       <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
     

--- a/docs/api/getting_started/getting_a_token.html
+++ b/docs/api/getting_started/getting_a_token.html
@@ -337,8 +337,6 @@ user with only the permission levels you need for the token to perform the API t
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/getting_started/releases-at-okta.html
+++ b/docs/api/getting_started/releases-at-okta.html
@@ -481,8 +481,6 @@ Such features may spend more than one month between preview and production for t
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/apps.html
+++ b/docs/api/resources/apps.html
@@ -8194,8 +8194,6 @@ MIIC4DCCAcgCAQAwcTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNh
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/authn.html
+++ b/docs/api/resources/authn.html
@@ -8178,8 +8178,6 @@ Currently this is available only during <a href="#step-up-authentication">step-u
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/events.html
+++ b/docs/api/resources/events.html
@@ -1644,8 +1644,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/factor_admin.html
+++ b/docs/api/resources/factor_admin.html
@@ -875,8 +875,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/factors.html
+++ b/docs/api/resources/factors.html
@@ -4575,8 +4575,6 @@ Or, you can pass the existing phone number in a profile object.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/groups.html
+++ b/docs/api/resources/groups.html
@@ -2889,8 +2889,6 @@ The maximum value for limit is 300.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/idps.html
+++ b/docs/api/resources/idps.html
@@ -8451,8 +8451,6 @@ This object is used for dynamic discovery of related resources and lifecycle ope
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/oauth-clients.html
+++ b/docs/api/resources/oauth-clients.html
@@ -1143,8 +1143,6 @@ then no redirect URI or response type is necessary. In these cases you can pass 
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/oauth2.html
+++ b/docs/api/resources/oauth2.html
@@ -3956,8 +3956,6 @@ Token expiration times depend on how they are defined in the rules, and which po
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/oidc.html
+++ b/docs/api/resources/oidc.html
@@ -1756,8 +1756,6 @@ Generally speaking, the scopes specified in a request are included in the Access
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/policy.html
+++ b/docs/api/resources/policy.html
@@ -2564,8 +2564,6 @@ Application sign-on policy can’t be configured via the API.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/roles.html
+++ b/docs/api/resources/roles.html
@@ -1159,8 +1159,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/schemas.html
+++ b/docs/api/resources/schemas.html
@@ -2803,8 +2803,6 @@ A property cannot be removed if it is being referenced as a <a href="./idps.html
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/sessions.html
+++ b/docs/api/resources/sessions.html
@@ -1279,8 +1279,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/social_authentication.html
+++ b/docs/api/resources/social_authentication.html
@@ -868,8 +868,6 @@ ok -> ua: 302 to redirect_uri
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/system_log.html
+++ b/docs/api/resources/system_log.html
@@ -1667,8 +1667,6 @@ can use the following <code class="highlighter-rouge">curl</code> command to see
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/templates.html
+++ b/docs/api/resources/templates.html
@@ -976,8 +976,6 @@ provided in pairs: the language and translated template text.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/tokens.html
+++ b/docs/api/resources/tokens.html
@@ -346,8 +346,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/users.html
+++ b/docs/api/resources/users.html
@@ -4454,8 +4454,6 @@ For more information about <code class="highlighter-rouge">login</code>, see <a 
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/api/resources/zones.html
+++ b/docs/api/resources/zones.html
@@ -1141,8 +1141,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/how-to/beta-auth-service/api-access-management-troubleshooting.html
+++ b/docs/how-to/beta-auth-service/api-access-management-troubleshooting.html
@@ -355,8 +355,6 @@ Token expiration times depend on how they are defined in the rules, and which po
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/how-to/byo_saml.html
+++ b/docs/how-to/byo_saml.html
@@ -647,8 +647,6 @@ Content-Type: application/json;charset=UTF-8
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/how-to/inbound-saml-with-oidc.html
+++ b/docs/how-to/inbound-saml-with-oidc.html
@@ -346,8 +346,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/how-to/set-up-auth-server.html
+++ b/docs/how-to/set-up-auth-server.html
@@ -583,8 +583,6 @@ Be sure to check that your expression returns the results expected–the express
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/how-to/sharing-cert.html
+++ b/docs/how-to/sharing-cert.html
@@ -508,8 +508,6 @@ using the same certificate to sign assertions.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/how-to/updating_saml_cert.html
+++ b/docs/how-to/updating_saml_cert.html
@@ -601,8 +601,6 @@ sure to note the certificate format that the decoder service requires.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes.html
+++ b/docs/platform-release-notes/platform-release-notes.html
@@ -296,8 +296,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-23.html
+++ b/docs/platform-release-notes/platform-release-notes2016-23.html
@@ -294,8 +294,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-24.html
+++ b/docs/platform-release-notes/platform-release-notes2016-24.html
@@ -305,8 +305,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-25.html
+++ b/docs/platform-release-notes/platform-release-notes2016-25.html
@@ -312,8 +312,6 @@ If more than 100 groups match the filter, then the request fails.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-26.html
+++ b/docs/platform-release-notes/platform-release-notes2016-26.html
@@ -311,8 +311,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-27.html
+++ b/docs/platform-release-notes/platform-release-notes2016-27.html
@@ -332,8 +332,6 @@ after <a href="https://support.okta.com/help/articles/Knowledge_Article/Current-
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-28.html
+++ b/docs/platform-release-notes/platform-release-notes2016-28.html
@@ -358,8 +358,6 @@ and <a href="/docs/api/resources/authn#answer-recovery-question">Answer Recovery
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-29.html
+++ b/docs/platform-release-notes/platform-release-notes2016-29.html
@@ -308,8 +308,6 @@ Existing SAML IdP instances will continue to use the certificate they currently 
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-30.html
+++ b/docs/platform-release-notes/platform-release-notes2016-30.html
@@ -330,8 +330,6 @@ and specify the value <code class="highlighter-rouge">CUSTOM_ATTRIBUTE</code> in
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-31.html
+++ b/docs/platform-release-notes/platform-release-notes2016-31.html
@@ -313,8 +313,6 @@ see <a href="https://github.com/okta/okta-auth-js/releases/tag/okta-auth-js-1.4.
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-33.html
+++ b/docs/platform-release-notes/platform-release-notes2016-33.html
@@ -296,8 +296,6 @@ failed to receive <code class="highlighter-rouge">expires_in</code> and <code cl
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-34.html
+++ b/docs/platform-release-notes/platform-release-notes2016-34.html
@@ -304,8 +304,6 @@ This failure occurred if the username was in both the username and email and a s
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-35.html
+++ b/docs/platform-release-notes/platform-release-notes2016-35.html
@@ -322,8 +322,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-36.html
+++ b/docs/platform-release-notes/platform-release-notes2016-36.html
@@ -292,8 +292,6 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-37.html
+++ b/docs/platform-release-notes/platform-release-notes2016-37.html
@@ -293,8 +293,6 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-39.html
+++ b/docs/platform-release-notes/platform-release-notes2016-39.html
@@ -309,8 +309,6 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-40.html
+++ b/docs/platform-release-notes/platform-release-notes2016-40.html
@@ -294,8 +294,6 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-41.html
+++ b/docs/platform-release-notes/platform-release-notes2016-41.html
@@ -354,8 +354,6 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-43.html
+++ b/docs/platform-release-notes/platform-release-notes2016-43.html
@@ -352,8 +352,6 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-45.html
+++ b/docs/platform-release-notes/platform-release-notes2016-45.html
@@ -328,8 +328,6 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-46.html
+++ b/docs/platform-release-notes/platform-release-notes2016-46.html
@@ -293,8 +293,6 @@ scroll to the bottom of the Admin <b>Dashboard</b> page to see the version numbe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-47.html
+++ b/docs/platform-release-notes/platform-release-notes2016-47.html
@@ -291,8 +291,6 @@ scroll to the bottom of the Admin <strong>Dashboard</strong> page to see the ver
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-49.html
+++ b/docs/platform-release-notes/platform-release-notes2016-49.html
@@ -311,8 +311,6 @@ scroll to the bottom of the Admin <strong>Dashboard</strong> page to see the ver
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-50.html
+++ b/docs/platform-release-notes/platform-release-notes2016-50.html
@@ -310,8 +310,6 @@ scroll to the bottom of the Admin <strong>Dashboard</strong> page to see the ver
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-51.html
+++ b/docs/platform-release-notes/platform-release-notes2016-51.html
@@ -307,8 +307,6 @@ As of 2016.51, HAL links for these three operations are returned only if the pol
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-52.html
+++ b/docs/platform-release-notes/platform-release-notes2016-52.html
@@ -296,8 +296,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2016-index.html
+++ b/docs/platform-release-notes/platform-release-notes2016-index.html
@@ -306,8 +306,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-02.html
+++ b/docs/platform-release-notes/platform-release-notes2017-02.html
@@ -310,8 +310,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-03.html
+++ b/docs/platform-release-notes/platform-release-notes2017-03.html
@@ -353,8 +353,6 @@ but is now 401. (OKTA-111888)</li>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-04.html
+++ b/docs/platform-release-notes/platform-release-notes2017-04.html
@@ -312,8 +312,6 @@ the pre-filled default values include all grant types and the <code class="highl
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-05.html
+++ b/docs/platform-release-notes/platform-release-notes2017-05.html
@@ -320,8 +320,6 @@ include <code class="highlighter-rouge">ID Tokens</code>, <code class="highlight
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-09.html
+++ b/docs/platform-release-notes/platform-release-notes2017-09.html
@@ -328,8 +328,6 @@ link. This feature will be in preview for at least a month.
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-10.html
+++ b/docs/platform-release-notes/platform-release-notes2017-10.html
@@ -319,8 +319,6 @@ point, the warnings in the System Log will change to error notifications.</li>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-11.html
+++ b/docs/platform-release-notes/platform-release-notes2017-11.html
@@ -339,8 +339,6 @@ returned the user’s status as ACTIVE rather than RECOVERY. (OKTA-109772)</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-12.html
+++ b/docs/platform-release-notes/platform-release-notes2017-12.html
@@ -323,8 +323,6 @@ point, the warnings in the System Log will change to error notifications.</li>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-15.html
+++ b/docs/platform-release-notes/platform-release-notes2017-15.html
@@ -366,8 +366,6 @@ for requests when the user is in a PROVISIONED state but doesn’t have a passwo
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-16.html
+++ b/docs/platform-release-notes/platform-release-notes2017-16.html
@@ -396,8 +396,6 @@ This feature is Generally Available in preview orgs for at least one month befor
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-17.html
+++ b/docs/platform-release-notes/platform-release-notes2017-17.html
@@ -431,8 +431,6 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-18.html
+++ b/docs/platform-release-notes/platform-release-notes2017-18.html
@@ -422,8 +422,6 @@ For more information, see the <a href="/docs/api/resources/idps.html#social-auth
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-19.html
+++ b/docs/platform-release-notes/platform-release-notes2017-19.html
@@ -417,8 +417,6 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-20.html
+++ b/docs/platform-release-notes/platform-release-notes2017-20.html
@@ -426,8 +426,6 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-21.html
+++ b/docs/platform-release-notes/platform-release-notes2017-21.html
@@ -401,8 +401,6 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-22.html
+++ b/docs/platform-release-notes/platform-release-notes2017-22.html
@@ -399,8 +399,6 @@ Okta expects to deliver this feature in production orgs (with the same Okta .NET
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-23.html
+++ b/docs/platform-release-notes/platform-release-notes2017-23.html
@@ -471,8 +471,6 @@ As outlined in <a href="/docs/api/getting_started/design_principles.html#links-i
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-24.html
+++ b/docs/platform-release-notes/platform-release-notes2017-24.html
@@ -407,8 +407,6 @@ Previously these notifications appeared only in the System Log (<code class="hig
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-25.html
+++ b/docs/platform-release-notes/platform-release-notes2017-25.html
@@ -381,8 +381,6 @@ encountered an invalid_client error, the response did not include the WWW­Authe
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-26.html
+++ b/docs/platform-release-notes/platform-release-notes2017-26.html
@@ -340,8 +340,6 @@ response code was 500 rather than 400. (OKTA-126223)</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-27.html
+++ b/docs/platform-release-notes/platform-release-notes2017-27.html
@@ -355,8 +355,6 @@ Okta SDK <code class="highlighter-rouge">EventsAPIClient</code>.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-28.html
+++ b/docs/platform-release-notes/platform-release-notes2017-28.html
@@ -396,8 +396,6 @@ To enable an EA feature, contact Okta Support.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-29.html
+++ b/docs/platform-release-notes/platform-release-notes2017-29.html
@@ -344,8 +344,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-30.html
+++ b/docs/platform-release-notes/platform-release-notes2017-30.html
@@ -349,8 +349,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-31.html
+++ b/docs/platform-release-notes/platform-release-notes2017-31.html
@@ -358,8 +358,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-32.html
+++ b/docs/platform-release-notes/platform-release-notes2017-32.html
@@ -366,8 +366,6 @@ Previously, application groups could only be retrieved with the Custom Authoriza
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-33.html
+++ b/docs/platform-release-notes/platform-release-notes2017-33.html
@@ -364,8 +364,6 @@ Previously, application groups could only be retrieved with the Custom Authoriza
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-34.html
+++ b/docs/platform-release-notes/platform-release-notes2017-34.html
@@ -346,8 +346,6 @@ This API can be enabled beginning August 22, 2017 for preview orgs, and beginnin
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-35.html
+++ b/docs/platform-release-notes/platform-release-notes2017-35.html
@@ -328,8 +328,6 @@ This API can be enabled beginning August 22, 2017 for preview orgs, and beginnin
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/docs/platform-release-notes/platform-release-notes2017-index.html
+++ b/docs/platform-release-notes/platform-release-notes2017-index.html
@@ -310,8 +310,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -349,11 +349,11 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     
+    
+      <script type="text/javascript" src="/assets/docsIndex-546112c9ccd98aac94c723bd879eaf56c04eecab1db2ede2e00d1e721f6de5af.js"></script>
     
 
   <!-- START Post Footer -->

--- a/documentation/stormpath-import.html
+++ b/documentation/stormpath-import.html
@@ -1010,8 +1010,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/error.html
+++ b/error.html
@@ -211,8 +211,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/index.html
+++ b/index.html
@@ -352,8 +352,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/integrate_with_okta/index.html
+++ b/integrate_with_okta/index.html
@@ -293,8 +293,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/oidc_playground/index.html
+++ b/oidc_playground/index.html
@@ -194,8 +194,6 @@ function loadPlayground (iframe) {
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/pricing-preview/index.html
+++ b/pricing-preview/index.html
@@ -420,8 +420,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -335,8 +335,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/product/index.html
+++ b/product/index.html
@@ -792,8 +792,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/quickstart/index.html
+++ b/quickstart/index.html
@@ -214,11 +214,11 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     
+    
+      <script type="text/javascript" src="/assets/quickstart-5d853038b86916fba9048db44f99ab97f96facb97b3106518a345e7f1d277f79.js"></script>
     
 
     <!-- END Footer -->

--- a/reference/api_reference.html
+++ b/reference/api_reference.html
@@ -276,8 +276,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/reference/authentication_reference.html
+++ b/reference/authentication_reference.html
@@ -276,8 +276,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/reference/error_codes/index.html
+++ b/reference/error_codes/index.html
@@ -782,8 +782,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/reference/getting_started.html
+++ b/reference/getting_started.html
@@ -276,8 +276,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/reference/okta_expression_language/index.html
+++ b/reference/okta_expression_language/index.html
@@ -1311,8 +1311,6 @@ Note: At this time, only <strong>active_directory</strong> is supported for <em>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/reference/platform_release_notes.html
+++ b/reference/platform_release_notes.html
@@ -276,8 +276,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/search/index.html
+++ b/search/index.html
@@ -218,8 +218,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/signup/index.html
+++ b/signup/index.html
@@ -261,8 +261,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/signup/stormpath/index.html
+++ b/signup/stormpath/index.html
@@ -269,8 +269,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/signup/thank-you/index.html
+++ b/signup/thank-you/index.html
@@ -207,8 +207,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/standards/OAuth/index.html
+++ b/standards/OAuth/index.html
@@ -887,8 +887,6 @@ However, you can also use OpenID Connect with a Custom Authorization Server:</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/standards/OIDC/index.html
+++ b/standards/OIDC/index.html
@@ -804,8 +804,6 @@ For more information about configuring an app for OpenID Connect, including grou
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/standards/SAML/index.html
+++ b/standards/SAML/index.html
@@ -474,8 +474,6 @@ can help you build your applications and integrations:</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/standards/SAML/saml_tracer.html
+++ b/standards/SAML/saml_tracer.html
@@ -513,8 +513,6 @@ RKvwyyTfqfq9pgSmB9xNVJIeVZbbZGTlNGqJti24E0AiIPggtxg5NJ+HHnEQ5RxdSsR4fbMz9i0K
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/standards/SAML/setting_up_a_saml_application_in_okta.html
+++ b/standards/SAML/setting_up_a_saml_application_in_okta.html
@@ -373,8 +373,6 @@ opened in step #10 contains the information that you’ll need to configure SAML
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/standards/SCIM/index.html
+++ b/standards/SCIM/index.html
@@ -2146,8 +2146,6 @@ only happen if the User table isn’t defined.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/terms/index.html
+++ b/terms/index.html
@@ -292,8 +292,6 @@ DEVELOPER EDITION LICENSE AGREEMENT</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/test_page/index.html
+++ b/test_page/index.html
@@ -315,8 +315,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/api_access_management/index.html
+++ b/use_cases/api_access_management/index.html
@@ -363,8 +363,6 @@ This benefit depends, of course, on the level of security your apps require.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/authentication/index.html
+++ b/use_cases/authentication/index.html
@@ -386,8 +386,6 @@ secure your API as well as manage OpenID Connect for your customer app.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/authentication/session_cookie.html
+++ b/use_cases/authentication/session_cookie.html
@@ -449,8 +449,6 @@ that contains the the session token as query parameter <code class="highlighter-
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/integrate_with_okta/index.html
+++ b/use_cases/integrate_with_okta/index.html
@@ -290,8 +290,6 @@ with Okta’s enterprise-grade identity management solution. The OIN provides a 
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/integrate_with_okta/oan-faqs.html
+++ b/use_cases/integrate_with_okta/oan-faqs.html
@@ -384,8 +384,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/integrate_with_okta/promotion.html
+++ b/use_cases/integrate_with_okta/promotion.html
@@ -399,8 +399,6 @@ Raising awareness for your integration among joint customers and new prospects h
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/integrate_with_okta/provisioning.html
+++ b/use_cases/integrate_with_okta/provisioning.html
@@ -292,8 +292,6 @@ Get started by reviewing the program process, SCIM docs, and applying to the pro
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/integrate_with_okta/sso-with-saml.html
+++ b/use_cases/integrate_with_okta/sso-with-saml.html
@@ -332,8 +332,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/mfa/index.html
+++ b/use_cases/mfa/index.html
@@ -520,8 +520,6 @@ These instructions only cover part of what is covered in the video.</li>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/mobile/okta_mobile_connect.html
+++ b/use_cases/mobile/okta_mobile_connect.html
@@ -412,8 +412,6 @@ which includes an example of how to add SAML support to an iOS app.</p>
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/sso_and_provisioning/draft.html
+++ b/use_cases/sso_and_provisioning/draft.html
@@ -276,8 +276,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/users_groups_applications/draft.html
+++ b/use_cases/users_groups_applications/draft.html
@@ -276,8 +276,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     

--- a/use_cases/web_development/draft.html
+++ b/use_cases/web_development/draft.html
@@ -276,8 +276,6 @@
 </footer>
 
     <script type="text/javascript" src="/assets/master-0365dd27cf276cb2a15c0a43906ca592538204cf1ad4557547bf4e50609b411e.js"></script>
-    <script type="text/javascript" src="/assets/quickstart-26919e2a466e6346d96282973427a3998da81637fd2a2ceb6917a61da7eaf2a8.js"></script>
-    <script type="text/javascript" src="/assets/docsIndex-aebe0e7212e0f2974ef463f06967cba7144f5eed4f14bb11c346866f3fd4ecb7.js"></script>    
     
     
     


### PR DESCRIPTION
## Description:
Previously, the documentation (index) and quickstart pages had global scripts running on every page. To enhance performance:
- Move uncommon `.js` scripts to load only on desired page.


