### PR TITLE
:bug: Removes non-supported SCIM filter

### DIFF
--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -1049,7 +1049,6 @@ Examples use cURL-style escaping instead of URL encoding to make them easier to 
 | `profile.email eq "email@example.com"`        | Users with a specified `email`*                  |
 | `profile.firstName eq "John"`                 | Users with a specified `firstName`*              |
 | `profile.lastName eq "Smith" `                | Users with a specified `lastName`*               |
-| `profile.lastName sw "Sm" `                   | Users whose `lastName` starts with "Sm"          |
 
 > Hint: If filtering by `email`, `lastName`, or `firstName`, it may be easier to use `q` instead of `filter`.
 


### PR DESCRIPTION
## Description:
- Listing users by a `filter` uses a subset of SCIM operators shown in this section: [#list-users-with-a-filter](https://developer.okta.com/docs/api/resources/users.html#list-users-with-a-filter). According to [OKTA-64880](https://oktainc.atlassian.net/browse/OKTA-64880), the "sw" field is only supported with **search**, not basic **filtering**.

### Resolves:
<!-- Required for Okta-generated PRs -->
* [OKTA-142555](https://oktainc.atlassian.net/browse/OKTA-142555)
* [OKTA-110553](https://oktainc.atlassian.net/browse/OKTA-110553) & [OKTA-108026](https://oktainc.atlassian.net/browse/OKTA-108026)

