### PR TITLE
Changing the way our feed generator works

### DIFF
--- a/_source/feed.xml
+++ b/_source/feed.xml
@@ -8,7 +8,7 @@ layout: null
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}</link>
     <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
-    {% for post in site.posts limit:15 %}
+    {% for post in site.posts %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>


### PR DESCRIPTION
It now outputs *all* articles.

This is necessary for supporting feed readers so that newly subscribed
users can view all past articles properly.

This will also let us do some smart automation with social sharing in
the near future.