### PR TITLE
:bug: Fix code pages showing up incorrectly in search results

### DIFF
--- a/_source/_code/angular/index.md
+++ b/_source/_code/angular/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Angular
+title: Add Okta Authentication to your Angular App
+language: Angular
 integration: client
 ---
 

--- a/_source/_code/angular/okta_angular_auth_js.md
+++ b/_source/_code/angular/okta_angular_auth_js.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Angular
+title: Okta Auth JS and Angular
+language: Angular
 weight: 20
 excerpt: Integrate Okta with an Angular application using Auth JS.
 ---

--- a/_source/_code/angular/okta_angular_sign-in_widget.md
+++ b/_source/_code/angular/okta_angular_sign-in_widget.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Angular
+title: Okta Sign-In Widget and Angular
+language: Angular
 weight: 20
 excerpt: Integrate Okta with an Angular application using the Sign-In Widget.
 ---

--- a/_source/_code/dotnet/index.md
+++ b/_source/_code/dotnet/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: .NET
+title: Add Okta to your .NET app
+language: .NET
 integration: server
 ---
 

--- a/_source/_code/dotnet/jwt-validation.md
+++ b/_source/_code/dotnet/jwt-validation.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: JWT Validation Guide
+language: .NET
 excerpt: How to manually validate Okta JWTs with .NET (C#).
 support_email: developers@okta.com
 ---

--- a/_source/_code/dotnet/okta-oauth-aspnet-codeflow.md
+++ b/_source/_code/dotnet/okta-oauth-aspnet-codeflow.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: OAuth Authorization Code Flow Sample
+language: .NET
 excerpt: Code sample demonstrating the use of OpenID Connect with Okta and the <i>Microsoft.<wbr>Owin.<wbr>Security.OpenIdConnect</i> library.
 github_url: https://github.com/oktadeveloper/okta-oauth-aspnet-codeflow
 weight: 2

--- a/_source/_code/dotnet/okta-oauth-spa-authjs-osw.md
+++ b/_source/_code/dotnet/okta-oauth-spa-authjs-osw.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: OpenID Connect with Single Page Application
+language: .NET
 excerpt: OpenID Connect/OAuth code sample (implicit flow) with Okta Authentication JS SDK, Okta Sign In Widget and ASP.NET resource server.
 github_url: https://github.com/oktadeveloper/okta-oauth-spa-authjs-osw
 weight: 3

--- a/_source/_code/dotnet/okta-oidc-spa-osw-aspnet.md
+++ b/_source/_code/dotnet/okta-oidc-spa-osw-aspnet.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: OpenID Connect with ASP.NET
+language: .NET
 excerpt: OpenID Connect code sample with Okta using an ASP.NET MVC Single Page Application calling an ASP.NET Web API.
 github_url: https://github.com/oktadeveloper/okta-oidc-spa-osw-aspnet
 weight: 4

--- a/_source/_code/dotnet/quickstart.md
+++ b/_source/_code/dotnet/quickstart.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Okta Sign-In Widget
+title: Okta Sign-In Widget and .NET
+language: .NET
 excerpt: Quickstart guide for using the Okta Sign-In Widget with .NET.
 support_email: developers@okta.com
 weight: 1

--- a/_source/_code/dotnet/sample_application.md
+++ b/_source/_code/dotnet/sample_application.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: Okta Music Store
+language: .NET
 excerpt: The Okta Music Store is a sample application written in .NET and is a demonstration of how to add Okta as an identity provider for an existing application.
 redirect_from: "/docs/examples/dotnet_sample_application.html"
 weight: 6

--- a/_source/_code/dotnet/sdk.md
+++ b/_source/_code/dotnet/sdk.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: Okta API .NET SDK
+language: .NET
 excerpt: .NET bindings for the Okta API. <a href="/docs/sdk/core/csharp_api_sdk/html/6af60b57-62fa-477c-a899-e2f21286c53d.htm">Get started now</a>.
 github_url: https://github.com/okta/okta-sdk-dotnet
 weight: 1

--- a/_source/_code/ios/index.md
+++ b/_source/_code/ios/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: iOS
+title: Add Okta authentication to your Swift app
+language: iOS
 integration: client
 ---
 

--- a/_source/_code/ios/quickstart-appauth-swift.md
+++ b/_source/_code/ios/quickstart-appauth-swift.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: Okta + AppAuth Auth SDK
+language: iOS
 weight: 20
 excerpt: Integrate Okta with an iOS native application using OktaAuth.
 ---

--- a/_source/_code/java/index.md
+++ b/_source/_code/java/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Java
+title: Add Okta authentication to your Java app
+language: Java
 integration: server
 ---
 

--- a/_source/_code/java/jwt-validation.md
+++ b/_source/_code/java/jwt-validation.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: JWT Validation Guide
+language: Java
 excerpt: How to validate Okta JWTs with Java.
 support_email: developers@okta.com
 weight: 2

--- a/_source/_code/java/okta-openidconnect-appauth-sample-android.md
+++ b/_source/_code/java/okta-openidconnect-appauth-sample-android.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: Android Native Application with AppAuth
+language: Java
 excerpt: Sample application for communicating with OAuth 2.0 and OpenID Connect providers. Demonstrates single-sign-on (SSO) with AppAuth for Android.
 github_url: https://github.com/oktadeveloper/okta-openidconnect-appauth-sample-android
 weight: 3

--- a/_source/_code/java/oktasdk-java.md
+++ b/_source/_code/java/oktasdk-java.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: Okta SDK
+language: Java
 excerpt: Java bindings for the Okta API. <a href="https://developer.okta.com/okta-sdk-java/apidocs/">Documentation here</a>.
 github_url: https://github.com/okta/okta-sdk-java
 weight: 1

--- a/_source/_code/java/spring_security_saml.md
+++ b/_source/_code/java/spring_security_saml.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: Spring Security SAML
+language: Java
 excerpt: Guidance on how to SAML-enable your application using open source Spring Security library.
 redirect_from: "/docs/examples/spring_security_saml.html"
 weight: 4

--- a/_source/_code/javascript/index.md
+++ b/_source/_code/javascript/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: JavaScript
+title: Add Okta authentication to your JavaScript app
+language: JavaScript
 integration: client
 ---
 

--- a/_source/_code/javascript/okta_auth_sdk.md
+++ b/_source/_code/javascript/okta_auth_sdk.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: JavaScript
+title: Okta Auth JS SDK
+language: JavaScript
 weight: 10
 excerpt: A JavaScript wrapper for Okta's Authentication APIs.
 ---

--- a/_source/_code/javascript/okta_auth_sdk_ref.md
+++ b/_source/_code/javascript/okta_auth_sdk_ref.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: JavaScript 
+title: Okta Auth SDK Reference
+language: JavaScript
 weight: 100
 hide_from_layout: 0
 excerpt: Reference information for customizing the Okta Auth SDK.

--- a/_source/_code/javascript/okta_sign-in_widget.md
+++ b/_source/_code/javascript/okta_sign-in_widget.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: JavaScript
+title: Okta Sign-In Widget
+language: JavaScript
 excerpt: A drop-in widget with custom UI capabilities to power sign-in with Okta.
 weight: 1
 redirect_from:

--- a/_source/_code/javascript/okta_sign-in_widget_ref.md
+++ b/_source/_code/javascript/okta_sign-in_widget_ref.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: JavaScript
+title: Okta Sign-In Widget Reference
+language: JavaScript
 weight: 100
 hide_from_layout: 0
 excerpt: Reference information for customizing the Okta Sign-In Widget.

--- a/_source/_code/nodejs/index.md
+++ b/_source/_code/nodejs/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Node.js
+title: Add Okta authentication to your Node.js app
+language: Node.js
 integration: server
 ---
 

--- a/_source/_code/php/index.md
+++ b/_source/_code/php/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: PHP
+title: Add Okta authentication to your PHP app
+language: PHP
 integration: server
 ---
 

--- a/_source/_code/php/jwt-validation.md
+++ b/_source/_code/php/jwt-validation.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: PHP
+title: Validate Okta JWTs with PHP
+language: PHP
 excerpt: How to validate Okta JWTs with PHP.
 support_email: developers@okta.com
 ---

--- a/_source/_code/php/quickstart-signin-widget.md
+++ b/_source/_code/php/quickstart-signin-widget.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: PHP
+title: Okta Sign-In Widget with PHP
+language: PHP
 excerpt: Quickstart guide for using the Okta Sign-In Widget with PHP
 support_email: developers@okta.com
 weight: 1

--- a/_source/_code/php/simplesamlphp.md
+++ b/_source/_code/php/simplesamlphp.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: PHP
+title: SimpleSAMPphp
+language: PHP
 excerpt: How to use SimpleSAMLphp to add support for Okta via SAML.
 support_email: developers@okta.com
 weight: 2

--- a/_source/_code/python/index.md
+++ b/_source/_code/python/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Python
+title: Add Okta authentication to your Python app
+language: Python
 integration: server
 ---
 

--- a/_source/_code/python/pysaml2.md
+++ b/_source/_code/python/pysaml2.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Python
+title: SAML-enable your Python application
+language: Python
 excerpt: Guidance on how to SAML-enable your Python application using open source PySAML2.
 chiclet_name: PySAML2 Example
 programming_language: Python

--- a/_source/_code/python/quickstart.md
+++ b/_source/_code/python/quickstart.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: Python
+title: Okta Sign-In Widget with Python
+language: Python
 excerpt: Quickstart guide for using the Okta Sign-In Widget with Python.
 support_email: developers@okta.com
 weight: 1

--- a/_source/_code/python/sdk.md
+++ b/_source/_code/python/sdk.md
@@ -1,6 +1,7 @@
 ---
 layout: software
 title: Okta API Python SDK
+language: Python
 excerpt: Python bindings for the Okta API. <a href="/docs/sdk/core/python_api_sdk/">Documentation here</a>.
 github_url: https://github.com/okta/okta-sdk-python
 weight: 1

--- a/_source/_code/react/index.md
+++ b/_source/_code/react/index.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: React
+title: Add Okta authentication to your React app
+language: React
 integration: client
 ---
 

--- a/_source/_code/react/okta_react.md
+++ b/_source/_code/react/okta_react.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: React
+title: Okta Auth JS and React
+language: React
 weight: 30
 excerpt: Integrate Okta with a React app using Auth JS.
 ---

--- a/_source/_code/react/okta_react_sign-in_widget.md
+++ b/_source/_code/react/okta_react_sign-in_widget.md
@@ -1,6 +1,7 @@
 ---
 layout: software
-title: React
+title: Okta Sign-In Widget and React
+language: React
 weight: 30
 excerpt: Integrate Okta with a React app using the Sign-In Widget.
 ---

--- a/_source/_layouts/software.html
+++ b/_source/_layouts/software.html
@@ -29,8 +29,8 @@
               {% endunless %}
               {% assign language = parts[2] %}
               {% assign element = index %}
-              <li {% if element.title == page.title %}class="is-active"{% endif %}>
-                <a href="/code/{{ language | prepend: site.baseurl }}/">{{ element.title | upcase }}</a>
+              <li {% if element.language == page.language %}class="is-active"{% endif %}>
+                <a href="/code/{{ language | prepend: site.baseurl }}/">{{ element.language | upcase }}</a>
               </li>
             {% endfor %}
           </ul>
@@ -50,8 +50,8 @@
               {% endunless %}
               {% assign language = parts[2] %}
               {% assign element = index %}
-              <li {% if element.title == page.title %}class="is-active"{% endif %}>
-                <a href="/code/{{ language | prepend: site.baseurl }}/">{{ element.title | upcase }}</a>
+              <li {% if element.language == page.language %}class="is-active"{% endif %}>
+                <a href="/code/{{ language | prepend: site.baseurl }}/">{{ element.language | upcase }}</a>
               </li>
             {% endfor %}
           </ul>

--- a/code/angular/index.html
+++ b/code/angular/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Angular | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta Authentication to your Angular App | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta authentication to your Angular app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Angular | Okta Developer</title>
+  <title>Add Okta Authentication to your Angular App | Okta Developer</title>
   <meta name="description" content="Add Okta authentication to your Angular app">
   <link rel="canonical" href="https://developer.okta.com/code/angular/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/angular/okta_angular_auth_js.html
+++ b/code/angular/okta_angular_auth_js.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Angular | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Auth JS and Angular | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Integrate Okta with an Angular application using Auth JS." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Angular | Okta Developer</title>
+  <title>Okta Auth JS and Angular | Okta Developer</title>
   <meta name="description" content="Integrate Okta with an Angular application using Auth JS.">
   <link rel="canonical" href="https://developer.okta.com/code/angular/okta_angular_auth_js">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/angular/okta_angular_sign-in_widget.html
+++ b/code/angular/okta_angular_sign-in_widget.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Angular | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Sign-In Widget and Angular | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Integrate Okta with an Angular application using the Sign-In Widget." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Angular | Okta Developer</title>
+  <title>Okta Sign-In Widget and Angular | Okta Developer</title>
   <meta name="description" content="Integrate Okta with an Angular application using the Sign-In Widget.">
   <link rel="canonical" href="https://developer.okta.com/code/angular/okta_angular_sign-in_widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/dotnet/index.html
+++ b/code/dotnet/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content=".NET | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta to your .NET app | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta to your .NET app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>.NET | Okta Developer</title>
+  <title>Add Okta to your .NET app | Okta Developer</title>
   <meta name="description" content="Add Okta to your .NET app">
   <link rel="canonical" href="https://developer.okta.com/code/dotnet/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/dotnet/jwt-validation.html
+++ b/code/dotnet/jwt-validation.html
@@ -273,7 +273,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/dotnet/">.NET</a>
               </li>
             

--- a/code/dotnet/okta-oauth-aspnet-codeflow.html
+++ b/code/dotnet/okta-oauth-aspnet-codeflow.html
@@ -273,7 +273,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/dotnet/">.NET</a>
               </li>
             

--- a/code/dotnet/okta-oauth-spa-authjs-osw.html
+++ b/code/dotnet/okta-oauth-spa-authjs-osw.html
@@ -273,7 +273,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/dotnet/">.NET</a>
               </li>
             

--- a/code/dotnet/okta-oidc-spa-osw-aspnet.html
+++ b/code/dotnet/okta-oidc-spa-osw-aspnet.html
@@ -273,7 +273,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/dotnet/">.NET</a>
               </li>
             

--- a/code/dotnet/quickstart.html
+++ b/code/dotnet/quickstart.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Okta Sign-In Widget | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Sign-In Widget and .NET | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Quickstart guide for using the Okta Sign-In Widget with .NET." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Okta Sign-In Widget | Okta Developer</title>
+  <title>Okta Sign-In Widget and .NET | Okta Developer</title>
   <meta name="description" content="Quickstart guide for using the Okta Sign-In Widget with .NET.">
   <link rel="canonical" href="https://developer.okta.com/code/dotnet/quickstart">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->
@@ -273,7 +273,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/dotnet/">.NET</a>
               </li>
             

--- a/code/dotnet/sample_application.html
+++ b/code/dotnet/sample_application.html
@@ -273,7 +273,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/dotnet/">.NET</a>
               </li>
             

--- a/code/dotnet/sdk.html
+++ b/code/dotnet/sdk.html
@@ -273,7 +273,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/dotnet/">.NET</a>
               </li>
             

--- a/code/ios/index.html
+++ b/code/ios/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="iOS | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta authentication to your Swift app | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta authentication to your Swift app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>iOS | Okta Developer</title>
+  <title>Add Okta authentication to your Swift app | Okta Developer</title>
   <meta name="description" content="Add Okta authentication to your Swift app">
   <link rel="canonical" href="https://developer.okta.com/code/ios/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/ios/quickstart-appauth-swift.html
+++ b/code/ios/quickstart-appauth-swift.html
@@ -179,7 +179,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/ios/">IOS</a>
               </li>
             

--- a/code/java/index.html
+++ b/code/java/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Java | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta authentication to your Java app | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta authentication to your Java app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Java | Okta Developer</title>
+  <title>Add Okta authentication to your Java app | Okta Developer</title>
   <meta name="description" content="Add Okta authentication to your Java app">
   <link rel="canonical" href="https://developer.okta.com/code/java/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/java/jwt-validation.html
+++ b/code/java/jwt-validation.html
@@ -305,7 +305,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/java/">JAVA</a>
               </li>
             

--- a/code/java/okta-openidconnect-appauth-sample-android.html
+++ b/code/java/okta-openidconnect-appauth-sample-android.html
@@ -305,7 +305,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/java/">JAVA</a>
               </li>
             

--- a/code/java/oktasdk-java.html
+++ b/code/java/oktasdk-java.html
@@ -305,7 +305,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/java/">JAVA</a>
               </li>
             

--- a/code/java/spring_security_saml.html
+++ b/code/java/spring_security_saml.html
@@ -305,7 +305,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/java/">JAVA</a>
               </li>
             

--- a/code/javascript/index.html
+++ b/code/javascript/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="JavaScript | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta authentication to your JavaScript app | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta authentication to your JavaScript app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>JavaScript | Okta Developer</title>
+  <title>Add Okta authentication to your JavaScript app | Okta Developer</title>
   <meta name="description" content="Add Okta authentication to your JavaScript app">
   <link rel="canonical" href="https://developer.okta.com/code/javascript/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/javascript/okta_auth_sdk.html
+++ b/code/javascript/okta_auth_sdk.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="JavaScript | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Auth JS SDK | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="A JavaScript wrapper for Okta's Authentication APIs." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>JavaScript | Okta Developer</title>
+  <title>Okta Auth JS SDK | Okta Developer</title>
   <meta name="description" content="A JavaScript wrapper for Okta's Authentication APIs.">
   <link rel="canonical" href="https://developer.okta.com/code/javascript/okta_auth_sdk">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/javascript/okta_auth_sdk_ref.html
+++ b/code/javascript/okta_auth_sdk_ref.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="JavaScript | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Auth SDK Reference | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Reference information for customizing the Okta Auth SDK." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>JavaScript | Okta Developer</title>
+  <title>Okta Auth SDK Reference | Okta Developer</title>
   <meta name="description" content="Reference information for customizing the Okta Auth SDK.">
   <link rel="canonical" href="https://developer.okta.com/code/javascript/okta_auth_sdk_ref">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/javascript/okta_sign-in_widget.html
+++ b/code/javascript/okta_sign-in_widget.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="JavaScript | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Sign-In Widget | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="A drop-in widget with custom UI capabilities to power sign-in with Okta." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>JavaScript | Okta Developer</title>
+  <title>Okta Sign-In Widget | Okta Developer</title>
   <meta name="description" content="A drop-in widget with custom UI capabilities to power sign-in with Okta.">
   <link rel="canonical" href="https://developer.okta.com/code/javascript/okta_sign-in_widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/javascript/okta_sign-in_widget_ref.html
+++ b/code/javascript/okta_sign-in_widget_ref.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="JavaScript | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Sign-In Widget Reference | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Reference information for customizing the Okta Sign-In Widget." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>JavaScript | Okta Developer</title>
+  <title>Okta Sign-In Widget Reference | Okta Developer</title>
   <meta name="description" content="Reference information for customizing the Okta Sign-In Widget.">
   <link rel="canonical" href="https://developer.okta.com/code/javascript/okta_sign-in_widget_ref">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/nodejs/index.html
+++ b/code/nodejs/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Node.js | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta authentication to your Node.js app | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta authentication to your Node.js app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Node.js | Okta Developer</title>
+  <title>Add Okta authentication to your Node.js app | Okta Developer</title>
   <meta name="description" content="Add Okta authentication to your Node.js app">
   <link rel="canonical" href="https://developer.okta.com/code/nodejs/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/php/index.html
+++ b/code/php/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="PHP | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta authentication to your PHP app | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta authentication to your PHP app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>PHP | Okta Developer</title>
+  <title>Add Okta authentication to your PHP app | Okta Developer</title>
   <meta name="description" content="Add Okta authentication to your PHP app">
   <link rel="canonical" href="https://developer.okta.com/code/php/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/php/jwt-validation.html
+++ b/code/php/jwt-validation.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="PHP | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Validate Okta JWTs with PHP | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="How to validate Okta JWTs with PHP." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>PHP | Okta Developer</title>
+  <title>Validate Okta JWTs with PHP | Okta Developer</title>
   <meta name="description" content="How to validate Okta JWTs with PHP.">
   <link rel="canonical" href="https://developer.okta.com/code/php/jwt-validation">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/php/quickstart-signin-widget.html
+++ b/code/php/quickstart-signin-widget.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="PHP | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Sign-In Widget with PHP | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Quickstart guide for using the Okta Sign-In Widget with PHP" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>PHP | Okta Developer</title>
+  <title>Okta Sign-In Widget with PHP | Okta Developer</title>
   <meta name="description" content="Quickstart guide for using the Okta Sign-In Widget with PHP">
   <link rel="canonical" href="https://developer.okta.com/code/php/quickstart-signin-widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/php/simplesamlphp.html
+++ b/code/php/simplesamlphp.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="PHP | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="SimpleSAMPphp | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="How to use SimpleSAMLphp to add support for Okta via SAML." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>PHP | Okta Developer</title>
+  <title>SimpleSAMPphp | Okta Developer</title>
   <meta name="description" content="How to use SimpleSAMLphp to add support for Okta via SAML.">
   <link rel="canonical" href="https://developer.okta.com/code/php/simplesamlphp">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/python/index.html
+++ b/code/python/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Python | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta authentication to your Python app | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta authentication to your Python app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Python | Okta Developer</title>
+  <title>Add Okta authentication to your Python app | Okta Developer</title>
   <meta name="description" content="Add Okta authentication to your Python app">
   <link rel="canonical" href="https://developer.okta.com/code/python/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/python/pysaml2.html
+++ b/code/python/pysaml2.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Python | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="SAML-enable your Python application | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Guidance on how to SAML-enable your Python application using open source PySAML2." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Python | Okta Developer</title>
+  <title>SAML-enable your Python application | Okta Developer</title>
   <meta name="description" content="Guidance on how to SAML-enable your Python application using open source PySAML2.">
   <link rel="canonical" href="https://developer.okta.com/code/python/pysaml2">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/python/quickstart.html
+++ b/code/python/quickstart.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="Python | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Sign-In Widget with Python | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Quickstart guide for using the Okta Sign-In Widget with Python." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>Python | Okta Developer</title>
+  <title>Okta Sign-In Widget with Python | Okta Developer</title>
   <meta name="description" content="Quickstart guide for using the Okta Sign-In Widget with Python.">
   <link rel="canonical" href="https://developer.okta.com/code/python/quickstart">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/python/sdk.html
+++ b/code/python/sdk.html
@@ -366,7 +366,7 @@
               
               
               
-              <li >
+              <li class="is-active">
                 <a href="/code/python/">PYTHON</a>
               </li>
             

--- a/code/react/index.html
+++ b/code/react/index.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="React | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Add Okta authentication to your React app | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Add Okta authentication to your React app" />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>React | Okta Developer</title>
+  <title>Add Okta authentication to your React app | Okta Developer</title>
   <meta name="description" content="Add Okta authentication to your React app">
   <link rel="canonical" href="https://developer.okta.com/code/react/index">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/react/okta_react.html
+++ b/code/react/okta_react.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="React | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Auth JS and React | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Integrate Okta with a React app using Auth JS." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>React | Okta Developer</title>
+  <title>Okta Auth JS and React | Okta Developer</title>
   <meta name="description" content="Integrate Okta with a React app using Auth JS.">
   <link rel="canonical" href="https://developer.okta.com/code/react/okta_react">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->

--- a/code/react/okta_react_sign-in_widget.html
+++ b/code/react/okta_react_sign-in_widget.html
@@ -39,7 +39,7 @@
  	
 
   <link type="text/css" rel="stylesheet" href="https://developer.okta.com/sites/all/themes/developer/css/master.css" media="all" />
-  <meta class="swiftype" name="title" data-type="string" content="React | Okta Developer" />
+  <meta class="swiftype" name="title" data-type="string" content="Okta Sign-In Widget and React | Okta Developer" />
   <meta class="swiftype" name="summary" data-type="string" content="Integrate Okta with a React app using the Sign-In Widget." />
 
   <link type="text/css" rel="stylesheet" href="/assets/animate-ec43d72c3ed45e08a460b8a2966d8dba6006aebfa0530935c3973fa493a8771f.css">
@@ -47,7 +47,7 @@
   
   
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
-  <title>React | Okta Developer</title>
+  <title>Okta Sign-In Widget and React | Okta Developer</title>
   <meta name="description" content="Integrate Okta with a React app using the Sign-In Widget.">
   <link rel="canonical" href="https://developer.okta.com/code/react/okta_react_sign-in_widget">
   <link rel="alternate" type="application/rss+xml" title="Okta Developer" href="https://developer.okta.com/feed.xml"><!-- GA -->


### PR DESCRIPTION
## Description:
- Search identifies pages based on their "title" element. A few pages had "Okta Sign-In Widget" as their title, causing search to render .NET results.

### Resolves:
* [OKTA-141320](https://oktainc.atlassian.net/browse/OKTA-141320)

