### PR TITLE
Fix urls that do not contain '.html'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,6 +64,7 @@ collections:
     output: true
   code:
     output: true
+    parmalink: /:collection/:path:output_ext
   use_cases:
     output: true
   authentication-guide:

--- a/_source/_authentication-guide/auth-overview/index.md
+++ b/_source/_authentication-guide/auth-overview/index.md
@@ -67,7 +67,7 @@ At the core of both OAuth 2.0 and its OpenID Connect extension is the authorizat
 and its own signing key for tokens in order to keep proper boundary between security domains. In the context of this guide, Okta is your authorization server.
 
 The authorization server also acts as an OpenID Connect Provider,
-which means you can request [ID tokens](/standards/OIDC/index#id-token)
+which means you can request [ID tokens](/standards/OIDC/index.html#id-token)
 in addition to [access tokens](/standards/OAuth/#access-token) from the authorization server endpoints.
 
 ### OpenID Connect

--- a/_source/_authentication-guide/saml-login/index.md
+++ b/_source/_authentication-guide/saml-login/index.md
@@ -12,7 +12,7 @@ Okta supports authentication with an external SAML Identity Provider (IdP) that 
 
 The SAML flow is initiated with the Service Provider (SP), in this case Okta, who then redirects you to the IdP for authentication. On successful authentication, a user is created inside Okta, and you are redirected back to the URL you specified along with an ID token. 
 
-For more high-level information, you can read about [Understanding SP-initiated Login Flow](/standards/SAML/index#understanding-sp-initiated-login-flow).
+For more high-level information, you can read about [Understanding SP-initiated Login Flow](/standards/SAML/index.html#understanding-sp-initiated-login-flow).
 
 ## Set-up
 

--- a/_source/_authentication-guide/social-login/social-settings.md
+++ b/_source/_authentication-guide/social-login/social-settings.md
@@ -38,4 +38,4 @@ More user profile attributes are available for matching as an {% api_lifecycle e
 
 ## Error Codes
 
-See the [OpenID Connect and Okta Social Authentication](/reference/error_codes/index#openid-connect-and-okta-social-authentication) section of the [Error Codes](/docs/api/getting_started/error_codes.html) API documentation.
+See the [OpenID Connect and Okta Social Authentication](/reference/error_codes/index.html#openid-connect-and-okta-social-authentication) section of the [Error Codes](/docs/api/getting_started/error_codes.html) API documentation.

--- a/_source/_authentication-guide/tokens/index.md
+++ b/_source/_authentication-guide/tokens/index.md
@@ -7,9 +7,9 @@ title: Working with OAuth 2.0 Tokens
 
 Once you have [implemented your preferred OAuth 2.0 flow](/authentication-guide/implementing-authentication/), you will need to know how work with the tokens that you have been granted.
 
-More information about access tokens can be found here: <https://developer.okta.com/standards/OAuth/index#access-token>
+More information about access tokens can be found here: <https://developer.okta.com/standards/OAuth/index.html#access-token>
 
-Additional information about ID tokens can be found here: <https://developer.okta.com/standards/OIDC/index#id-token>
+Additional information about ID tokens can be found here: <https://developer.okta.com/standards/OIDC/index.html#id-token>
 
 This section will help you understand token validation, revocation, as well as how to use a refresh token to get a new access token.
 

--- a/_source/_authentication-guide/tokens/revoking-tokens.md
+++ b/_source/_authentication-guide/tokens/revoking-tokens.md
@@ -35,7 +35,7 @@ Revoking only the access token will effectively force the use of the refresh tok
 
 If you revoke only the refresh token then the access token will also be revoked. This allows you to, for example, force a user to reauthenticate. 
 
-For more information on configuring TTL and other parameters involving access and refresh tokens, you can read about [Okta Access Policies](/standards/OAuth/index#access-policies).
+For more information on configuring TTL and other parameters involving access and refresh tokens, you can read about [Okta Access Policies](/standards/OAuth/index.html#access-policies).
 
 ## Removing a User Session
 

--- a/_source/_authentication-guide/tokens/validating-access-tokens.md
+++ b/_source/_authentication-guide/tokens/validating-access-tokens.md
@@ -23,7 +23,7 @@ A high-level overview of OAuth 2.0 can be found [here](/authentication-guide/aut
 
 The access tokens are in JSON Web Token (JWT) format, the specification for which can be found here: <https://tools.ietf.org/html/rfc7519>. They are signed using private JSON Web Keys (JWK), the specification for which you can find here: <https://tools.ietf.org/html/rfc7517>.
 
-More information about Okta's access tokens can be found here: <https://developer.okta.com/standards/OAuth/index#access-token>.
+More information about Okta's access tokens can be found here: <https://developer.okta.com/standards/OAuth/index.html#access-token>.
 
 ## Access Tokens vs ID Tokens
 

--- a/_source/_authentication-guide/tokens/validating-id-tokens.md
+++ b/_source/_authentication-guide/tokens/validating-id-tokens.md
@@ -23,7 +23,7 @@ A high-level overview of OpenID Connect can be found [here](/authentication-guid
 
 The ID tokens are in JSON Web Token (JWT) format, the specification for which can be found here: <https://tools.ietf.org/html/rfc7519>. They are signed using private JSON Web Keys (JWK), the specification for which you can find here: <https://tools.ietf.org/html/rfc7517>.
 
-More information about Okta's ID tokens can be found here: <https://developer.okta.com/standards/OIDC/index#id-token>
+More information about Okta's ID tokens can be found here: <https://developer.okta.com/standards/OIDC/index.html#id-token>
 
 ## ID Tokens vs Access Tokens
 

--- a/_source/_code/ios/index.md
+++ b/_source/_code/ios/index.md
@@ -3,7 +3,8 @@ layout: software
 title: Add Okta authentication to your Swift app
 language: iOS
 integration: client
-redirect_from: '/code/swift'
+redirect_from:
+  - '/code/swift/'
 ---
 
 # Add Okta authentication to your Swift app

--- a/_source/_docs/api/resources/social_authentication.md
+++ b/_source/_docs/api/resources/social_authentication.md
@@ -540,4 +540,4 @@ More user profile attributes are available for matching as an {% api_lifecycle e
 
 ## Error Codes
 
-See the [OpenID Connect and Okta Social Authentication](/reference/error_codes/index#openid-connect-and-okta-social-authentication) section of the [Error Codes](/docs/api/getting_started/error_codes.html) API documentation.
+See the [OpenID Connect and Okta Social Authentication](/reference/error_codes/index.html#openid-connect-and-okta-social-authentication) section of the [Error Codes](/docs/api/getting_started/error_codes.html) API documentation.

--- a/_source/_docs/how-to/inbound-saml-with-oidc.md
+++ b/_source/_docs/how-to/inbound-saml-with-oidc.md
@@ -10,7 +10,7 @@ Okta supports authentication with an external SAML Identity Provider (IdP) that 
 
 The SAML flow is initiated with the Service Provider (SP), in this case Okta, who then redirects you to the IdP for authentication. On successful authentication, a user is created inside Okta, and you are redirected back to the URL you specified along with an ID token. 
 
-For more high-level information, you can read about [Understanding SP-initiated Login Flow](/standards/SAML/index#understanding-sp-initiated-login-flow).
+For more high-level information, you can read about [Understanding SP-initiated Login Flow](/standards/SAML/index.html#understanding-sp-initiated-login-flow).
 
 ## Set-up
 

--- a/_source/_standards/OIDC/index.md
+++ b/_source/_standards/OIDC/index.md
@@ -110,7 +110,7 @@ Clients should always [validate ID Tokens](/docs/api/resources/oidc.html#validat
 
 The ID Tokens returned by the authentication endpoint (implicit flow) or the Token endpoint (authorization code flow)
 are identical, except that in the implicit flow, the *nonce* parameter is required (and hence must have been included
-in the request), and the *at_hash* parameter is required if the response includes [an Access Token](/standards/OAuth/index#access-token) but prohibited if the
+in the request), and the *at_hash* parameter is required if the response includes [an Access Token](/standards/OAuth/index.html#access-token) but prohibited if the
 response does not include an Access Token.
 
 The ID Token (*id_token*) consists of three period-separated, base64URL-encoded JSON segments: [a header](#id-token-header), [the payload](#id-token-payload), and [the signature](#id-token-signature).

--- a/_source/quickstart/nodejs/express-implicit.md
+++ b/_source/quickstart/nodejs/express-implicit.md
@@ -3,7 +3,7 @@ layout: quickstart_partial
 exampleDescription: Express.js Implicit Flow Example
 ---
 
-In the Generic Node example (see other tab) we show you how to use the simplified [Okta JWT Verifier](https://www.npmjs.com/package/@okta/jwt-verifier) to verify Okta's JWTs.  In the example below we use the same verifier to create a simple Express middleware function that can prevent a request from completing if the request is not authenticated with a valid access token.  To learn more about validating Okta access tokens, please see [Validating Access Tokens](https://developer.okta.com/standards/OAuth/index#validating-access-tokens).
+In the Generic Node example (see other tab) we show you how to use the simplified [Okta JWT Verifier](https://www.npmjs.com/package/@okta/jwt-verifier) to verify Okta's JWTs.  In the example below we use the same verifier to create a simple Express middleware function that can prevent a request from completing if the request is not authenticated with a valid access token.  To learn more about validating Okta access tokens, please see [Validating Access Tokens](https://developer.okta.com/standards/OAuth/index.html#validating-access-tokens).
 
 ```javascript
 const express = require('express');

--- a/_source/quickstart/nodejs/generic-implicit.md
+++ b/_source/quickstart/nodejs/generic-implicit.md
@@ -3,7 +3,7 @@ layout: quickstart_partial
 exampleDescription: NodeJS Implicit Example
 ---
 
-Okta has created a simplified Node library to make this easy for Okta applications, [Okta JWT Verifier](https://www.npmjs.com/package/@okta/jwt-verifier).  Below is an example that shows you how to validate access tokens for a specific Okta authorization server (the issuer) and adds a secondary check for the audience of the token. To learn more about validating Okta access tokens, please see [Validating Access Tokens](https://developer.okta.com/standards/OAuth/index#validating-access-tokens).
+Okta has created a simplified Node library to make this easy for Okta applications, [Okta JWT Verifier](https://www.npmjs.com/package/@okta/jwt-verifier).  Below is an example that shows you how to validate access tokens for a specific Okta authorization server (the issuer) and adds a secondary check for the audience of the token. To learn more about validating Okta access tokens, please see [Validating Access Tokens](https://developer.okta.com/standards/OAuth/index.html#validating-access-tokens).
 
 ```javascript
 const OktaJwtVerifier = require('@okta/jwt-verifier');

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -125,6 +125,18 @@ function check_for_localhost_links() {
     fi
 }
 
+# Verify for occurences of 'index' contain .html
+function check_index_links() {
+    local dir=$(pwd)/_source
+    local links=$(grep -EoR "index#"  --include="*.md" $dir --exclude={README.md,package.json} | sort | uniq )
+    if [ "$links" ];
+    then
+        echo $links
+        echo "A link contains index without the filetype!"
+        return 1
+    fi
+}
+
 # Check for broken markdown headers
 function header_checker() {
     local dir=$(pwd)

--- a/scripts/post-build-lint.sh
+++ b/scripts/post-build-lint.sh
@@ -8,6 +8,12 @@ then
     exit 1;
 fi
 
+if ! check_index_links ;
+then
+    echo "Failed index href check. Please use the proper file type"
+    exit 1;
+fi
+
 if ! header_checker ;
 then
     echo "Failed header checker!"

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -22,7 +22,7 @@ export GENERATED_SITE_LOCATION="dist"
 # 5. Run Lint checker
 npm run post-build-lint
 
-if ! url_consistency_check || ! duplicate_slug_in_url || ! check_for_localhost_links ; then
+if ! url_consistency_check || ! duplicate_slug_in_url || ! check_for_localhost_links || ! check_index_links; then
   echo "FAILED LINT CHECK!"
   exit 1;
 fi


### PR DESCRIPTION
## Description:
- :bug: Fixes deep-linked URLs that do not append `.html` to the `index` file.

This resolves the `404` issue when viewing on the [staging site](https://d384qaxymvjmjw.cloudfront.net).
 
### Resolves:
<!-- Required for Okta-generated PRs -->
* [OKTA-147212](https://oktainc.atlassian.net/browse/OKTA-147212)

