### PR TITLE
Fix the incorrect layout for response parameter sub-header.

### DIFF
--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -16,7 +16,7 @@ If you are new to OpenID Connect, read [the standards topic](/standards/OIDC/ind
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/fd92d7c1ab0fbfdecab2)
 
-You can also view the video [Getting Started with the Okta API and OpenID Connect](https://www.youtube.com/watch?v=fPW66abobMI). 
+You can also view the video [Getting Started with the Okta API and OpenID Connect](https://www.youtube.com/watch?v=fPW66abobMI).
 
 ## Endpoints
 
@@ -165,7 +165,7 @@ using either of the following methods:
 * Provide the `client_id` and `client_secret`
   as additional parameters to the POST body (`client_secret_post`)
 * Provide `client_id` in a JWT that you sign with the `client_secret`
-  using HMAC algorithms HS256, HS384, or HS512. Specify the JWT in `client_assertion` and the type, `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, in `client_assertion_type` in the request. 
+  using HMAC algorithms HS256, HS384, or HS512. Specify the JWT in `client_assertion` and the type, `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`, in `client_assertion_type` in the request.
 
 Use only one of these methods in a single request or an error will occur.
 
@@ -187,7 +187,7 @@ Parameter Details
 * If `jti` is specified, the token can only be used once. So, for example, subsequent token requests won&#8217;t succeed.
 * The `exp` claim will fail the request if the expiration time is more than one hour in the future or has already expired.
 * If `iat` is specified, then it must be a time before the request is received.
-* 
+
 #### Response Parameters
 
 Based on the type of token and whether it is active or not, the returned JSON contains a different set of information. Besides the claims in the token, the possible top-level members include:
@@ -687,7 +687,7 @@ https://www.example.com/#error=invalid_scope&error_description=The+requested+sco
 
 {% api_operation post /oauth2/v1/token %}
 
-The API returns Access Tokens, ID Tokens, and Refresh Tokens, depending on the request parameters. 
+The API returns Access Tokens, ID Tokens, and Refresh Tokens, depending on the request parameters.
 
 >Because this endpoint works with the [Okta Authorization Server](/standards/OAuth/index.html#authorization-servers), you don&#8217;t need an authorization server ID.
 
@@ -723,7 +723,7 @@ For more information about token authentication, see [Token Authentication Metho
 #### Response Parameters
 
 Based on the `grant_type` and sometimes `scope`, the response contains different token sets.
-Generally speaking, the scopes specified in a request are included in the Access Tokens in the response. 
+Generally speaking, the scopes specified in a request are included in the Access Tokens in the response.
 
 | Requested grant type | Requested scope                                     | Response tokens                                                   |
 |:---------------------|:----------------------------------------------------|:------------------------------------------------------------------|
@@ -824,5 +824,3 @@ curl -v -X GET \
   post_logout_redirect_uri=${post_logout_redirect_uri}&
   state=${state}
 ~~~
-
-


### PR DESCRIPTION
## Description:

- additional `*` around line 190 broken the subtitle layout.
  
<img width="464" alt="screen shot 2017-10-24 at 4 49 39 pm" src="https://user-images.githubusercontent.com/13139863/31973530-611fef3a-b8db-11e7-91bd-801d427057ce.png">

- clean up extra whitespace.

### Resolves:
* [Issue #X](#X)
<!-- Required for Okta-generated PRs -->
* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

