### PR TITLE
Contradiction about API rate limits

### DIFF
--- a/_source/_docs/api/getting_started/design_principles.md
+++ b/_source/_docs/api/getting_started/design_principles.md
@@ -305,6 +305,7 @@ endpoint.
 ### Org-Wide Rate Limits
 
 API rate limits apply to the endpoints in an org. The rate applies either to all the endpoints with the same base URL or to an exact URL, as noted in the following table.
+<!-- It says here that for other endpoints, the limit is 10,000. This contradicts the value in the table below. -->
 For all endpoints not listed, the API rate limit is a combined 10,000 requests per minute.
 
 <table border="1" style="width: 100%;">
@@ -349,6 +350,7 @@ For all endpoints not listed, the API rate limit is a combined 10,000 requests p
 			<td colspan="1" rowspan="1" style="text-align: right;">600</td>
 		</tr>
 		<tr>
+		<!-- Here the number is 1000. If these are two different limits, can we be more explicit about the difference? -->
 			<td colspan="1" rowspan="1"><span style="font-family: courier new,courier,monospace;">/api/v1/</span>&nbsp; (if no other limit specified in this table)</td>
 			<td colspan="1" rowspan="1" style="text-align: right;">1000</td>
 		</tr>


### PR DESCRIPTION
In two different places, the document says for other endpoints, the limit is 10,000 and 1000. Please either change the values or provide more clarification on the difference.

## Description:
- Describe your changes. This will most likely be a copy-paste of your commit
  message(s), which should be descriptive and informative.

### Resolves:
* [Issue #X](#X)
<!-- Required for Okta-generated PRs -->
* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

