### PR TITLE
Updated iOS quickstart

### DIFF
--- a/_source/quickstart/ios/default-example.md
+++ b/_source/quickstart/ios/default-example.md
@@ -143,16 +143,6 @@ OktaAuth
   }
 ```
 
-When starting up the application, check for the existence of an `access_token` to see if the user has an existing session:
-
-```swift
-if let currentToken = OktaAuth.tokens.get(forKey: "accessToken") {
-  // Token is valid!
-} else {
-  // Token does not exist, prompt the user to login.
-}
-```
-
 ## Using the Access Token
 
 Your iOS application now has an access token in the Keychain that was issued by your Okta Authorization server. You can use this token to authenticate requests for resources on your server or API. As a hypothetical example, let's say that you have an API that gives us messages for our user.  You could create a `callMessagesApi` function that gets the access token from the Keychain, and use it to make an authenticated request to your server.


### PR DESCRIPTION
## Description:
- Removes snippet to manage the User's session, as the current implementation will always return `nil`

This 🐛 can be tracked [here](https://oktainc.atlassian.net/browse/OKTA-150370)

