### PR TITLE
:seedling: Adds navigation to quickstarts

### DIFF
--- a/_source/_assets/css/okta/pages/_quickstarts.scss
+++ b/_source/_assets/css/okta/pages/_quickstarts.scss
@@ -48,6 +48,12 @@
   }
 }
 
+// Disable the margin width determined by the parent CSS.
+.PageContent.has-tableOfContents
+.PageContent-main {
+	max-width: none;
+}
+
 .example-content-well {
   padding: 10px 0;
   h1, h2, h3, h4, h5, h6 {

--- a/_source/_layouts/quickstart.html
+++ b/_source/_layouts/quickstart.html
@@ -2,7 +2,7 @@
 layout: base
 js: quickstart
 ---
-<section class="PageContent quickstart-page">
+<section class="PageContent quickstart-page has-tableOfContents">
   <!-- START Page Content -->
   <div class="PageContent-main" id="docs-body">
     <h1>{{ page.title }}</h1>
@@ -31,6 +31,11 @@ js: quickstart
     </div>
     
     <div id="server_content" class="example-content-well"></div>
+  </div>
+
+  <div class="TableOfContents TableOfContentsPreload">
+     <a class="TableOfContents-item is-level2" style="display: block;" onclick="scrollToClient()" id="client_setup_link">Client Setup</a>
+     <a class="TableOfContents-item is-level2" style="display: block;" onclick="scrollToServer()" id="server_setup_link">Server Setup</a>
   </div>
   <!-- END Page Content -->
 </section><!-- END Page Center w/Sub Nav & Content -->

--- a/tests/selenium/framework/page-objects/QuickStartsPage.js
+++ b/tests/selenium/framework/page-objects/QuickStartsPage.js
@@ -7,6 +7,9 @@ class QuickStartsPage extends BasePage {
   constructor(url) {
     super(url);
     this.$clientSelector = $('#client-selector');
+    this.$skipToServerSetup = element(by.linkText('Skip to server setup'));
+    this.$clientSetupLink = $('#client_setup_link');
+    this.$serverSetupLink = $('#server_setup_link');
     this.$androidLink = element(by.linkText('Android'));
     this.$angularLink = element(by.linkText('Angular'));
     this.$iOSLink = element(by.linkText('iOS'));
@@ -28,6 +31,22 @@ class QuickStartsPage extends BasePage {
     this.$$frameworkLinks = $$('#framework-selector a');
 
     this.setPageLoad(this.$clientSelector);
+  }
+
+  selectClientSetupLink() {
+    return this.$clientSetupLink.click();
+  }
+
+  selectServerSetupLink() {
+    return this.$serverSetupLink.click();
+  }
+
+  getSkipLink() {
+    return this.$skipToServerSetup;
+  }
+
+  getNodeJSLink() {
+    return this.$nodeJSLink;
   }
 
   selectSignInWidget() {

--- a/tests/selenium/spec/quickstarts-spec.js
+++ b/tests/selenium/spec/quickstarts-spec.js
@@ -18,6 +18,14 @@ describe('quickstarts page spec', () => {
       ])).toBe(true);
   });
 
+  it('can toggle to client and server setup via right-side nav', () => {
+    quickstartsPage.resizeXLarge();
+    quickstartsPage.waitUntilOnScreen(quickstartsPage.getSkipLink());    
+    quickstartsPage.selectServerSetupLink();
+    quickstartsPage.waitUntilOnScreen(quickstartsPage.getNodeJSLink());
+    quickstartsPage.selectClientSetupLink();
+  });
+
   it('can select all client setups', () => {
     quickstartsPage.selectSignInWidget();
     expect(quickstartsPage.urlContains("/widget")).toBe(true);


### PR DESCRIPTION
## Description:
- Adds ride-side navigation to quickstarts
- Mocks: <https://okta.invisionapp.com/share/2FBI90NN7#/screens/240193150>
- Tests: Since the URL on the page isn't updating, it was difficult to expect a condition to resolve. Instead, we wait for specific elements to appear/disappear on the page.

![Gif](http://g.recordit.co/xi9eXufh8u.gif)

### Resolves:
* [OKTA-138596](https://oktainc.atlassian.net/browse/OKTA-138596)

