### PR TITLE
Fix misused 'yourOktaDomain' tags

### DIFF
--- a/_source/_authentication-guide/implementing-authentication/set-up-authz-server.md
+++ b/_source/_authentication-guide/implementing-authentication/set-up-authz-server.md
@@ -168,7 +168,7 @@ We have included here a few things that you can try to ensure that your Authoriz
 
 ### OpenID Connect Configuration
 
-To verify that your server was created and has the expected configuration values, you can send an API request to the Server's OpenID Connect Metadata URI: `https://{yourOktaDomain}/oauth2/{authorizationServerId}/.well-known/openid-configuration` using an HTTP client or by typing the URI inside of a browser. This will return information about the OpenID configuration of your Authorization Server, though it does not currently return any custom scopes or claims that you might have created.
+To verify that your server was created and has the expected configuration values, you can send an API request to the Server's OpenID Connect Metadata URI: `https://{yourOktaDomain}.com/oauth2/{authorizationServerId}/.well-known/openid-configuration` using an HTTP client or by typing the URI inside of a browser. This will return information about the OpenID configuration of your Authorization Server, though it does not currently return any custom scopes or claims that you might have created.
 
 For more information on this endpoint, see here: [Retrieve Authorization Server OpenID Connect Metadata](/docs/api/resources/oauth2.html#retrieve-authorization-server-openid-connect-metadata).
 
@@ -201,7 +201,7 @@ You will need the following values from your Okta OpenID Connect application, bo
 
 Once you have an OpenID Connect Application set-up, and a User assigned to it you can try the authentication flow.
 
-First, you will need your Authorization Server's Authorization Endpoint, which you can retrieve using the Server's Metadata URI: `https://{yourOktaDomain}/oauth2/:authorizationServerId/.well-known/openid-configuration`. It will look like this:
+First, you will need your Authorization Server's Authorization Endpoint, which you can retrieve using the Server's Metadata URI: `https://{yourOktaDomain}.com/oauth2/:authorizationServerId/.well-known/openid-configuration`. It will look like this:
 
 `https://{yourOktaDomain}.com/oauth2/{authorizationServerId}/v1/authorize`
 

--- a/_source/_code/php/jwt-validation.md
+++ b/_source/_code/php/jwt-validation.md
@@ -30,7 +30,7 @@ endpoint is listed in your authorization server dashboard and looks like
 Once you have your .well-known URL, have your application make a request to this endpoint and `json_decode` the results.
 
 ```php
-$keys = json_decode(file_get_contents('https://{yourOktaDomain}/oauth2/{authorizationServerId}/v1/keys'));
+$keys = json_decode(file_get_contents('https://{yourOktaDomain}.com/oauth2/{authorizationServerId}/v1/keys'));
 ```
 
 This will return a JSON object of any keys. Typically, this will return a single key entry, but can return a set of keys. 

--- a/_source/quickstart/java/generic-implicit.md
+++ b/_source/quickstart/java/generic-implicit.md
@@ -34,7 +34,7 @@ public static class OktaAccessTokenFilter implements Filter {
 
         try {
             this.jwtVerifier = new JwtHelper()
-                    .setIssuerUrl("https://{yourOktaOrg}.com/oauth2/default"))
+                    .setIssuerUrl("https://{yourOktaDomain}.com/oauth2/default"))
                     .setAudience("api://default")
                     .build();
 

--- a/_source/quickstart/nodejs/express-implicit.md
+++ b/_source/quickstart/nodejs/express-implicit.md
@@ -11,7 +11,7 @@ const OktaJwtVerifier = require('@okta/jwt-verifier');
 var cors = require('cors');
 
 const oktaJwtVerifier = new OktaJwtVerifier({
-  issuer: 'http://{yourOktaDomain}.com/oauth2/default',
+  issuer: 'https://{yourOktaDomain}.com/oauth2/default',
   assertClaims: {
     aud: 'api://default',
   },

--- a/_source/quickstart/nodejs/generic-implicit.md
+++ b/_source/quickstart/nodejs/generic-implicit.md
@@ -9,7 +9,7 @@ Okta has created a simplified Node library to make this easy for Okta applicatio
 const OktaJwtVerifier = require('@okta/jwt-verifier');
 
 const oktaJwtVerifier = new OktaJwtVerifier({
-  issuer: 'http://{your-okta-org-url}/oauth2/default',
+  issuer: 'https://{yourOktaDomain}.com/oauth2/default',
   assertClaims: {
     aud: 'api://default'
   }

--- a/_source/quickstart/php/generic-auth-code.md
+++ b/_source/quickstart/php/generic-auth-code.md
@@ -19,7 +19,7 @@ $query = http_build_query([
     'nonce' => $nonce
 ]);
 
-header('Location: ' . 'https://{yourOktaDomain}/oauth2/default/v1/authorize?'.$query);
+header('Location: ' . 'https://{yourOktaDomain}.com/oauth2/default/v1/authorize?'.$query);
 ```
 > The `nonce` should be a generated string such as UUID, and the `state` can be any string representing state of the 
 application.
@@ -53,7 +53,7 @@ function exchangeCode($code) {
         'Connection: close',
         'Content-Length: 0'
     ];
-    $url = 'https://{yourOktaDomain}}/oauth2/default/v1/token?' . $query;
+    $url = 'https://{yourOktaDomain}.com/oauth2/default/v1/token?' . $query;
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);


### PR DESCRIPTION
## Description:
- Fix various instances where `https://{yourOktaDomain}.com` should have been used.


