### PR TITLE
:bug: Fix browser search

### DIFF
--- a/_source/_assets/js/master.js
+++ b/_source/_assets/js/master.js
@@ -85,7 +85,7 @@ function oktaCustomRenderFunction(document_type, item) {
     e.preventDefault();
 
     if($('#st-search-input-auto').val() != '') {
-      window.location.href = searchDomain + '/search/#stq=' + encodeURIComponent($('#st-search-input-auto').val());
+      window.location.href = searchDomain + '/search?q=' + encodeURIComponent($('#st-search-input-auto').val());
     }
 
     return false;


### PR DESCRIPTION
## Description:
- When using the address bar in chrome to search for content within a site, the default query passed is `?q=`. This updates d.o.c to perform searches using that query, instead of the swiftype default: `stq`.

- **Update**: Better solution may be to redirect all `/search?q=` requests through the Swiftype seach `/search#stq=`

⚠️  Needs more investigation

### Resolves:
* [OKTA-142963](https://oktainc.atlassian.net/browse/OKTA-142963)

