### PR TITLE
hotfix for missing formatting

### DIFF
--- a/_source/_docs/platform-release-notes/platform-release-notes.md
+++ b/_source/_docs/platform-release-notes/platform-release-notes.md
@@ -1,7 +1,7 @@
 ---
 layout: docs_page
 title: Okta API Release Notes
-excerpt: Release Note for 2017.47: Bug fix to partial profile update
+excerpt: Release Note for 2017.47 Bug fix to partial profile update
 ---
 
 ## Okta API Release Notes for Release 2017.47

--- a/_source/_docs/platform-release-notes/platform-release-notes2017-46.md
+++ b/_source/_docs/platform-release-notes/platform-release-notes2017-46.md
@@ -1,7 +1,7 @@
 ---
 layout: docs_page
 title: Okta API Release Notes
-excerpt: 2017.46 Release Note: HAL link bug fixed
+excerpt: 2017.46 Release Note HAL link bug fixed
 ---
 
 ## Okta API Release Notes for Release 2017.46


### PR DESCRIPTION
## Description:
- A colon in excerpt kills all CSS formatting. Missed this in two files

### Resolves:
 [OKTA-149555](https://oktainc.atlassian.net/browse/OKTA-149555)

