### PR TITLE
:bug: Fixes parent CSS being overwritten

### DIFF
--- a/_source/_assets/css/okta/pages/_quickstarts.scss
+++ b/_source/_assets/css/okta/pages/_quickstarts.scss
@@ -1,4 +1,4 @@
-.Page.authentication-quickstart-guide {
+.Page.okta-authentication-quickstart-guides {
   background: #20313b;
 }
 .code-selector {
@@ -79,6 +79,16 @@
   h2 {
     border-bottom: none;
     font-size: 23px;
+    font-weight: lighter;
+  }
+  h3 {
+    border-bottom: none;
+    font-size: 21px;
+    font-weight: lighter;
+  }
+  h4 {
+    border-bottom: none;
+    font-size: 18px;
     font-weight: lighter;
   }
   .TableOfContents-item{

--- a/_source/_assets/css/okta/pages/_quickstarts.scss
+++ b/_source/_assets/css/okta/pages/_quickstarts.scss
@@ -1,3 +1,6 @@
+.Page.authentication-quickstart-guide {
+  background: #20313b;
+}
 .code-selector {
   background-color: rgb(32, 49, 59);
   border-radius: 5px;
@@ -29,13 +32,13 @@
       border-bottom: 2px solid #fff;
     }
     .icon {
-      left: 15px;
+      left: 5px;
       position: absolute;
     }
   }
 
   li.with-icon a{
-    padding-left: 55px;
+    padding-left: 45px;
   }
 
   ul {
@@ -49,10 +52,13 @@
 }
 
 // Disable the margin width determined by the parent CSS.
-.PageContent.has-tableOfContents
-.PageContent-main {
-	max-width: none;
+.PageContent.quickstart-page.has-tableOfContents
+.PageContent-main#quickstart-body {
+  max-width: none;
+  padding: 30px;
+  padding-right: 0px;
 }
+
 
 .example-content-well {
   padding: 10px 0;

--- a/_source/_layouts/quickstart.html
+++ b/_source/_layouts/quickstart.html
@@ -4,7 +4,7 @@ js: quickstart
 ---
 <section class="PageContent quickstart-page has-tableOfContents">
   <!-- START Page Content -->
-  <div class="PageContent-main" id="docs-body">
+  <div class="PageContent-main" id="quickstart-body">
     <h1>{{ page.title }}</h1>
 
     These quickstart instructions will help you integrate Okta into your existing front-end and/or backend application.


### PR DESCRIPTION
## Description:
- :bug: Fixes overwritten CSS on docs page
- :art: Minor style changes to make all quickstart icons appear in one line

What happened: Since our CSS files are loaded on every page, the altered `quickstart.css` page changed the `max-width` element across all elements who used `PageContent has-tableOfContents PageContent-main`.

Now, we only apply the change to elements containing the id: `quickstart-body`

### Resolves:
* [OKTA-147799](https://oktainc.atlassian.net/browse/OKTA-147799)

