### PR TITLE
Document new excludeAttributes array in Password Complexity Object

### DIFF
--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -1148,6 +1148,7 @@ minUpperCase | Indicates if a password must contain at least one upper case lett
 minNumber | Indicates if a password must contain at least one number: 0 indicates no, 1 indicates yes | integer | No | 1
 minSymbol | Indicates if a password must contain at least one symbol (e.g., !@#$%^&*): 0 indicates no, 1 indicates yes | integer | No | 1
 excludeUsername | Indicates if the user name must be excluded from the password | boolean | No | true
+excludeAttributes | The user profile attributes whose values must be excluded from the password: currently only supports `firstName` and `lastName` | Array | No | Empty Array
 dictionary {%api_lifecycle beta %} | Weak password dictionary lookup settings | <a href="#WeakPasswordDictionaryObject">Weak Password Dictionary Object</a> | No | N/A
 
 ###### Weak Password Dictionary Object


### PR DESCRIPTION
## Description:
- Add excludeAttributes array in Password Complexity Object documentation
- Second try since first merge was premature (https://github.com/okta/okta.github.io/pull/1302)

### Resolves:
<!-- Required for Okta-generated PRs -->
* [OKTA-140223](https://oktainc.atlassian.net/browse/OKTA-140223)


