### PR TITLE
link changes from old support.okta.com URLs

### DIFF
--- a/_source/_code/javascript/okta_auth_sdk.md
+++ b/_source/_code/javascript/okta_auth_sdk.md
@@ -27,7 +27,7 @@ You will need the following things for this quickstart:
 
 - An Okta org - If you don't have an existing org, register for [Okta Developer Edition](https://developer.okta.com/signup/).
 - An OpenID Connect Application. Instructions for creating one can be found on [this page](https://help.okta.com/en/prev/Content/Topics/Apps/Apps_App_Integration_Wizard.htm), under the "OpenID Connect Wizard" section.
-- At least one User [assigned to the Application](https://support.okta.com/help/Documentation/Knowledge_Article/27418177-Using-the-Okta-Applications-Page#Assigning).
+- At least one User [assigned to the Application](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_Apps_Page.htm#Assigning).
 - An entry in your Org's "Trusted Origins" for your application. To do this, follow the steps found under the "Trusted Origins tab" section in our [API Security help page](https://help.okta.com/en/prev/Content/Topics/Security/API.htm).
 
 ## Installation

--- a/_source/_code/javascript/okta_sign-in_widget.md
+++ b/_source/_code/javascript/okta_sign-in_widget.md
@@ -40,7 +40,7 @@ If you want to see the Sign-in Widget in action for yourself, you will need thre
 
 - An Okta Developer org, which you can sign-up for here: <https://developer.okta.com/signup/>
 - A client Application in Okta: for more information, you can read about [the OpenID Connect Application Wizard](https://help.okta.com/en/prev/Content/Topics/Apps/Apps_App_Integration_Wizard.htm)
-- At least one [User assigned to it](https://support.okta.com/help/Documentation/Knowledge_Article/27418177-Using-the-Okta-Applications-Page#Assigning)
+- At least one [User assigned to it](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_Apps_Page.htm#Assigning)
 
 Once you have these prerequisites, getting the Sign-in Widget working has four steps:
 

--- a/_source/_code/php/simplesamlphp.md
+++ b/_source/_code/php/simplesamlphp.md
@@ -36,9 +36,7 @@ section titled "Configuring SimpleSAMLphp to work with Okta."
 ## Configuring Okta to work with SimpleSAMLphp
 
 Before you can configure the example application and SimpleSAMLphp
-you will need to set up an Okta
-"[chiclet](https://support.okta.com/articles/Knowledge_Article/27838096-Okta-Terminology)"
-(application icon) that an Okta user would select to sign in to your to your
+you need to set up an Okta chiclet (application icon) that an Okta user selects to sign in to your to your
 application using SAML via SimpleSAMLphp.
 
 To set up Okta to connect to your application, follow the guide to

--- a/_source/_code/python/pysaml2.md
+++ b/_source/_code/python/pysaml2.md
@@ -43,7 +43,7 @@ section titled "Configuring {{ page.saml_library }} to work with Okta."
 ## Configuring Okta to work with {{ page.saml_library }}
 
 Before you can configure your application and {{ page.saml_library }} set up an
-Okta "[chiclet](https://support.okta.com/articles/Knowledge_Article/27838096-Okta-Terminology)" (application icon) that enables an Okta user to sign in to your to your application with SAML and {{ page.saml_library }}.
+Okta chiclet (application icon) that enables an Okta user to sign in to your to your application with SAML and {{ page.saml_library }}.
 
 To set up Okta to connect to your application, follow the
 [setting up a SAML application in Okta](/docs/guides/setting_up_a_saml_application_in_okta.html)

--- a/_source/_docs/api/getting_started/design_principles.md
+++ b/_source/_docs/api/getting_started/design_principles.md
@@ -89,7 +89,7 @@ Okta supports the standard `User-Agent` HTTP header to identify the user's brows
 
 The **public IP address** of your application will be automatically used as the client IP address for your request. Okta supports the standard `X-Forwarded-For` HTTP header to forward the originating client's IP address if your application is behind a proxy server or acting as a login portal or gateway.
 
-> The **public IP address** of your trusted web application must be whitelisted in your [org's network security settings](https://support.okta.com/help/articles/Knowledge_Article/27529977-Using-the-Okta-Security-Page#Obey) as a trusted gateway in order to forward the user agent's original IP address with the `X-Forwarded-For` HTTP header.
+> The **public IP address** of your trusted web application must be whitelisted in your [org's network security settings](https://help.okta.com/en/prod/Content/Topics/Security/Security_Network.htm) as a trusted gateway in order to forward the user agent's original IP address with the `X-Forwarded-For` HTTP header.
 
 
 ## Errors

--- a/_source/_docs/api/resources/events.md
+++ b/_source/_docs/api/resources/events.md
@@ -14,7 +14,7 @@ Explore the Events API: [![Run in Postman](https://run.pstmn.io/button.svg)](htt
 
 ## Data Retention
 
-Log data older than 90 days is not returned, in accordance with Okta's [Data Retention Policy}(https://support.okta.com/help/Documentation/Knowledge_Article/Okta-Data-Retention-Policy).
+Log data older than 90 days is not returned, in accordance with Okta's [Data Retention Policy](https://support.okta.com/help/Documentation/Knowledge_Article/Okta-Data-Retention-Policy).
 
 ## Event Operations
 

--- a/_source/_docs/api/resources/groups.md
+++ b/_source/_docs/api/resources/groups.md
@@ -22,7 +22,7 @@ Explore the Groups API: [![Run in Postman](https://run.pstmn.io/button.svg)](htt
 Adds a new group with `OKTA_GROUP` type to your organization.
 
 > Application import operations are responsible for syncing groups with `APP_GROUP` type such as Active Directory groups.<br>
-> See [Importing and Using Groups in Okta](https://support.okta.com/help/articles/Knowledge_Article/92113353-Importing-and-Using-Groups-in-Okta) for more information.
+> See [Importing Groups into Okta](https://help.okta.com/en/prod/Content/Topics/Directory/Directory_Groups.htm) for more information.
 
 ##### Request Parameters
 {:.api .api-request .api-request-params}

--- a/_source/_docs/api/resources/oauth2.md
+++ b/_source/_docs/api/resources/oauth2.md
@@ -224,17 +224,17 @@ For web and native application types, an additional process is required:
 ##### Token Authentication Methods
 <!--If you change this section, change the section in oidc.md as well -->
 
-If you authenticate a client with client credentials, provide the [`client_id`](oidc.html#request-parameters)
-and [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect) using either of the following methods:
+If you authenticate a client with client credentials, provide the [`client_id` and `client_secret`](oidc.html#request-parameters)
+using either of the following methods:
 
-* Provide [`client_id`](oidc.html#request-parameters) and [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect)
+* Provide  the [`client_id` and `client_secret`](#request-parameters-1)
   in an Authorization header in the Basic auth scheme (`client_secret_basic`). For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request:
   ~~~sh
   Authorization: Basic ${Base64(<client_id>:<client_secret>)}
   ~~~
-* Provide [`client_id`](oidc.html#request-parameters) and [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect)
+* Provide [`client_id` and `client_secret`](#request-parameters-1)
   as additional parameters to the POST body (`client_secret_post`)
-* Provide [`client_id`](oidc.html#request-parameters) in a JWT that you sign with the [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect)
+* Provide [`client_id`](#request-parameters-1) in a JWT that you sign with the [`client_secret`](#request-parameters-1)
   using HMAC algorithms HS256, HS384, or HS512. Specify the JWT in `client_assertion` and the type, `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, in `client_assertion_type` in the request. 
 
 Use only one of these methods in a single request or an error will occur.

--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -152,17 +152,17 @@ The following parameters can be posted as a part of the URL-encoded form values 
 ##### Token Authentication Methods
 <!--If you change this section, change the section in oauth2.md as well -->
 
-If you authenticate a client with client credentials, provide the [`client_id`](oidc.html#request-parameters)
-and [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect) using either of the following methods:
+If you authenticate a client with client credentials, provide the [`client_id` and `client_secret`](#request-parameters-1)
+using either of the following methods:
 
-* Provide [`client_id`](oidc.html#request-parameters) and [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect)
+* Provide `client_id` and `client_secret`
   in an Authorization header in the Basic auth scheme (`client_secret_basic`). For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request:
   ~~~sh
   Authorization: Basic ${Base64(<client_id>:<client_secret>)}
   ~~~
-* Provide [`client_id`](oidc.html#request-parameters) and [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect)
+* Provide the `client_id` and `client_secret`
   as additional parameters to the POST body (`client_secret_post`)
-* Provide [`client_id`](oidc.html#request-parameters) in a JWT that you sign with the [`client_secret`](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect)
+* Provide `client_id` in a JWT that you sign with the `client_secret`
   using HMAC algorithms HS256, HS384, or HS512. Specify the JWT in `client_assertion` and the type, `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, in `client_assertion_type` in the request. 
 
 Use only one of these methods in a single request or an error will occur.

--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -150,6 +150,7 @@ The following parameters can be posted as a part of the URL-encoded form values 
 | client_assertion_type | Indicates a JWT is being used to authenticate the client. Per the     [Client Authentication spec](http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication), the valid value is `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.           | String |
 
 ##### Token Authentication Methods
+
 <!--If you change this section, change the section in oauth2.md as well -->
 
 If you authenticate a client with client credentials, provide the [`client_id` and `client_secret`](#request-parameters-1)

--- a/_source/_docs/api/resources/schemas.md
+++ b/_source/_docs/api/resources/schemas.md
@@ -5,7 +5,7 @@ title: Schemas
 
 # Schemas API
 
-Okta&#8217;s [Universal Directory](https://support.okta.com/articles/Knowledge_Article/About-Universal-Directory) allows administrators to define custom user profiles for Okta users and applications.  Okta has adopted a subset [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04) as the schema language to describe and validate extensible user profiles. [JSON Schema](http://json-schema.org/) is a lightweight declarative format for describing the structure, constraints, and validation of JSON documents.
+Okta&#8217;s [Universal Directory](https://help.okta.com/en/prod/Content/Topics/Directory/About_Universal_Directory.htm) allows administrators to define custom user profiles for Okta users and applications.  Okta has adopted a subset [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04) as the schema language to describe and validate extensible user profiles. [JSON Schema](http://json-schema.org/) is a lightweight declarative format for describing the structure, constraints, and validation of JSON documents.
 
 > Okta has only implemented a subset of [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04).  This document should describe which parts are applicable to Okta and any extensions Okta has made to [JSON Schema Draft 4](https://tools.ietf.org/html/draft-zyp-json-schema-04)
 
@@ -1259,7 +1259,7 @@ The base user profile is based on the [System for Cross-Domain Identity Manageme
 | manager           | displayName of the user&#8217;s manager                                                                                            | String   | TRUE     | FALSE  | FALSE    |           |           |                                                                                                                   |
 |-------------------+------------------------------------------------------------------------------------------------------------------------------+----------+----------+--------+----------+-----------+-----------+-------------------------------------------------------------------------------------------------------------------|
 
-> Note: A locale value is a concatenation of the ISO 639-1 two letter language code, an underscore, and the ISO 3166-1 2 letter country code; e.g., 'en_US' specifies the language English and country US. [Okta Support Doc for ISO compliant Locale values](https://support.okta.com/help/articles/Knowledge_Article/Universal-Directory-enforcement-of-ISO-compliant-Locale-values)
+> Note: A locale value is a concatenation of the ISO 639-1 two letter language code, an underscore, and the ISO 3166-1 2 letter country code. For example, `'en_US'` specifies the language English and country US.
 
 #### User Profile Custom Subschema
 

--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -2830,7 +2830,7 @@ The default user profile is based on the [System for Cross-Domain Identity Manag
 | managerId         | `id` of a user&#8217;s manager                                                                                                     | String   | TRUE     | FALSE  | FALSE    |           |           |                                                                                                                  |
 | manager           | displayName of the user&#8217;s manager                                                                                            | String   | TRUE     | FALSE  | FALSE    |           |           |                                                                                                                  |
 
-> Note: A locale value is a concatenation of the ISO 639-1 two letter language code, an underscore, and the ISO 3166-1 2 letter country code. For example, 'en_US' specifies the language English and country US. [Okta Support Doc for ISO compliant Locale values](https://support.okta.com/help/articles/Knowledge_Article/Universal-Directory-enforcement-of-ISO-compliant-Locale-values)
+> Note: A locale value is a concatenation of the ISO 639-1 two letter language code, an underscore, and the ISO 3166-1 2 letter country code. For example, 'en_US' specifies the language English and country US.
 
 ##### Okta Login
 

--- a/_source/_docs/how-to/inbound-saml-with-oidc.md
+++ b/_source/_docs/how-to/inbound-saml-with-oidc.md
@@ -23,7 +23,7 @@ In addition to a SAML IdP that supports SP-initiated SAML, and an Okta org, this
 
 ### 1. Configure your SAML Identity Provider inside Okta
 
-The configuration information for your external Identity Provider is stored within an Identity Provider entity inside Okta. The instructions for creating a SAML IdP inside Okta can be found on the [Configuring Inbound SAML Support Page](https://support.okta.com/help/Documentation/Knowledge_Article/40561903-Configuring-Inbound-SAML).
+The configuration information for your external Identity Provider is stored within an Identity Provider entity inside Okta. The instructions for creating a SAML IdP inside Okta can be found on the [Configuring Inbound SAML](https://help.okta.com/en/prod/Content/Topics/Security/Identity_Providers.htm).
 
 > If you need a quick and easy SAML Identity Provider to use for testing purposes, you can try using this one: <https://github.com/mcguinness/saml-idp>
 
@@ -31,7 +31,7 @@ Once you are done with the configuration, take note of the value at the end of y
 
 ### 2. Configure an OpenID Connect Client Application
 
-You will also need to add an OIDC Client Application inside Okta. Users that are signing in for the first time will have [user entities](/docs/api/resources/users.html) created for them and associated with this application. You can add an OIDC App using [the OpenID Connect Application Wizard](https://help.okta.com/en/prev/Content/Topics/Apps/Apps_App_Integration_Wizard.htm). You will also need to assign the application to either "Everyone" or a particular Group that you'd like your new SAML users to be associated with. For more information, see [How to assign a User to an Application](https://support.okta.com/help/Documentation/Knowledge_Article/27418177-Using-the-Okta-Applications-Page#Assigning).
+You will also need to add an OIDC Client Application inside Okta. Users that are signing in for the first time will have [user entities](/docs/api/resources/users.html) created for them and associated with this application. You can add an OIDC App using [the OpenID Connect Application Wizard](https://help.okta.com/en/prev/Content/Topics/Apps/Apps_App_Integration_Wizard.htm). You will also need to assign the application to either "Everyone" or a particular Group that you'd like your new SAML users to be associated with. For more information, see [Assign Applications](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_Apps_Page.htm).
 
 Once you are done setting this up, be sure to copy the Client ID for your new application.
 

--- a/_source/_docs/how-to/set-up-auth-server.md
+++ b/_source/_docs/how-to/set-up-auth-server.md
@@ -194,7 +194,7 @@ To test your Authorization Server more thoroughly, you can try a full authentica
 
 For more information you can read about: 
 - [The OpenID Connect Application Wizard](https://help.okta.com/en/prev/Content/Topics/Apps/Apps_App_Integration_Wizard.htm)
-- [How to assign a User to an Application](https://support.okta.com/help/Documentation/Knowledge_Article/27418177-Using-the-Okta-Applications-Page#Assigning)
+- [Assign Applications](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_Apps_Page.htm)
 
 You will need the following values from your Application:
 

--- a/_source/_standards/OIDC/index.md
+++ b/_source/_standards/OIDC/index.md
@@ -229,7 +229,7 @@ Be aware of the following before you work with scope-dependent claims:
 
 * To protect against arbitrarily large numbers of groups matching the group filter, the groups claim has a limit of 100.
 If more than 100 groups match the filter, then the request fails. Expect that this limit may change in the future.
-For more information about configuring an app for OpenID Connect, including group claims, see [Using OpenID Connect](https://support.okta.com/help/articles/Knowledge_Article/Using-OpenID-Connect).
+For more information about configuring an app for OpenID Connect, including group claims, see [OpenID Connect Wizard](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard.htm).
 * **Important:** Scope-dependent claims are returned differently depending on the values in `response_type` and the scopes requested:
 
     | Response Type             | Claims Returned in ID Token                                                                        | Claims Returned from the Userinfo Endpoint  |

--- a/_source/_standards/SCIM/index.md
+++ b/_source/_standards/SCIM/index.md
@@ -68,7 +68,7 @@ Because of this, Okta doesn't make delete requests to the user APIs in downstrea
 #### Sync Password
 
 Okta sets the user’s password to either match the Okta password or to be a randomly generated password.
-Learn more about the overall use case [here](https://support.okta.com/help/articles/Knowledge_Article/Using-Sync-Password?retURL=%2Fhelp%2Fapex%2FKnowledgeArticleJson%3Fc%3DOkta_Documentation%253ADirectories%26p%3D101%26inline%3D1&popup=true).
+Learn more about the overall use case in [Using Sync Password: Active Directory Environments](https://help.okta.com/en/prod/Content/Topics/Security/Security_Using_Sync_Password.htm).
 
 #### Profile Mastering Users
 
@@ -95,7 +95,7 @@ Provisioning actions can be combined to solve for end-to-end use cases.
 
 In many enterprises, Active Directory (or LDAP) is the system of record for employee identities.
 Okta has developed a powerful, lightweight agent to sync with Active Directory to populate employee and group information.
-Within Okta, IT admins can leverage features such as [Universal Directory](https://support.okta.com/help/articles/Knowledge_Article/About-Universal-Directory) and [group membership rules](https://support.okta.com/help/articles/Knowledge_Article/About-Universal-Directory) to map that information when provisioning accounts and permissions in downstream apps.
+Within Okta, IT admins can leverage features such as [Universal Directory](https://help.okta.com/en/prod/Content/Topics/Directory/About_Universal_Directory.htm) and [group membership rules](https://help.okta.com/en/prod/Content/Topics/Directory/About_Universal_Directory.htm) to map that information when provisioning accounts and permissions in downstream apps.
 
 Subsequently, any updates to an employee’s profile, such as a change in department, in either Active Directory or Okta flow into the downstream app.
 Similarly, removing or deactivating an employee from Active Directory triggers deactivation in the downstream app as well.
@@ -159,7 +159,7 @@ Okta has doubled down on our investment in our SCIM client and launched our own 
 ### Provisioning to On-Premise Apps
 
 The options above are geared towards cloud apps but we have a solution for on-premise applications as well.
-See [Configuring On-Premise Provisioning](https://support.okta.com/help/articles/Knowledge_Article/29448976-Configuring-On-Premises-Provisioning) for details about Okta’s agent-based provisioning solution.
+See [the product documentation](https://help.okta.com/en/prod/Content/Topics/Directory/Okta%20Active%20Directory%20Agent.htm) for details about Okta’s agent-based provisioning solution.
 
 ### SCIM Facade
 
@@ -1291,9 +1291,9 @@ Zendesk - https://developer.zendesk.com/apps
 
 [SCIM Overview](https://www.lucidchart.com/techblog/2016/08/04/an-implementers-overview-managing-cloud-identity-with-scim/)
 
-[Okta End-User Management](https://support.okta.com/help/articles/Knowledge_Article/28352376-Overview-of-End-User-Management)
+[Okta End-User Management](https://help.okta.com/en/prod/Content/Topics/Directory/Directory_People.htm)
 
-[Okta Provisioning Basics](https://support.okta.com/help/articles/Knowledge_Article/Provisioning-Concepts-and-Methods)
+[Okta Provisioning Basics](https://help.okta.com/en/prod/Content/Topics/Apps/Provisioning_Deprovisioning_Overview.htm)
 
 [SCIM and Facebook](https://developers.facebook.com/docs/facebook-at-work/provisioning/scim-api)
 

--- a/_source/_use_cases/integrate_with_okta/oan-faqs.md
+++ b/_source/_use_cases/integrate_with_okta/oan-faqs.md
@@ -65,13 +65,13 @@ A: There are two different app certification levels in the OIN – Okta Verified
 
 **Q: I’m setting up a SAML 2.0 app using the App Wizard and we have different domains for each customer. How do you manage these types of situations?**
 
-A: Currently, the App Wizard does not support custom domains. Create an app integration as you normally would using the [App Wizard](https://support.okta.com/help/articles/Knowledge_Article/Using-the-App-Integration-Wizard). In step #3 Feedback, please try to include in the “How to enable SAML” section or email <developers@okta.com>. Our team will work with you to add this functionality when they begin to work with you.
+A: Currently, the App Wizard does not support custom domains. Create an app integration as you normally would using the [App Wizard](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard.htm). In step #3 Feedback, please try to include in the “How to enable SAML” section or email <developers@okta.com>. Our team will work with you to add this functionality when they begin to work with you.
 
 <br/>
 
 **Q: My app currently supports WS-FED for single sign-on. Can I use the App Wizard?**
 
-A: The Okta App Wizard only supports SAML 2.0 for federated single sign-on. If your app supports WS-Fed, you will instead need to create a [WS-Fed Template App](https://support.okta.com/help/articles/Knowledge_Article/Web-Security-Federation-WS-Fed-Template-Overview). Once completed, the Template Application you have created will only be able to be used within your account. In order to promote your Template App to the Okta Integration Network, please email a screenshot of the configured app details to <developers@okta.com> with your app name in the subject line.
+A: The Okta App Wizard only supports SAML 2.0 for federated single sign-on. If your app supports WS-Fed, you will instead need to create a [WS-Fed Template App](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_Configure_Okta%20Template_WS_Federation.htm). Once completed, the Template Application you have created will only be able to be used within your account. In order to promote your Template App to the Okta Integration Network, please email a screenshot of the configured app details to <developers@okta.com> with your app name in the subject line.
 
 <br/>
 
@@ -83,7 +83,7 @@ A: Currently, the App Wizard does not support extra login fields. Create an app 
 
 **Q: Does Okta support single logout / single sign-out (SAML protocol)?**
 
-A: Yes. For more information, see [Using the App Integration Wizard](https://support.okta.com/help/articles/Knowledge_Article/Using-the-App-Integration-Wizard#SAML_Single_Logout_section).
+A: Yes. For more information, see [Using the App Integration Wizard: SAML App Wizard: Advanced Settings](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard.htm).
 
 <br/>
 

--- a/_source/_use_cases/integrate_with_okta/promotion.md
+++ b/_source/_use_cases/integrate_with_okta/promotion.md
@@ -74,7 +74,7 @@ In addition to amplifying your launch marketing, we’ll alert our thousands of 
 
 * Product Release Notes
 
-    We’ll include enhancements to your integration in the “Application Update” section of our [Product Release Notes](https://support.okta.com/help/articles/Knowledge_Article/Okta-Production-Release-2017-02).
+    We’ll include enhancements to your integration in the “Application Update” section of our [Product Release Notes](https://help.okta.com).
 
 #### Ongoing Marketing Opportunities
 

--- a/_source/_use_cases/integrate_with_okta/sso-with-saml.md
+++ b/_source/_use_cases/integrate_with_okta/sso-with-saml.md
@@ -23,7 +23,7 @@ Use Okta’s [Single Sign-On with Okta](/docs/guides/saml_guidance.html) guide f
 #### 2. Integrate Your App
 
 * Sign up for an Okta [developer account](https://developer.okta.com/signup/).
-* In your Okta account (make sure you are signed in as an admin), use the [App Wizard](https://support.okta.com/help/articles/Knowledge_Article/Using-the-App-Integration-Wizard) to build a Single Sign-on integration with Okta. For the more visually inclined, see our [video](https://support.okta.com/help/articles/Knowledge_Article/Adding-Applications-Using-the-Application-Integration-Wizard-AIW) for using the App Wizard.
+* In your Okta account (make sure you are signed in as an admin), use the [App Wizard](https://help.okta.com/en/prod/Content/Topics/Apps/Apps_App_Integration_Wizard.htm) to build a Single Sign-on integration with Okta.
 * When you are ready, navigate to the Feedback tab of the App Wizard:
     {% img saml-step3.png alt:"Feedback page for App wizard" %}
 

--- a/_source/documentation/stormpath-import.md
+++ b/_source/documentation/stormpath-import.md
@@ -436,8 +436,8 @@ Identity Providers have a `name` property that is composed of a `dir:` prefix an
 
 As mentioned in [the Caveats section](#things-that-wont-migrate-and-known-caveats), LDAP Directories (including Active Directory) cannot be imported into Okta. You will need to set them up fresh inside Okta, which will re-import the data from your LDAP directory.
 
-- For instructions on how to set-up Active Directory, see here: https://help.okta.com/en/prod/Content/Topics/Directory/Okta%20Active%20Directory%20Agent.htm
-- For instructions on how to set-up LDAP, see here: https://support.okta.com/help/Documentation/Knowledge_Article/87604166-LDAP-Agent-Deployment-Guide
+- Instructions to set-up Active Directory](https://help.okta.com/en/prod/Content/Topics/Directory/Okta%20Active%20Directory%20Agent.htm)
+- [Instructions to set-up LDAP](https://help.okta.com/en/prod/Content/Topics/Directory/Okta%20Java%20LDAP%20Agent.htm)
 
 <a name="stormpath-groups"></a>
 ### Stormpath Groups

--- a/_source/documentation/stormpath-import.md
+++ b/_source/documentation/stormpath-import.md
@@ -436,8 +436,8 @@ Identity Providers have a `name` property that is composed of a `dir:` prefix an
 
 As mentioned in [the Caveats section](#things-that-wont-migrate-and-known-caveats), LDAP Directories (including Active Directory) cannot be imported into Okta. You will need to set them up fresh inside Okta, which will re-import the data from your LDAP directory.
 
-- Instructions to set-up Active Directory](https://help.okta.com/en/prod/Content/Topics/Directory/Okta%20Active%20Directory%20Agent.htm)
-- [Instructions to set-up LDAP](https://help.okta.com/en/prod/Content/Topics/Directory/Okta%20Java%20LDAP%20Agent.htm)
+- [Instructions to set up Active Directory](https://help.okta.com/en/prod/Content/Topics/Directory/Okta%20Active%20Directory%20Agent.htm)
+- [Instructions to set up LDAP](https://help.okta.com/en/prod/Content/Topics/Directory/Okta%20Java%20LDAP%20Agent.htm)
 
 <a name="stormpath-groups"></a>
 ### Stormpath Groups


### PR DESCRIPTION
## Description:
- If an old Knowledge Article has been replaced with Product doc new topic, the existing link sends you to a sign-in page, never tells you the article doesn't exist. Note: not all articles have been moved to Product doc, so not all old-style URLs have been replaced.

There is a separate REQ for using aliases instead of full URLs which tend to change over time.

### Resolves:

 [OKTA-141394](https://oktainc.atlassian.net/browse/OKTA-141394)

