### PR TITLE
Remove the need for sudo during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
 
 script: ./scripts/travis.sh
 
-sudo: required
 dist: trusty
 
 env:


### PR DESCRIPTION
We don't use it, and we can build on newer images and locally debug issues when not using the Travis-CI VMs
