### PR TITLE
Added missing html redirects back in

### DIFF
--- a/_source/_docs/api/getting_started/error_codes.md
+++ b/_source/_docs/api/getting_started/error_codes.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /reference/error_codes/index
+---

--- a/_source/_docs/api/getting_started/okta_expression_lang.md
+++ b/_source/_docs/api/getting_started/okta_expression_lang.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /reference/okta_expression_language/index
+---

--- a/_source/_docs/api/resources/okta_signin_widget.md
+++ b/_source/_docs/api/resources/okta_signin_widget.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/javascript/okta_sign-in_widget_ref
+---

--- a/_source/_docs/api/rest/apps.md
+++ b/_source/_docs/api/rest/apps.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/apps.html
+---

--- a/_source/_docs/api/rest/authn.md
+++ b/_source/_docs/api/rest/authn.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/authn.html
+---

--- a/_source/_docs/api/rest/events.md
+++ b/_source/_docs/api/rest/events.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/events.html
+---

--- a/_source/_docs/api/rest/factors.md
+++ b/_source/_docs/api/rest/factors.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/factors.html
+---

--- a/_source/_docs/api/rest/groups.md
+++ b/_source/_docs/api/rest/groups.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/groups.html
+---

--- a/_source/_docs/api/rest/idps.md
+++ b/_source/_docs/api/rest/idps.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/idps.html
+---

--- a/_source/_docs/api/rest/oauth-clients.md
+++ b/_source/_docs/api/rest/oauth-clients.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/oauth-clients.html
+---

--- a/_source/_docs/api/rest/oidc.md
+++ b/_source/_docs/api/rest/oidc.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/oidc
+---

--- a/_source/_docs/api/rest/search-beta.md
+++ b/_source/_docs/api/rest/search-beta.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/search-beta
+---

--- a/_source/_docs/api/rest/search-beta.md
+++ b/_source/_docs/api/rest/search-beta.md
@@ -1,3 +1,0 @@
----
-redirect_to: /docs/api/resources
----

--- a/_source/_docs/api/rest/search-beta.md
+++ b/_source/_docs/api/rest/search-beta.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /docs/api/resources/search-beta
+redirect_to: /docs/api/resources
 ---

--- a/_source/_docs/api/rest/sessions.md
+++ b/_source/_docs/api/rest/sessions.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/sessions.html
+---

--- a/_source/_docs/api/rest/templates.md
+++ b/_source/_docs/api/rest/templates.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/templates.html
+---

--- a/_source/_docs/api/rest/users.md
+++ b/_source/_docs/api/rest/users.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/users.html
+---

--- a/_source/_docs/examples.md
+++ b/_source/_docs/examples.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /documentation/
+---

--- a/_source/_docs/examples/configuring_a_saml_application_in_okta.md
+++ b/_source/_docs/examples/configuring_a_saml_application_in_okta.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /standards/SAML/setting_up_a_saml_application_in_okta
+---

--- a/_source/_docs/examples/dotnet_sample_application.md
+++ b/_source/_docs/examples/dotnet_sample_application.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/dotnet/sample_application
+---

--- a/_source/_docs/examples/index.md
+++ b/_source/_docs/examples/index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /documentation/
+---

--- a/_source/_docs/examples/pysaml2.md
+++ b/_source/_docs/examples/pysaml2.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/python/pysaml2
+---

--- a/_source/_docs/examples/session_cookie.md
+++ b/_source/_docs/examples/session_cookie.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /use_cases/authentication/session_cookie
+---

--- a/_source/_docs/examples/spring_security_saml.md
+++ b/_source/_docs/examples/spring_security_saml.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/java/spring_security_saml
+---

--- a/_source/_docs/getting_started/api_test_client.md
+++ b/_source/_docs/getting_started/api_test_client.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/getting_started/api_test_client.html
+---

--- a/_source/_docs/getting_started/design_principles.md
+++ b/_source/_docs/getting_started/design_principles.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/getting_started/design_principles.html
+---

--- a/_source/_docs/getting_started/enabling_cors.md
+++ b/_source/_docs/getting_started/enabling_cors.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/getting_started/enabling_cors.html
+---

--- a/_source/_docs/getting_started/error_codes.md
+++ b/_source/_docs/getting_started/error_codes.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /reference/error_codes/index
+---

--- a/_source/_docs/getting_started/factor_admin.md
+++ b/_source/_docs/getting_started/factor_admin.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/factor_admin.html
+---

--- a/_source/_docs/getting_started/getting_a_token.md
+++ b/_source/_docs/getting_started/getting_a_token.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/getting_started/getting_a_token.html
+---

--- a/_source/_docs/getting_started/oan_guidance.md
+++ b/_source/_docs/getting_started/oan_guidance.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /use_cases/integrate_with_okta/index
+---

--- a/_source/_docs/getting_started/okta_expression_lang.md
+++ b/_source/_docs/getting_started/okta_expression_lang.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /reference/okta_expression_language/index
+---

--- a/_source/_docs/getting_started/policy.md
+++ b/_source/_docs/getting_started/policy.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/policy.html
+---

--- a/_source/_docs/getting_started/saml_guidance.md
+++ b/_source/_docs/getting_started/saml_guidance.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /standards/SAML/index
+---

--- a/_source/_docs/getting_started/tokens.md
+++ b/_source/_docs/getting_started/tokens.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/tokens.html
+---

--- a/_source/_docs/guides.md
+++ b/_source/_docs/guides.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /documentation/
+---

--- a/_source/_docs/guides/add_mfa.md
+++ b/_source/_docs/guides/add_mfa.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /use_cases/mfa/
+---

--- a/_source/_docs/guides/index.md
+++ b/_source/_docs/guides/index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /documentation/
+---

--- a/_source/_docs/guides/oan_guidance.md
+++ b/_source/_docs/guides/oan_guidance.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /use_cases/integrate_with_okta/index
+---

--- a/_source/_docs/guides/okta_auth_sdk.md
+++ b/_source/_docs/guides/okta_auth_sdk.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/javascript/okta_auth_sdk.html
+---

--- a/_source/_docs/guides/okta_mobile_connect.md
+++ b/_source/_docs/guides/okta_mobile_connect.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /use_cases/mobile/okta_mobile_connect
+---

--- a/_source/_docs/guides/okta_sign-in_widget.md
+++ b/_source/_docs/guides/okta_sign-in_widget.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/javascript/okta_sign-in_widget
+---

--- a/_source/_docs/guides/overview.md
+++ b/_source/_docs/guides/overview.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /documentation/
+---

--- a/_source/_docs/guides/pysaml2.md
+++ b/_source/_docs/guides/pysaml2.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/python/pysaml2.html
+---

--- a/_source/_docs/guides/saml_guidance.md
+++ b/_source/_docs/guides/saml_guidance.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /standards/SAML/index
+---

--- a/_source/_docs/guides/scim_developer_program.md
+++ b/_source/_docs/guides/scim_developer_program.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /standards/SCIM/scim_developer_program
+---

--- a/_source/_docs/guides/scim_developer_program.md
+++ b/_source/_docs/guides/scim_developer_program.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /standards/SCIM/scim_developer_program
+redirect_to: /standards/SCIM/index
 ---

--- a/_source/_docs/guides/scim_guidance.md
+++ b/_source/_docs/guides/scim_guidance.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /standards/SCIM/index
+---

--- a/_source/_docs/guides/setting_up_a_saml_application_in_okta.md
+++ b/_source/_docs/guides/setting_up_a_saml_application_in_okta.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /standards/SAML/setting_up_a_saml_application_in_okta
+---

--- a/_source/_docs/guides/simplesamlphp.md
+++ b/_source/_docs/guides/simplesamlphp.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/php/simplesamlphp.html
+---

--- a/_source/_docs/guides/social_authentication.md
+++ b/_source/_docs/guides/social_authentication.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/api/resources/social_authentication
+---

--- a/_source/_docs/guides/spring_security_saml.md
+++ b/_source/_docs/guides/spring_security_saml.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /code/java/spring_security_saml.html
+---


### PR DESCRIPTION
Generated mostly from d91bb31599764210fddccb3f3de26eaaafe4783d and the following script (actual script not important but included here for record)

```bash
#!/bin/bash
REDIRECTS=$(find . -type f | grep '\.html'| grep -v /javadoc/ |grep -v java_api_sdk | xargs grep -l 'http-equiv="refresh" content="0; url=' |sort |uniq | xargs grep 'http-equiv="refresh" content="0' | sed 's_<meta http-equiv="refresh" content="0; url=__' | sed 's_">$__' | sed 's_https://developer.okta.com__')

DEST_DIR="$HOME/dev/source/okta/blog/_source/_docs/"

while read -r line; do
    IFS=':  ' read -r -a ITEM <<< "$line"
    CURRENT_FILE="${DEST_DIR}/$(echo ${ITEM[0]} | sed 's_\.html_\.md_')"
    NEW_FILE="${ITEM[1]}"
    echo "$CURRENT_FILE"
    
    mkdir -p $(dirname $CURRENT_FILE)
    
cat > "$CURRENT_FILE" <<EOF
---
redirect_to: ${NEW_FILE}
---
EOF

done <<< "$REDIRECTS"
```
