### PR TITLE
fix oidc-md links to oauth2-md

### DIFF
--- a/_source/_docs/api/resources/oauth2.md
+++ b/_source/_docs/api/resources/oauth2.md
@@ -224,18 +224,15 @@ For web and native application types, an additional process is required:
 ##### Token Authentication Methods
 <!--If you change this section, change the section in oidc.md as well -->
 
-If you authenticate a client with client credentials, provide the [`client_id` and `client_secret`](oidc.html#request-parameters)
+If you authenticate a client with client credentials, provide the [`client_id` and `client_secret`](#request-parameters-1)
 using either of the following methods:
 
-* Provide  the [`client_id` and `client_secret`](#request-parameters-1)
-  in an Authorization header in the Basic auth scheme (`client_secret_basic`). For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request:
+* Provide  the `client_id` and `client_secret` in an Authorization header in the Basic auth scheme (`client_secret_basic`). For authentication with Basic auth, an HTTP header with the following format must be provided with the POST request:
   ~~~sh
   Authorization: Basic ${Base64(<client_id>:<client_secret>)}
   ~~~
-* Provide [`client_id` and `client_secret`](#request-parameters-1)
-  as additional parameters to the POST body (`client_secret_post`)
-* Provide [`client_id`](#request-parameters-1) in a JWT that you sign with the [`client_secret`](#request-parameters-1)
-  using HMAC algorithms HS256, HS384, or HS512. Specify the JWT in `client_assertion` and the type, `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, in `client_assertion_type` in the request. 
+* Provide `client_id` and `client_secret` as additional parameters to the POST body (`client_secret_post`)
+* Provide `client_id` in a JWT that you sign with the `client_secret` using HMAC algorithms HS256, HS384, or HS512. Specify the JWT in `client_assertion` and the type, `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, in `client_assertion_type` in the request. 
 
 Use only one of these methods in a single request or an error will occur.
 


### PR DESCRIPTION
## Description:
- Fix links that pointed to oidc instead of oauth2 per https://github.com/okta/okta.github.io/pull/1281#discussion_r140357692

I removed some extra links (you really only need to link once per paragraph!)

### Resolves:
[OKTA-141394](https://oktainc.atlassian.net/browse/OKTA-141394)

