### PR TITLE
Doc policy rule type in examples in Policy API

### DIFF
--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -313,6 +313,7 @@ curl -v -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
+  "type": "PASSWORD",
   "name": "New Policy Rule",
   "conditions": {
     "people": {
@@ -414,6 +415,7 @@ curl -v -X PUT \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
 -d '{
+  "type": "PASSWORD",
   "name": "My Updated Policy Rule",
   "conditions": {
     "people": {


### PR DESCRIPTION
## Description:
- Adds the `type` property to the policy rule object examples
- It's already documented elsewhere in the Policy API--adding to these examples because they just happen to lack that property

### Resolves:
* [OKTA-141467](https://oktainc.atlassian.net/browse/OKTA-141467)

