### PR TITLE
:bug: Fixes URL in iframe

### DIFF
--- a/_source/_assets/js/myOkta.js
+++ b/_source/_assets/js/myOkta.js
@@ -1,6 +1,6 @@
 (function($) {    
   $(function() {
-    var iframe = $('<iframe id="myOktaIFrame" src="https://login.okta.com/discovery/iframe.html" style="display:none"></iframe>');
+    var iframe = $('<iframe id="myOktaIFrame" src="https://login.okta.com" style="display:none"></iframe>');
 
     $('body').append(iframe);
 

--- a/_source/_plugins/ApiTags.rb
+++ b/_source/_plugins/ApiTags.rb
@@ -59,11 +59,10 @@ module Okta
     end
   end
 
-  Jekyll::Hooks.register [:pages, :posts], :post_render do |pages|
+  Jekyll::Hooks.register [:pages, :posts, :documents], :post_render do |pages|
     # Replaces all occurences of 'yourOktaDomain' with a searchable span
     pages.output = pages.output.gsub(/https:\/\/{yourOktaDomain}.com/, '<span class="okta-preview-domain">https://{yourOktaDomain}.com</span>')
   end
-
 end
 
 Liquid::Template.register_tag('api_lifecycle', Okta::ApiLifecycleTag)


### PR DESCRIPTION
## Description:
- :bug: Fixes the URL the hidden `iframe` was accessing

Not sure how this was passing before, but when trying to access the URL <https://login.okta.com/discovery/iframe.html>, we receive the following event data:

```
{
  messageType: "iframe_loaded"
}
```

Updating the URL to point directly to <https://login.okta.com> correctly loads the user accounts, and returns the expected user JSON. 


![gif](http://g.recordit.co/M7GY9AO5mw.gif)
