### PR TITLE
Fix filter documentation for /api/v1/zones

### DIFF
--- a/_source/_docs/api/resources/zones.md
+++ b/_source/_docs/api/resources/zones.md
@@ -378,7 +378,7 @@ curl -X GET \
 
 Lists all zones that match the filter criteria
 
-This operation requires [URL encoding](/docs/api/getting_started/design_principles.html#filtering). For example, `filter=type eq "IP"` is encoded as `filter=type%20eq%20%22IP%22`.
+This operation requires [URL encoding](/docs/api/getting_started/design_principles.html#filtering). For example, `filter=(id eq "nzoul0wf9jyb8xwZm0g3" or id eq "nzoul1MxmGN18NDQT0g3")` is encoded as `filter=%28id+eq+%22nzoul0wf9jyb8xwZm0g3%22+or+id+eq+%22nzoul1MxmGN18NDQT0g3%22%29`.
 
 See [Filtering](/docs/api/getting_started/design_principles.html#filtering) for more information about the expressions used in filtering.
 


### PR DESCRIPTION
## Description:
- [Some context](https://oktainc.atlassian.net/browse/REQ-10190?focusedCommentId=529452&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-529452)
- Previously our docs for `/api/v1/zones` suggested that the API supported filtering by type. That is in fact not the case as we can only filter on ids
- updated the example to use filtering on ids, not type
- note that the curl request was already correct, just the description was wrong
- my only concern is that the line is very long so it wraps now. That being said it's important that we show filtering on a list of at least 2 ids because if it was just 1 id, they would actually use a different end point `/api/v1/zones/{ZONE_ID}`

<img width="1357" alt="screen shot 2017-11-08 at 13 09 45" src="https://user-images.githubusercontent.com/21957865/32574468-2d16f6b4-c486-11e7-917a-1ee864f288f1.png">


### Resolves:

<!-- Required for Okta-generated PRs -->
* [OKTA-148100](https://oktainc.atlassian.net/browse/OKTA-148100)

