### PR TITLE
Blacklist specific links during html-proofer check

### DIFF
--- a/_source/_includes/head.html
+++ b/_source/_includes/head.html
@@ -52,7 +52,7 @@
   {% endif %}
   <title>{% if page.meta_title %}{{ page.meta_title }}{% elsif page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-  <link rel="canonical" href="{{ page.url | replace:'/index.html','/' | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="canonical" href="{{ page.url | replace:'/index.html','/' | prepend: site.baseurl | prepend: site.url }}"  data-proofer-ignore>
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}"><!-- GA -->
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/_source/_layouts/docs_page.html
+++ b/_source/_layouts/docs_page.html
@@ -8,7 +8,7 @@ variant: docs_base
       <!-- START Fixed sidebar -->{% include sidebar.html %}<!-- END Fixed sidebar -->
       <!-- START Page Content -->
       <div class="PageContent-main" id="docs-body">
-        <a id="edit-link" href="{{ site.github_edit_url }}{{ page.relative_path }}">Edit Page</a>
+        <a id="edit-link" href="{{ site.github_edit_url }}{{ page.relative_path }}" data-proofer-ignore>Edit Page</a>
       {{ content }}
       </div>
       <div class="TableOfContents TableOfContentsPreload">


### PR DESCRIPTION
## Description:
- :bug: Fixes a bug where the GitHub edit link and page canonical link were checked by the `html-proofer` lib.