### PR TITLE
Fixing the flaky blog page spec test

### DIFF
--- a/tests/selenium/framework/page-objects/BlogPage.js
+++ b/tests/selenium/framework/page-objects/BlogPage.js
@@ -20,7 +20,7 @@ class BlogPage extends BasePage {
 
   isPaginationVisible() {
     this.waitForPresence(this.$pagination);
-    return this.$pagination.isDisplayed();
+    return this.$pagination.isPresent();
   }
 
   clickNext() {
@@ -42,6 +42,7 @@ class BlogPage extends BasePage {
   clickReadMoreOnPost(post) {
     const blogPost = this.$$blogPost.get(post);
     const readMoreLink = blogPost.element(by.linkText('Read more'));
+    this.waitForPresence(readMoreLink);
     return readMoreLink.click();
   }
 


### PR DESCRIPTION
## Description:
- Blog page spec is flaky sometimes when run locally
- This fixes the test by waiting for the presence of certain links

### Resolves:
* [Issue #X](#X)
<!-- Required for Okta-generated PRs -->
* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

