### PR TITLE
:fire: Updates links to end in '.html' or '/'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,6 @@ plugins:
   - jekyll-redirect-from
   - jekyll-paginate
   - jekyll-assets
-  - jekyll-redirect-from
 
 source: _source
 destination: dist
@@ -25,7 +24,7 @@ kramdown:
   syntax_highlighter: rouge
   toc_levels: 1..3
 
-permalink: /blog/:year/:month/:day/:title
+permalink: /blog/:year/:month/:day/:title.html
 
 support_phone_number: "1-888-722-7871"
 github_base_url: "https://github.com/okta/okta.github.io/tree/source/_source/"
@@ -41,7 +40,6 @@ ga_ua_id: "UA-15777010-3"
 production_url: "https://developer.okta.com"
 
 include: [_static, .nojekyll, .woff, .tff]
-
 
 assets:
   compress:
@@ -61,25 +59,32 @@ assets:
     automatic_img_alt : true
 
 collections:
-  standards:
+  3rd_party_notices:
     output: true
+    permalink: /:collection/:path:output_ext
+  authentication-guide:
+    output: true
+    permalink: /:collection/:path:output_ext
   code:
     output: true
     permalink: /:collection/:path:output_ext
-  use_cases:
+  docs:
     output: true
-  authentication-guide:
+    permalink: /:collection/:path:output_ext
+  documentation:
+    output: true
+  quickstarts:
     output: true
     permalink: /:collection/:path:output_ext
   reference:
     output: true
-  3rd_party_notices:
-    output: true
-  docs:
+    permalink: /:collection/:path:output_ext
+  standards:
     output: true
     permalink: /:collection/:path:output_ext
-  quickstarts:
+  use_cases:
     output: true
+    permalink: /:collection/:path:output_ext
 
 paginate: 10
 paginate_path: "/blog/page/:num"

--- a/_source/_authentication-guide/auth-overview/index.md
+++ b/_source/_authentication-guide/auth-overview/index.md
@@ -59,7 +59,7 @@ The usual OAuth 2.0 grant flow looks like this:
 3. If the grant is valid, the authorization server returns an access token, possibly alongside a refresh and/or ID token.
 4. The client now uses that access token to access the resource server.
 
-> For a deeper dive into OAuth 2.0, see [What the Heck is OAuth?](/blog/2017/06/21/what-the-heck-is-oauth) over on the Okta Developer blog.
+> For a deeper dive into OAuth 2.0, see [What the Heck is OAuth?](/blog/2017/06/21/what-the-heck-is-oauth.html) over on the Okta Developer blog.
 > 
 > If you'd like to see the OAuth 2.0 spec, you can find it here: <https://tools.ietf.org/html/rfc6749>
 
@@ -173,7 +173,7 @@ app -> client: Response
 
 -->
 
-For information how to set up your application to use this flow, see [Implement the Authorization Code Flow](/authentication-guide/implementing-authentication/auth-code).
+For information how to set up your application to use this flow, see [Implement the Authorization Code Flow](/authentication-guide/implementing-authentication/auth-code.html).
 
 ### Authorization Code with PKCE
 
@@ -213,7 +213,7 @@ app -> client: Response
 
 -->
 
-For information how to set up your application to use this flow, see [Implement the Authorization Code Flow with PKCE](/authentication-guide/implementing-authentication/auth-code-pkce).
+For information how to set up your application to use this flow, see [Implement the Authorization Code Flow with PKCE](/authentication-guide/implementing-authentication/auth-code-pkce.html).
 
 ### Implicit Flow
 
@@ -240,7 +240,7 @@ client -> app: Request with access token
 app -> client: Response
 -->
 
-For information how to set up your application to use this flow, see [Implement the Implicit Flow](/authentication-guide/implementing-authentication/implicit).
+For information how to set up your application to use this flow, see [Implement the Implicit Flow](/authentication-guide/implementing-authentication/implicit.html).
 
 ### Resource Owner Password Flow 
 
@@ -265,7 +265,7 @@ app -> client: Response
 
 -->
 
-For information how to set up your application to use this flow, see [Implement the Resource Owner Password Flow](/authentication-guide/implementing-authentication/password).
+For information how to set up your application to use this flow, see [Implement the Resource Owner Password Flow](/authentication-guide/implementing-authentication/password.html).
 
 ### Client Credentials Flow
 
@@ -290,4 +290,4 @@ app -> client: Response
 
 -->
 
-For information how to set up your application to use this flow, see [Implement the Client Credentials Flow](/authentication-guide/implementing-authentication/client-creds).
+For information how to set up your application to use this flow, see [Implement the Client Credentials Flow](/authentication-guide/implementing-authentication/client-creds.html).

--- a/_source/_authentication-guide/implementing-authentication/auth-code-pkce.md
+++ b/_source/_authentication-guide/implementing-authentication/auth-code-pkce.md
@@ -94,7 +94,7 @@ curl --request POST \
   3puUjFaYWg3T1NDTDQtcW1ROUY5YXlwalNoc0hhakxifmZHag'
 ```
 
-> Important: Unlike the regular [Authorization Code Flow](auth-code), this call does not require the Authorization header with the client ID and secret. This is why this version of the Authorization Code flow is appropriate for native apps.
+> Important: Unlike the regular [Authorization Code Flow](/authentication-guide/implementing-authentication/auth-code.html), this call does not require the Authorization header with the client ID and secret. This is why this version of the Authorization Code flow is appropriate for native apps.
 
 Note the parameters that are being passed:
 
@@ -119,7 +119,7 @@ If the code is still valid, and the code verifier matches, your application will
 
 ### 4. Next Steps
 
-When your application passes a request with an `access_token`, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens).
+When your application passes a request with an `access_token`, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens.html).
 
 ### Examples
 

--- a/_source/_authentication-guide/implementing-authentication/auth-code.md
+++ b/_source/_authentication-guide/implementing-authentication/auth-code.md
@@ -93,7 +93,7 @@ If the code is still valid, your application will receive back access and ID tok
 
 ### 4. Next Steps
 
-When your application passes a request with an `access_token`, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens).
+When your application passes a request with an `access_token`, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens.html).
 
 ### Examples
 

--- a/_source/_authentication-guide/implementing-authentication/client-creds.md
+++ b/_source/_authentication-guide/implementing-authentication/client-creds.md
@@ -60,4 +60,4 @@ If the credentials are valid, the application will receive back an access token:
 
 ### 3. Next Steps
 
-When your application sends a request with an access_token, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens).
+When your application sends a request with an access_token, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens.html).

--- a/_source/_authentication-guide/implementing-authentication/implicit.md
+++ b/_source/_authentication-guide/implementing-authentication/implicit.md
@@ -59,7 +59,7 @@ Your application must now extract the token(s) from the URI and store them.
 
 ### 3. Next Steps
 
-When your application passes a request with an `access_token`, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens).
+When your application passes a request with an `access_token`, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens.html).
 
 ### Examples
 

--- a/_source/_authentication-guide/implementing-authentication/index.md
+++ b/_source/_authentication-guide/implementing-authentication/index.md
@@ -11,7 +11,7 @@ This section covers the steps required to integrate an OAuth 2.0 authentication 
 
 Before you can use OAuth 2.0 flows with Okta, you will need to configure an Authorization Server in Okta. If you have an Okta Developer Account, you already have a default Authorization Server created for you. 
 
-If you don't have an existing authorizations server, or would like to create a new one, then you can find out how to do that in the [Setting up an Authorization Server](set-up-authz-server) section.
+If you don't have an existing authorizations server, or would like to create a new one, then you can find out how to do that in the [Setting up an Authorization Server](/authentication-guide/implementing-authentication/set-up-authz-server.html) section.
 
 Once you have an authorization server, you can then implement an OAuth 2.0 flow. 
 
@@ -21,8 +21,8 @@ The table below shows you which OAuth 2.0 flow to use for the type of applicatio
 
 | Type of Application     | OAuth 2.0 Flow|
 |-----------------------------|----------------------------------------|
-| Server-side (AKA Web)    | [Authorization Code Flow](auth-code)|
-| Single-Page Application   | [Implicit Flow](implicit)|
-| Native                | [Authorization Code Flow with PKCE](auth-code-pkce)|
-| Trusted               | [Resource Owner Password Flow](password)|
-| Service               | [Client Credentials](client-creds)|
+| Server-side (AKA Web)    | [Authorization Code Flow](/authentication-guide/implementing-authentication/auth-code.html)|
+| Single-Page Application   | [Implicit Flow](/authentication-guide/implementing-authentication/implicit.html)|
+| Native                | [Authorization Code Flow with PKCE](/authentication-guide/implementing-authentication/auth-code-pkce.html)|
+| Trusted               | [Resource Owner Password Flow](/authentication-guide/implementing-authentication/password.html)|
+| Service               | [Client Credentials](/authentication-guide/implementing-authentication/client-creds.html)|

--- a/_source/_authentication-guide/implementing-authentication/password.md
+++ b/_source/_authentication-guide/implementing-authentication/password.md
@@ -66,4 +66,4 @@ If the credentials are valid, your application will receive back access and ID t
 
 ### 3. Next Steps
 
-When your application passes a request with an access token, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens).
+When your application passes a request with an access token, the resource server will need to validate it. For more on this, see [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens.html).

--- a/_source/_authentication-guide/social-login/facebook.md
+++ b/_source/_authentication-guide/social-login/facebook.md
@@ -40,7 +40,7 @@ title: Facebook
 * **Client Secret:** Paste in the App Secret that you got from Facebook in step 1.5 above.
 * **Scopes:** Leave set to the default.
 
-> For more information about these, see [Social Identity Provider Settings](social-settings).
+> For more information about these, see [Social Identity Provider Settings](/authentication-guide/social-login/social-settings.html).
 
 2.5. Once you have completed all the fields, click on **Add Identity Provider**. You will be returned to the main “Identity Providers” page. 
 

--- a/_source/_authentication-guide/social-login/google.md
+++ b/_source/_authentication-guide/social-login/google.md
@@ -42,7 +42,7 @@ title: Google
 * **Client Secret:** Paste in the App Secret that you got from Google in step 1.3 above.
 * **Scopes:** Leave set to the default.
 
-> For more information about these, see [Social Identity Provider Settings](social-settings).
+> For more information about these, see [Social Identity Provider Settings](/authentication-guide/social-login/social-settings.html).
 
 2.5. Once you have completed all the fields, click on **Add Identity Provider**. You will be returned to the main “Identity Providers” page. 
 

--- a/_source/_authentication-guide/social-login/index.md
+++ b/_source/_authentication-guide/social-login/index.md
@@ -12,10 +12,10 @@ Okta allows your users to sign in to your app using credentials from external so
 
 Currently Okta supports the following social login providers:
 
-- [Facebook](facebook)
-- [Google](google)
-- [LinkedIn](linkedin)
-- [Microsoft](microsoft)
+- [Facebook](/authentication-guide/social-login/facebook.html)
+- [Google](/authentication-guide/social-login/google.html)
+- [LinkedIn](/authentication-guide/social-login/linkedin.html)
+- [Microsoft](/authentication-guide/social-login/microsoft.html)
 
 ### Features
 
@@ -72,4 +72,4 @@ To set up social login, configure the following:
 2. An Identity Provider in Okta
 3. An OpenID Connect Application in Okta
 
-Every Identity Provider in Okta is linked to an Application, and every time a user signs in with a Social Identity Provider for the first time, an Application User is created for them. The Application User represents the external user at the Social Identity Provider and can be used to map attributes to the Okta User. For more information about how to configure this behavior see [Social Identity Provider Settings](social-settings) below.
+Every Identity Provider in Okta is linked to an Application, and every time a user signs in with a Social Identity Provider for the first time, an Application User is created for them. The Application User represents the external user at the Social Identity Provider and can be used to map attributes to the Okta User. For more information about how to configure this behavior see [Social Identity Provider Settings](/authentication-guide/social-login/social-settings.html) below.

--- a/_source/_authentication-guide/social-login/linkedin.md
+++ b/_source/_authentication-guide/social-login/linkedin.md
@@ -38,7 +38,7 @@ title: LinkedIn
 * **Client Secret:** Paste in the App Secret that you got from LinkedIn in step 1.3 above.
 * **Scopes:** Leave set to the default.
 
-> For more information about these, see [Social Identity Provider Settings](social-settings).
+> For more information about these, see [Social Identity Provider Settings](/authentication-guide/social-login/social-settings.html).
 
 2.5. Once you have completed all the fields, click on **Add Identity Provider**. You will be returned to the main “Identity Providers” page. 
 

--- a/_source/_authentication-guide/social-login/microsoft.md
+++ b/_source/_authentication-guide/social-login/microsoft.md
@@ -37,7 +37,7 @@ title: Microsoft
 * **Client Secret:** Paste in the App Secret that you got from Microsoft in step 1.4 above.
 * **Scopes:** Leave set to the default.
 
-> For more information about these, see [Social Identity Provider Settings](social-settings).
+> For more information about these, see [Social Identity Provider Settings](/authentication-guide/social-login/social-settings.html).
 
 2.5. Once you have completed all the fields, click on **Add Identity Provider**. You will be returned to the main “Identity Providers” page. 
 

--- a/_source/_authentication-guide/tokens/index.md
+++ b/_source/_authentication-guide/tokens/index.md
@@ -13,7 +13,7 @@ Additional information about ID tokens can be found here: <https://developer.okt
 
 This section will help you understand token validation, revocation, as well as how to use a refresh token to get a new access token.
 
-- [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens)
-- [Validating ID Tokens](/authentication-guide/tokens/validating-id-tokens)
-- [Refreshing Access Tokens](/authentication-guide/tokens/refreshing-tokens)
-- [Revoking Tokens](/authentication-guide/tokens/revoking-tokens)
+- [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens.html)
+- [Validating ID Tokens](/authentication-guide/tokens/validating-id-tokens.html)
+- [Refreshing Access Tokens](/authentication-guide/tokens/refreshing-tokens.html)
+- [Revoking Tokens](/authentication-guide/tokens/revoking-tokens.html)

--- a/_source/_authentication-guide/tokens/refreshing-tokens.md
+++ b/_source/_authentication-guide/tokens/refreshing-tokens.md
@@ -29,7 +29,7 @@ In the case of the Authorization Code flow, you use the Authorization Server's `
 
 For the Authorization Code and Resource Owner Password flows, you use the Authorization Server's `/token` endpoint directly. For more information about this endpoint, see [Request a Token](/docs/api/resources/oauth2.html#request-a-token). For more information about the Client Credentials and Resource Owner Password flows, see:
 
-- [Implementing the Authorization Code Flow](/authentication-guide/implementing-authentication/auth-code)
+- [Implementing the Authorization Code Flow](/authentication-guide/implementing-authentication/auth-code.html)
 - [Implementing the Resource Owner Password Flow](/authentication-guide/implementing-authentication/password.html)
 
 The following combinations of grant type and scope, when sent to `/token` endpoint, will return a refresh token:

--- a/_source/_authentication-guide/tokens/validating-access-tokens.md
+++ b/_source/_authentication-guide/tokens/validating-access-tokens.md
@@ -42,7 +42,7 @@ The high-level overview of validating an access token looks like this:
 
 ### Retrieve The JSON Web Keys
 
-The JSON Web Keys (JWK) need to be retrieved from your [Okta Authorization Server](/authentication-guide/implementing-authentication/set-up-authz-server), though your application should have them cached. Specifically, your Authorization Server's Metadata endpoint contains the `jwks_uri`, which you can use to get the JWK. 
+The JSON Web Keys (JWK) need to be retrieved from your [Okta Authorization Server](/authentication-guide/implementing-authentication/set-up-authz-server.html), though your application should have them cached. Specifically, your Authorization Server's Metadata endpoint contains the `jwks_uri`, which you can use to get the JWK. 
 
 > For more information about retrieving this metadata, see [Retrieve Authorization Server Metadata](/docs/api/resources/oauth2.html#retrieve-authorization-server-metadata).
  

--- a/_source/_authentication-guide/tokens/validating-id-tokens.md
+++ b/_source/_authentication-guide/tokens/validating-id-tokens.md
@@ -31,7 +31,7 @@ The ID Token is a security token granted by the OpenID Provider that contains in
 
 You can pass an ID Token around different components of your client, and these components can use the ID Token to confirm that the user is authenticated and also to retrieve information about them.
 
-Access tokens, on the other hand, are not intended to carry information about the user. They simply allow access to certain defined server resources. More discussion about when to use access tokens can be found in [Validating Access Tokens](validating-access-tokens).
+Access tokens, on the other hand, are not intended to carry information about the user. They simply allow access to certain defined server resources. More discussion about when to use access tokens can be found in [Validating Access Tokens](/authentication-guide/tokens/validating-access-tokens.html).
 
 ## What to Check When Validating an ID Token 
 
@@ -44,7 +44,7 @@ The high-level overview of validating an ID token looks like this:
 
 ### Retrieve The JSON Web Key Set
 
-The JSON Web Key Set (JWKS) needs to be retrieved from your [Okta Authorization Server](/authentication-guide/implementing-authentication/set-up-authz-server), though your application should have it cached. Specifically, your Authorization Server's Metadata endpoint contains the `jwks_uri`, which you can use to get the JWKS. 
+The JSON Web Key Set (JWKS) needs to be retrieved from your [Okta Authorization Server](/authentication-guide/implementing-authentication/set-up-authz-server.html), though your application should have it cached. Specifically, your Authorization Server's Metadata endpoint contains the `jwks_uri`, which you can use to get the JWKS. 
 
 > For more information about retrieving this metadata, see [Retrieve Authorization Server Metadata](/docs/api/resources/oauth2.html#retrieve-authorization-server-metadata).
 

--- a/_source/_code/javascript/index.md
+++ b/_source/_code/javascript/index.md
@@ -27,7 +27,7 @@ New to Okta? Our Quick Start Guide will walk you through adding user authenticat
 The Auth SDK builds on top of our Authentication API and OAuth 2.0 API to enable you to create a fully branded sign-in experience using JavaScript.  This SDK is meant to be used in front-end applications.
 
 <ul class='code-list'>
-  <li><span class='code-icon launch-16'></span> <a href='/code/javascript/okta_auth_sdk'>Okta Auth SDK Guide</a></li>
+  <li><span class='code-icon launch-16'></span> <a href='/code/javascript/okta_auth_sdk.html'>Okta Auth SDK Guide</a></li>
   <li><span class='code-icon expression-16'></span> <a href='https://github.com/okta/okta-auth-js'>Okta Auth SDK Source &amp; API Reference</a></li>
 </ul>
 
@@ -37,7 +37,7 @@ The Okta Sign-In Widget is a JavaScript library that gives you a pre-built, cust
 
 <ul class='code-list'>
   <li>
-    <span class='code-icon expression-16'></span> <a href='/code/javascript/okta_sign-in_widget'>Okta Sign-In Widget Guide</a>
+    <span class='code-icon expression-16'></span> <a href='/code/javascript/okta_sign-in_widget.html'>Okta Sign-In Widget Guide</a>
   </li>
   <li>
     <span class='fa fa-github'></span> <a href='https://github.com/okta/okta-signin-widget'>Okta Sign-In Widget Source &amp; API Reference</a>

--- a/_source/_code/javascript/okta_auth_sdk.md
+++ b/_source/_code/javascript/okta_auth_sdk.md
@@ -10,9 +10,9 @@ redirect_from:
 
 ## Okta Auth SDK Guide
 
-The Okta Auth SDK builds on top of our [Authentication API](/docs/api/resources/authn) and [OpenID Connect API](/docs/api/resources/oidc) to enable you to create a fully branded sign-in experience using JavaScript.
+The Okta Auth SDK builds on top of our [Authentication API](/docs/api/resources/authn.html) and [OpenID Connect API](/docs/api/resources/oidc.html) to enable you to create a fully branded sign-in experience using JavaScript.
 
-The Okta Auth SDK is used by Okta's [Sign-in Widget](/code/javascript/okta_auth_sdk) which powers the default Okta sign-in page. If you are building a JavaScript front end or Single Page App (SPA), the Auth SDK gives you added control and customization beyond what is possible with the Widget.
+The Okta Auth SDK is used by Okta's [Sign-in Widget](/code/javascript/okta_auth_sdk.html) which powers the default Okta sign-in page. If you are building a JavaScript front end or Single Page App (SPA), the Auth SDK gives you added control and customization beyond what is possible with the Widget.
 
 In this guide you will learn how to use the Auth SDK on a simple static page to:
 
@@ -170,7 +170,7 @@ Putting it all together, the final example looks like this:
 
 ## Part 2: Get an Okta Session Cookie
 
-In the code example above, the ID Token is retrieved using a redirect to the Okta sign-in page. It is also possible to take a user-inputted `username` and `password` pair and pass them to the `signIn` method. This method then initiates an authentication process which returns an [Okta session cookie](/use_cases/authentication/session_cookie#retrieving-a-session-cookie-by-visiting-a-session-redirect-link). This Okta session cookie can then be used, along with the `getWithRedirect` method, to get back the ID Token. This means that there is no need to redirect the user to the Okta sign-in page.
+In the code example above, the ID Token is retrieved using a redirect to the Okta sign-in page. It is also possible to take a user-inputted `username` and `password` pair and pass them to the `signIn` method. This method then initiates an authentication process which returns an [Okta session cookie](/use_cases/authentication/session_cookie.html#retrieving-a-session-cookie-by-visiting-a-session-redirect-link). This Okta session cookie can then be used, along with the `getWithRedirect` method, to get back the ID Token. This means that there is no need to redirect the user to the Okta sign-in page.
 
 [Read more about signIn in the Auth SDK Reference][authjs-reference-signin].
 

--- a/_source/_code/react/okta_react.md
+++ b/_source/_code/react/okta_react.md
@@ -35,7 +35,7 @@ If you do not already have a **Developer Edition Account**, you can create one a
 To quickly create a React app, we recommend the create-react-app CLI. Follow their guide [here](https://github.com/facebookincubator/create-react-app#quick-overview).
 
 ## Install Dependencies
-A simple way to add authentication to a React app is using the [Okta Auth JS](/code/javascript/okta_auth_sdk) library. We can install it via `npm`:
+A simple way to add authentication to a React app is using the [Okta Auth JS](/code/javascript/okta_auth_sdk.html) library. We can install it via `npm`:
 ```bash
 npm install @okta/okta-auth-js --save
 ```

--- a/_source/_docs/api/resources/oauth-clients.md
+++ b/_source/_docs/api/resources/oauth-clients.md
@@ -731,7 +731,7 @@ Property Details
 
 * The `client_secret` is only shown on the response of the creation or update of a client application (and only if the `token_endpoint_auth_method` is one that requires a client secret). You cannot specify the `client_secret` and if the `token_endpoint_auth_method` requires one Okta will generate a random `client_secret` for the client application.
 
-* If you want to specify the `client_id` or `client_secret`, you can use [Apps API](/docs/api/resources/apps#add-oauth-20-client-application) to create or update a client application.
+* If you want to specify the `client_id` or `client_secret`, you can use [Apps API](/docs/api/resources/apps.html#add-oauth-20-client-application) to create or update a client application.
 
 * At least one redirect URI and response type is required for all client types, with exceptions: if the client uses the
   [Resource Owner Password](https://tools.ietf.org/html/rfc6749#section-4.3) flow (if `grant_types` contains the value `password`)

--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -93,8 +93,7 @@ WWW-Authenticate: Bearer error="insufficient_scope", error_description="The acce
 ~~~
 
 #### Validating ID Tokens
-
-For more information on validating ID tokens, see our [Authentication Guide](/authentication-guide/tokens/validating-id-tokens).
+For more information on validating ID tokens, see our [Authentication Guide](/authentication-guide/tokens/validating-id-tokens.html).
 
 ### Introspection Request
 {:.api .api-operation}

--- a/_source/_docs/api/resources/sessions.md
+++ b/_source/_docs/api/resources/sessions.md
@@ -18,9 +18,9 @@ A [session token](./authn.html#session-token) is a one-time bearer token that pr
 
 Okta provides a very rich [Authentication API](./authn.html) to validate a [user's primary credentials](./authn.html#primary-authentication) and secondary [MFA factor](./authn.html#verify-factor). A session token is returned after successful authentication which can be later exchanged for a session cookie using one of the following flows:
 
-- [Retrieving a session cookie by visiting the OpenID Connect Authorization Endpoint](/use_cases/authentication/session_cookie#retrieving-a-session-cookie-via-openid-connect-authorization-endpoint)
-- [Retrieving a session cookie by visiting a session redirect link](/use_cases/authentication/session_cookie#retrieving-a-session-cookie-by-visiting-a-session-redirect-link)
-- [Retrieving a session cookie by visiting an application embed link](/use_cases/authentication/session_cookie#retrieving-a-session-cookie-by-visiting-an-application-embed-link)
+- [Retrieving a session cookie by visiting the OpenID Connect Authorization Endpoint](/use_cases/authentication/session_cookie.html#retrieving-a-session-cookie-via-openid-connect-authorization-endpoint)
+- [Retrieving a session cookie by visiting a session redirect link](/use_cases/authentication/session_cookie.html#retrieving-a-session-cookie-by-visiting-a-session-redirect-link)
+- [Retrieving a session cookie by visiting an application embed link](/use_cases/authentication/session_cookie.html#retrieving-a-session-cookie-by-visiting-an-application-embed-link)
 
 > **Session Tokens** are secrets and should be protected at rest as well as during transit. A session token for a user is equivalent to having the user's actual credentials.
 
@@ -39,9 +39,9 @@ Creates a new session for a user with a valid session token. Use this API if, fo
 
 > Don't use this API unless you need a session `id`. Instead, use one of the following flows to obtain a SSO session with a `sessionToken`:
 
-- [Retrieving a session cookie by visiting the OpenID Connect Authorization Endpoint](/use_cases/authentication/session_cookie#retrieving-a-session-cookie-via-openid-connect-authorization-endpoint)
-- [Retrieving a session cookie by visiting a session redirect link](/use_cases/authentication/session_cookie#retrieving-a-session-cookie-by-visiting-a-session-redirect-link)
-- [Retrieving a session cookie by visiting an application embed link](/use_cases/authentication/session_cookie#retrieving-a-session-cookie-by-visiting-an-application-embed-link)
+- [Retrieving a session cookie by visiting the OpenID Connect Authorization Endpoint](/use_cases/authentication/session_cookie.html#retrieving-a-session-cookie-via-openid-connect-authorization-endpoint)
+- [Retrieving a session cookie by visiting a session redirect link](/use_cases/authentication/session_cookie.html#retrieving-a-session-cookie-by-visiting-a-session-redirect-link)
+- [Retrieving a session cookie by visiting an application embed link](/use_cases/authentication/session_cookie.html#retrieving-a-session-cookie-by-visiting-an-application-embed-link)
 
 > This operation can be performed anonymously without an API Token.
 

--- a/_source/_docs/how-to/updating_saml_cert.md
+++ b/_source/_docs/how-to/updating_saml_cert.md
@@ -208,7 +208,7 @@ This step is the same as [Step 1](#step-1--list-your-apps-and-get-the-app-id-nam
 
 #### Step 2 – Retrieve all certificates associated with the app and locate the SHA1 certificate.
 
-Use the [List Key Credentials for an Application API](/docs/api/resources/apps#list-key-credentials-for-application) to list all the credentials.
+Use the [List Key Credentials for an Application API](/docs/api/resources/apps.html#list-key-credentials-for-application) to list all the credentials.
 Pass the app ID (`id`) that was collected in the previous step as the app ID (`aid`) in this API. Then, determine which certificate is the SHA1 certificate by copying the certificate text for each of the returned certificates, and [determine the signature algorithm](#determine-the-signature-algorithm-of-a-certificate)
 using the method described below. After determining which certificate is the SHA1 certificate, note the signing key id, `kid`.
 
@@ -255,7 +255,7 @@ Response:
 
 #### Step 3 – Update the key credential for the application with the SHA1 certificate.
 
-Use the [Apps API](/docs/api/resources/apps#update-key-credential-for-application)
+Use the [Apps API](/docs/api/resources/apps.html#update-key-credential-for-application)
 to update the key credential for the application to specify the kid of the SHA1 certificate that you retrieved in step 2.
 
 This step is the same as

--- a/_source/_docs/platform-release-notes/platform-release-notes2016-28.md
+++ b/_source/_docs/platform-release-notes/platform-release-notes2016-28.md
@@ -76,8 +76,8 @@ Also, the response to an answer recovery question (`/api/v1/authn/recovery/answe
 ~~~
 
 When performing a self-service password reset (forgot password), the request for an answer recovery question is made in response to the security question challenge.
-For more information, see [Password Complexity Object](/docs/api/resources/authn#password-complexity-object)
-and [Answer Recovery Question](/docs/api/resources/authn#answer-recovery-question).
+For more information, see [Password Complexity Object](/docs/api/resources/authn.html#password-complexity-object)
+and [Answer Recovery Question](/docs/api/resources/authn.html#answer-recovery-question).
 
 ### Does Your Org Have These Changes Yet?
 

--- a/_source/_docs/platform-release-notes/platform-release-notes2016-29.md
+++ b/_source/_docs/platform-release-notes/platform-release-notes2016-29.md
@@ -13,7 +13,7 @@ title: Platform Release Notes July 20, 2016
 The `expires_in` response parameter tells you the number of seconds before a `token` (Access Token) expires. If your
 response from the `/oauth2/v1/authorize` endpoint includes an Access Token, `expires_in` is included in the response.
 
-For more information, see the `/oauth2/v1/authorize` [Response Parameters](/docs/api/resources/oauth2#response-parameters).
+For more information, see the `/oauth2/v1/authorize` [Response Parameters](/docs/api/resources/oauth2.html#response-parameters).
 
 ### SHA256 Certificate for New SAML IdP Instances
 

--- a/_source/_docs/platform-release-notes/platform-release-notes2016-34.md
+++ b/_source/_docs/platform-release-notes/platform-release-notes2016-34.md
@@ -12,7 +12,7 @@ excerpt: Summary of changes to the Okta Platform since Release 2016.34
 Two Session API endpoints, `GET /api/v1/sessions/me` and `POST /sessions/me/lifecycle/refresh`, return `/me` instead of `/:id` in response links.
 These links are CORS-enabled, consistent with the original API calls which are also CORS-enabled.
 
-For more information, see [Get Session](/docs/api/resources/sessions#get-session) or [Refresh Session](/docs/api/resources/sessions#refresh-session).
+For more information, see [Get Session](/docs/api/resources/sessions.html#get-session) or [Refresh Session](/docs/api/resources/sessions.html#refresh-session).
 
 ## Bugs Fixed
 

--- a/_source/_includes/sidebar.html
+++ b/_source/_includes/sidebar.html
@@ -89,7 +89,7 @@
     <h3 class="Sidebar-title">Use Cases</h3>
     <ul class="Sidebar-nav">{% assign documents = site.use_cases | sort: 'weight' %}{% for document in documents %}{% unless document.id contains '/index' %}{% continue %}{% endunless %}
       <li{% if document.url == page.url%} class="is-active"{% endif %}>
-        <a href="{{ document.url | remove: '/index' | append: '/'}}">{{ document.title }}</a>
+        <a href="{% if document.id contains '/index' %}{{ document.url | remove: '/index.html' | append: '/' }}{% else %}{{ document.link }}{% endif %}">{{ document.title }}</a>
       </li>{% endfor %}
     </ul>
 
@@ -116,7 +116,7 @@
         </ul>{% endif %}
       </li>{% assign documents = site.reference %}{% for document in documents %}{% if document.id contains "docs/api/getting_started" %}{% continue %}{% endif %}{% if document.id contains "docs/api/resources" %}{% continue %}{% endif %}{% if document.id contains "reference/api_reference" %}{% continue %}{% endif %}{% if document.id contains "reference/getting_started" %}{% continue %}{% endif %}{% if document.id contains "reference/authentication_reference" %}{% continue %}{% endif %}
       <li{% if document.title == page.title or page.title contains document.title %} class="is-active"{% endif %}>
-        <a href="{% if document.id contains '/index' %}{{ document.url | remove: '/index' | append: '/'}}{% else %}{{ document.link }}{% endif %}">{{ document.title }}</a>
+        <a href="{% if document.id contains '/index' %}{{ document.url | remove: '/index.html' | append: '/'}}{% else %}{{ document.link }}{% endif %}">{{ document.title }}</a>
       </li>{% endfor %}
     </ul>
 
@@ -126,7 +126,7 @@
       {% for element in elements %}
       {% unless element.id contains '/index' %}{% continue %}{% endunless %}
       <li{% if element.title == page.title%} class="is-active"{% endif %}>
-        <a href="{{ element.url | remove: '/index' | append: '/' }}">{{ element.title }}</a>
+        <a href="{{ element.url | remove: '/index.html' | append: '/' }}">{{ element.title }}</a>
       </li>
       {% endfor %}
     </ul>

--- a/_source/_layouts/docs_index.html
+++ b/_source/_layouts/docs_index.html
@@ -24,10 +24,10 @@ js: docsIndex
                     {% continue %}
                     {% endunless %}
                     <div class="Column--4 Column--small-12">
-                        <a href="{{ document.url | remove: '/index' | append: '/' }}">
+                        <a href="{{ document.url | remove: '/index.html' | append: '/' }}">
                             <h3 class="h4">{{ document.title }}</h3>
                         </a>
-                        <p> {{ document.excerpt | default: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur efficitur viverra consectetur. Donec lobortis ante in pretium aliquet. Ut orci est, consectetur ac bibendum non, porttitor a enim." }} </p>
+                        <p> {{ document.excerpt }} </p>
                     </div>
                     {% endfor %}
                 </div>
@@ -39,7 +39,7 @@ js: docsIndex
                     {% assign documents = site.reference | sort:'weight' %}
                     {% for document in documents %}
                     <div class="Column--4 Column--small-12">
-                        <a href="{% if document.id contains '/index' %}{{ document.url | remove: '/index' | append: '/' }}{% else %}{{ document.link }}{% endif %}">
+                        <a href="{% if document.id contains '/index' %}{{ document.url | remove: '/index.html' | append: '/' }}{% else %}{{ document.link }}{% endif %}">
                             <h3 class="h4">{{ document.title }}</h3>
                         </a>
                         <p>{{ document.excerpt }}</p>
@@ -58,7 +58,7 @@ js: docsIndex
                     {% continue %}
                   {% endunless %}
                     <div class="Column--4 Column--small-12">
-                        <a href="{{ document.url | remove: '/index' | append: '/' }}">
+                        <a href="{{ document.url | remove: '/index.html' | append: '/' }}">
                             <h3 class="h4">{{ document.title }}</h3>
                         </a>
                         <p>{{ document.excerpt }}</p>

--- a/_source/_posts/2015-04-14-android-unit-testing-part-3.md
+++ b/_source/_posts/2015-04-14-android-unit-testing-part-3.md
@@ -9,7 +9,7 @@ the last two articles I discussed the [general principles of having
 good
 tests](https://www.okta.com/blog/2015/01/android-unit-testing-part-i-what-makes-strong-test-automation/)
 and the way to [run Android tests on JVM making them
-fast](/blog/2015/04/07/android-unit-testing-part-2). This
+fast](/blog/2015/04/07/android-unit-testing-part-2.html). This
 part will show how to make your Android code less heavily
 coupled. This is a preparation step to ensure that your tests are
 isolated from each other.*

--- a/_source/_posts/2015-04-23-android-unit-testing-part-4.md
+++ b/_source/_posts/2015-04-23-android-unit-testing-part-4.md
@@ -9,8 +9,8 @@ the last two articles I discussed the [general principles of having
 good
 tests](https://www.okta.com/blog/2015/01/android-unit-testing-part-i-what-makes-strong-test-automation/)
 and the way to [run Android tests on JVM making them
-fast](/blog/2015/04/07/android-unit-testing-part-2) and [how to make
-your code less coupled](/blog/2015/04/14/android-unit-testing-part-3).
+fast](/blog/2015/04/07/android-unit-testing-part-2.html) and [how to make
+your code less coupled](/blog/2015/04/14/android-unit-testing-part-3.html).
 This article will explain how to make tests isolated.*
 
 We need to mock a dependency, inject it, and then modify our test to

--- a/_source/_posts/2017-03-16-spring-boot-saml.md
+++ b/_source/_posts/2017-03-16-spring-boot-saml.md
@@ -29,7 +29,7 @@ Just like I did, the first thing you'll need to do is create a developer account
 
 {% img blog/spring-boot-saml/okta-dev-console.png alt:"Okta Dev Console" width:"800" %}{: .center-image }
  
-Click on **< > Developer** in the top-left corner and switch to the Classic UI. If you see a screen like the following, you're good to go! The reason you need to use the Classic UI for this tutorial is because we haven't yet added SAML support to the [Developer Console](/blog/2017/09/25/all-new-developer-console).
+Click on **< > Developer** in the top-left corner and switch to the Classic UI. If you see a screen like the following, you're good to go! The reason you need to use the Classic UI for this tutorial is because we haven't yet added SAML support to the [Developer Console](/blog/2017/09/25/all-new-developer-console.html).
 
 {% img blog/spring-boot-saml/okta-classic-ui.png alt:"Okta Classic UI" width:"800" %}{: .center-image }
 
@@ -237,9 +237,9 @@ You can find the source code for this article at [https://github.com/oktadevelop
 
 This article showed you how to create a SAML application in Okta and talk to it using Spring Boot and Spring Security's SAML extension. The SAML extension hasn't had a GA release, but hopefully will soon. I also believe it's possible to take the SAML DSL (in `SecurityConfiguration.java`) and create a Spring Boot starter that allows you to get started with SAML simply by configuring application properties.
 
-Have questions or comments? Post your question to Stack Overflow with the "[okta](http://stackoverflow.com/questions/tagged/okta)" or "[okta-api](http://stackoverflow.com/questions/tagged/okta-api)” tag, hit me up via email at [matt.raible@okta.com](mailto:matt.raible@okta.com), or ping me on Twitter [@mraible](https://twitter.com/mraible). In future articles, I'll show you [how to configure Spring Boot with OAuth 2.0 and Okta](/blog/2017/03/21/spring-boot-oauth). Then I'll explore different techniques of [authenticating with Angular](https://developer.okta.com/blog/2017/04/17/angular-authentication-with-oidc) and using the access token to talk to a [secured Spring Boot application](/blog/2017/09/19/build-a-secure-notes-application-with-kotlin-typescript-and-okta). Until then, happy authenticating! 😊
+Have questions or comments? Post your question to Stack Overflow with the "[okta](http://stackoverflow.com/questions/tagged/okta)" or "[okta-api](http://stackoverflow.com/questions/tagged/okta-api)” tag, hit me up via email at [matt.raible@okta.com](mailto:matt.raible@okta.com), or ping me on Twitter [@mraible](https://twitter.com/mraible). In future articles, I'll show you [how to configure Spring Boot with OAuth 2.0 and Okta](/blog/2017/03/21/spring-boot-oauth.html). Then I'll explore different techniques of [authenticating with Angular](https://developer.okta.com/blog/2017/04/17/angular-authentication-with-oidc.html) and using the access token to talk to a [secured Spring Boot application](/blog/2017/09/19/build-a-secure-notes-application-with-kotlin-typescript-and-okta.html). Until then, happy authenticating! 😊
 
 **Changelog:**
 
 * Apr 20, 2017: Thanks to [Alexey Soshin](https://github.com/AlexeySoshin) for contributing a [pull request](https://github.com/oktadeveloper/okta-spring-boot-saml-example/pull/2) to make the code in this blog post more bootiful!
-* Oct 10, 2017: Updated instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console).
+* Oct 10, 2017: Updated instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console.html).

--- a/_source/_posts/2017-03-21-spring-boot-oauth.md
+++ b/_source/_posts/2017-03-21-spring-boot-oauth.md
@@ -146,11 +146,11 @@ The source code for this tutorial and the examples in it are available [on GitHu
 
 This tutorial showed you how to use Spring CLI, Groovy, Spring Boot, Spring Security, and Okta to quickly prototype an OAuth client. This information is useful for those that are developing a Spring MVC application with traditional server-rendered pages. However, these days, lots of developers are using JavaScript frameworks and mobile applications to build their UIs.
 
-In a [future tutorial](/blog/2017/09/19/build-a-secure-notes-application-with-kotlin-typescript-and-okta), I'll show you how to develop one of these fancy UIs in Angular and use the access token retrieved to talk to a Spring Boot API that's secured by Spring Security and does JWT validation.
+In a [future tutorial](/blog/2017/09/19/build-a-secure-notes-application-with-kotlin-typescript-and-okta.html), I'll show you how to develop one of these fancy UIs in Angular and use the access token retrieved to talk to a Spring Boot API that's secured by Spring Security and does JWT validation.
 
 **Changelog:**
 
-* Oct 11, 2017: Updated instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console).
+* Oct 11, 2017: Updated instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console.html).
 * Oct 20, 2017: Added missing `scope: openid profile email` to `application.yaml`. 
 
 

--- a/_source/_posts/2017-03-27-angular-okta-sign-in-widget.md
+++ b/_source/_posts/2017-03-27-angular-okta-sign-in-widget.md
@@ -7,7 +7,7 @@ tags: [angular, sign-in widget, okta, typescript, angular-cli]
 
 AngularJS reigned as king of JavaScript MVC frameworks for several years. However, when the Angular team announced they would not provide backwards compatibility for their next version, there was a bit of a stir in its community, giving opportunities for frameworks like React and Vue.js to flourish. Fast forward a few years and both Angular 2 and Angular 4 have been released. Many developers are trying its TypeScript and finding the experience a pleasant one. [According to JAXenter](https://jaxenter.com/technology-trends-2017-top-frameworks-131993.html), it’s doing a pretty good job, and holding strong as the third most popular UI framework, behind React and HTML5.
 
-In this article, I’ll show you a quick way to get started with Angular, and add user authentication with [Okta's Sign-In Widget](/code/javascript/okta_sign-in_widget). If you’re just getting started with Angular, you might want to read my [Angular tutorial](http://gist.asciidoctor.org/?github-mraible/ng-demo//README.adoc). If you’d like to get the source code used in this article, you can [find it on GitHub](https://github.com/oktadeveloper/okta-angular-sign-in-widget-example).
+In this article, I’ll show you a quick way to get started with Angular, and add user authentication with [Okta's Sign-In Widget](/code/javascript/okta_sign-in_widget.html). If you’re just getting started with Angular, you might want to read my [Angular tutorial](http://gist.asciidoctor.org/?github-mraible/ng-demo//README.adoc). If you’d like to get the source code used in this article, you can [find it on GitHub](https://github.com/oktadeveloper/okta-angular-sign-in-widget-example).
 
 ## Why User Authentication with Okta?
 
@@ -275,6 +275,6 @@ I hope you’ve enjoyed this quick tour of our Angular support. If you have ques
 
 **Changelog:**
 
-* Sep 30, 2017: Updated to use Angular CLI 1.4.4 and Okta Sign-In Widget 2.1.0. See the code changes in the [example app on GitHub](https://github.com/oktadeveloper/okta-angular-sign-in-widget-example/pull/8). Updated "create an OIDC app" instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console).
+* Sep 30, 2017: Updated to use Angular CLI 1.4.4 and Okta Sign-In Widget 2.1.0. See the code changes in the [example app on GitHub](https://github.com/oktadeveloper/okta-angular-sign-in-widget-example/pull/8). Updated "create an OIDC app" instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console.html).
 
 [widget-reference]: https://github.com/okta/okta-signin-widget

--- a/_source/_posts/2017-03-30-react-okta-sign-in-widget.md
+++ b/_source/_posts/2017-03-30-react-okta-sign-in-widget.md
@@ -7,7 +7,7 @@ tags: [react, sign-in widget, okta, es6]
 
 React has quickly become one of the most favored front-end web frameworks, and is second only to plain old HTML5, [according to JAXenter](https://jaxenter.com/technology-trends-2017-top-frameworks-131993.html). So it’s no surprise that [developers are learning it](https://www.lynda.com/React-js-training-tutorials/7049-0.html), and [employers are asking for it](https://stackoverflow.com/jobs?sort=i&q=ReactJS).
 
-In this tutorial, you’ll start with a very simple React app with a couple of pages and some routing built in, and add authentication using [Okta’s Sign-In Widget](/code/javascript/okta_sign-in_widget). The Sign-In Widget is an embeddable Javascript widget that allows developers to use Okta’s secure, scalable architecture with a minimum of effort from within React applications. Let’s get started!
+In this tutorial, you’ll start with a very simple React app with a couple of pages and some routing built in, and add authentication using [Okta’s Sign-In Widget](/code/javascript/okta_sign-in_widget.html). The Sign-In Widget is an embeddable Javascript widget that allows developers to use Okta’s secure, scalable architecture with a minimum of effort from within React applications. Let’s get started!
 ## Get the Simple React Seed Project
 Start by cloning the simple React seed project.
 
@@ -300,4 +300,4 @@ I hope you’ve enjoyed this quick tour of our React support. If you have questi
 
 * October 20, 2017: Changed npm install to version 2.3.0 of widget and removed npm install at beginning. Also added instructions for fixing dependency issues in npm.
 * October 17, 2017: Fixed bugs and added navbar instructions.
-* September 30, 2017: Updated "create an OIDC app" instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console). Updated the widget reference to 2.1.0.
+* September 30, 2017: Updated "create an OIDC app" instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console.html). Updated the widget reference to 2.1.0.

--- a/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
+++ b/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
@@ -1111,7 +1111,7 @@ You can find a completed version of the application created in this blog post [o
 **Changelog:**
 
 * Aug 31, 2017: Updated to use Angular CLI 1.3.2 and angular-oauth2-oidc 2.0.12. See the code changes in the [example app on GitHub](https://github.com/oktadeveloper/okta-angular-openid-connect-example/pull/2/files).
-* Sep 28, 2017: Updated "create an OIDC app" instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console).
+* Sep 28, 2017: Updated "create an OIDC app" instructions for the [Okta Developer Console](/blog/2017/09/25/all-new-developer-console.html).
 
 
 

--- a/_source/_posts/2017-04-26-bootiful-development-with-spring-boot-and-angular.md
+++ b/_source/_posts/2017-04-26-bootiful-development-with-spring-boot-and-angular.md
@@ -458,8 +458,8 @@ You’ve just created an Angular app that talks to a Spring Boot API using cross
 
 To learn more about Angular, Spring Boot, or Okta, check out the following resources:
 
-* [Angular with OpenID Connect](/blog/2017/04/17/angular-authentication-with-oidc)
-* [Get Started with Spring Boot, OAuth 2.0, and Okta](/blog/2017/03/21/spring-boot-oauth)
+* [Angular with OpenID Connect](/blog/2017/04/17/angular-authentication-with-oidc.html)
+* [Get Started with Spring Boot, OAuth 2.0, and Okta](/blog/2017/03/21/spring-boot-oauth.html)
 * [Getting Started with Spring Boot by Josh Long](https://youtu.be/sbPSjI4tt10) (SF JUG 2015)
 * [Angular Best Practices by Stephen Fluin](https://youtu.be/hHNUohOPCCo) (ng-conf 2017)
 

--- a/_source/_posts/2017-05-09-progressive-web-applications-with-angular-and-spring-boot.md
+++ b/_source/_posts/2017-05-09-progressive-web-applications-with-angular-and-spring-boot.md
@@ -41,7 +41,7 @@ This article will show you how to build a PWA with a Spring Boot backend and an 
 
 ## Run a Spring Boot API
 
-In [part 1 of this series](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular), I showed you how to create an API with Spring Boot and display its data in an Angular UI. You'll be using that project as a starting point for this tutorial. You'll adding offline capabilities by turning it into a PWA.
+In [part 1 of this series](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html), I showed you how to create an API with Spring Boot and display its data in an Angular UI. You'll be using that project as a starting point for this tutorial. You'll adding offline capabilities by turning it into a PWA.
 
 To begin, clone the project from GitHub.
 
@@ -367,8 +367,8 @@ I'd like to give a big thanks to all the engineers that've been developing progr
 
 To learn more about progressive web applications, check out two of my recent posts:
 
-* [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications)
-* [Add Authentication to Your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa)
+* [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html)
+* [Add Authentication to Your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa.html)
 
 I’d also recommend visiting the following websites:
 

--- a/_source/_posts/2017-05-17-develop-a-mobile-app-with-ionic-and-spring-boot.md
+++ b/_source/_posts/2017-05-17-develop-a-mobile-app-with-ionic-and-spring-boot.md
@@ -19,7 +19,7 @@ To begin, create a directory on your hard drive called `spring-boot-ionic-exampl
 
 ## Build a Spring Boot API
 
-I recently wrote about how to build a Spring Boot API in [Bootiful Development with Spring Boot with Angular](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular). Rather than covering that again, you can clone the existing project and copy the `server` directory into `spring-boot-ionic-example`.
+I recently wrote about how to build a Spring Boot API in [Bootiful Development with Spring Boot with Angular](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html). Rather than covering that again, you can clone the existing project and copy the `server` directory into `spring-boot-ionic-example`.
 
 ```bash
 git clone https://github.com/oktadeveloper/spring-boot-angular-example.git
@@ -814,9 +814,9 @@ You can find a completed version of the application created in this blog post [o
 To learn more about Ionic and Angular, please see the following resources:
 
 * [Get started with Ionic Framework](http://ionicframework.com/getting-started/)
-* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot)
-* [Bootiful Development with Spring Boot and Angular](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular)
-* [Angular Authentication with OpenID Connect and Okta in 20 Minutes](/blog/2017/04/17/angular-authentication-with-oidc)
+* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html)
+* [Bootiful Development with Spring Boot and Angular](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html)
+* [Angular Authentication with OpenID Connect and Okta in 20 Minutes](/blog/2017/04/17/angular-authentication-with-oidc.html)
 
 
 

--- a/_source/_posts/2017-06-13-add-authentication-angular-pwa.md
+++ b/_source/_posts/2017-06-13-add-authentication-angular-pwa.md
@@ -27,7 +27,7 @@ Rather than building Spring Boot and Angular applications from scratch, you can 
 git clone https://github.com/oktadeveloper/spring-boot-angular-pwa-example.git
 ```
 
-If you'd prefer to build this application yourself, please read [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot).
+If you'd prefer to build this application yourself, please read [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html).
 
 In this project's `server/pom.xml` file, you'll need to add the following XML:
 
@@ -221,8 +221,8 @@ your needs, set the request's mode to 'no-cors' to fetch the resource with CORS 
 ```
 
 When you're using Spring Boot without the Stormpath Spring Boot starter, you can use a `@CrossOrigin` annotation to enable cross-origin resource 
-sharing (CORS) on the server. See the [configure CORS for Spring Boot section](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular#configure-cors-for-spring-boot) of 
-[Bootiful Development with Spring Boot and Angular](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular).
+sharing (CORS) on the server. See the [configure CORS for Spring Boot section](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html#configure-cors-for-spring-boot) of 
+[Bootiful Development with Spring Boot and Angular](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html).
 
 When you're using the Stormpath Spring Boot Starter, you can enable it by adding the following property to the Spring 
 Boot app's `src/main/resources/application.properties`.
@@ -777,7 +777,7 @@ Now both login techniques should work as expected and you should be able to load
 
 {% img blog/angular-pwa-auth/production-beer-list.png alt:"Production Beer List" width:"800" %}
 
-The first time I ran [Lighthouse](https://developers.google.com/web/tools/lighthouse/) on this application, I was surprised to see it received a PWA score of 91. When I deployed this application previously, it [received a 98](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot#cloud-foundry).
+The first time I ran [Lighthouse](https://developers.google.com/web/tools/lighthouse/) on this application, I was surprised to see it received a PWA score of 91. When I deployed this application previously, it [received a 98](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html#cloud-foundry).
  
 {% img blog/angular-pwa-auth/lighthouse-without-512.png alt:"Lighthouse Score, first attempt" width:"800" %}
 
@@ -805,8 +805,8 @@ This article showed you how to develop a Spring Boot backend, and lock it down w
 
 To learn more about PWAs, check out some recent tutorials I wrote:
 
-* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot) 
-* [Tutorial: Develop a Mobile App With Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot)
+* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html) 
+* [Tutorial: Develop a Mobile App With Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html)
 * [The Ultimate Guide to Progressive Web Applications](https://scotch.io/tutorials/the-ultimate-guide-to-progressive-web-applications)
 
 There's also a number of excellent resources by Google and Smashing Magazine:

--- a/_source/_posts/2017-06-15-build-microservices-architecture-spring-boot.md
+++ b/_source/_posts/2017-06-15-build-microservices-architecture-spring-boot.md
@@ -10,9 +10,9 @@ be a good idea when you have a large team working on a single product. Your proj
 that can function independently of one another. Once components can function independently, they can be built, tested, 
 and deployed independently. This gives an organization and its teams the agility to develop and deploy very quickly.
 
-In a [previous article](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular), I showed you how to build 
+In a [previous article](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html), I showed you how to build 
 a Spring Boot API with an Angular client. I then showed you how to 
-[convert the Angular app into a progressive web application that works offline](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot). 
+[convert the Angular app into a progressive web application that works offline](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html). 
 The Angular PWA is a good example of a resilient application because it still works when connectivity fails. Did you know 
 you can develop similar resiliency in your API with Spring Boot, Spring Cloud, and a microservices architecture? This 
 article shows you how to convert the previously created Spring Boot application to use microservices. You'll create a 
@@ -302,7 +302,7 @@ To enable the "Compile on save" feature:</p>
 ### Create an Edge Service
 
 The edge service will be similar to the standalone beer service created in 
-[Bootiful Development with Spring Boot and Angular](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular). 
+[Bootiful Development with Spring Boot and Angular](/blog/2017/04/26/bootiful-development-with-spring-boot-and-angular.html). 
 However, it will have fallback capabilities which prevent the client from receiving an HTTP error when the service is 
 not available.
 
@@ -491,7 +491,7 @@ Start the `beer-catalog-service` again and this list should eventually return th
 
 ### Add an Angular PWA Client
 
-You can copy the Angular PWA client I created in a [previous tutorial](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot) and install its dependencies.
+You can copy the Angular PWA client I created in a [previous tutorial](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html) and install its dependencies.
 
 ```bash
 git clone git@github.com:oktadeveloper/spring-boot-angular-pwa-example.git

--- a/_source/_posts/2017-06-20-develop-microservices-with-jhipster.md
+++ b/_source/_posts/2017-06-20-develop-microservices-with-jhipster.md
@@ -165,7 +165,7 @@ The [JHipster Registry](https://jhipster.github.io/jhipster-registry/) is built 
 Patterns provided by Spring Cloud Netflix include Service Discovery (Eureka), Circuit Breaker (Hystrix), Intelligent Routing (Zuul), 
 and Client Side Load Balancing (Ribbon). 
 
-In a [previous post](/blog/2017/06/15/build-microservices-architecture-spring-boot), I showed you how you can use Eureka for 
+In a [previous post](/blog/2017/06/15/build-microservices-architecture-spring-boot.html), I showed you how you can use Eureka for 
 service discovery. JHipster Registry is a Eureka server, a Spring Cloud Config server, as well as an administration server. 
 It includes dashboards to monitor and manage your JHipster applications. 
 
@@ -937,6 +937,6 @@ Stack Overflow with the ["jhipster" tag](http://stackoverflow.com/questions/tagg
 If you're interested in learning more about microservices, you might also find the following resources useful:
 
 * [Doing Microservices with JHipster](https://jhipster.github.io/microservices-architecture/)
-* [Build a Microservices Architecture for Microbrews](/blog/2017/06/15/build-microservices-architecture-spring-boot)
+* [Build a Microservices Architecture for Microbrews](/blog/2017/06/15/build-microservices-architecture-spring-boot.html)
 * [Bootstrapping Your Microservices Architecture with JHipster and Spring](https://blog.heroku.com/bootstrapping_your_microservices_architecture_with_jhipster_and_spring)
 * [Microservice Resources from Chris Richardson](http://microservices.io/resources/index.html)

--- a/_source/_posts/2017-06-29-oidc-user-auth-aspnet-core.md
+++ b/_source/_posts/2017-06-29-oidc-user-auth-aspnet-core.md
@@ -10,7 +10,7 @@ In the age of the “personalized web experience”, authentication and user man
 [OpenID Connect](http://openid.net/connect/) is a protocol for authenticating users. It is a specification by the OpenID Foundation describing the best way for the authentication “handshake” to happen. It lays out what an Identity Provider needs to provide in order to be considered “OpenID Connect Certified” which makes it easier than ever to consume authentication as a service.
 
 ## Why Not Use OAuth 2.0?
-First, [OAuth 2.0 is NOT an authentication protocol](https://developer.okta.com/blog/2017/06/21/what-the-heck-is-oauth). I know what you’re thinking: “What?!!?” But it’s not. It *is* an delegated authorization framework, which many modern authentication protocols are built on. 
+First, [OAuth 2.0 is NOT an authentication protocol](https://developer.okta.com/blog/2017/06/21/what-the-heck-is-oauth.html). I know what you’re thinking: “What?!!?” But it’s not. It *is* an delegated authorization framework, which many modern authentication protocols are built on. 
 
 Second, while OAuth 2.0 does a great job of providing the necessary information for consumers to make authorization decisions, it says nothing about how that information will be exchanged securely. This has led to every authentication provider having their own way of exchanging the OAuth 2.0 information, which has led to a few well-publicized hacks. OpenID Connect fixes these problems by providing an authentication protocol that describes exactly how the exchange of authorization information happens between a subscriber and their provider. 
 

--- a/_source/_posts/2017-07-20-the-ultimate-guide-to-progressive-web-applications.md
+++ b/_source/_posts/2017-07-20-the-ultimate-guide-to-progressive-web-applications.md
@@ -89,7 +89,7 @@ If your app is so dynamic that you don’t want anything cached, a PWA might not
 
 Adding PWA support is important so people with slow connections and affordable smart phones can use your webapp more easily. If your app is large and you can't load parts of it lazily (meaning loading it on-demand rather than at the beginning), bundling it all up in a hybrid app with [Cordova](https://www.google.com/url?q=http://cordova.apache.org/docs/en/latest/guide/cli/index.html&sa=D&ust=1496180358261000&usg=AFQjCNEg15ndTpZMXoO0pJX4AyRs-zdXjg) might make sense. If your app does intense tasks or is highly interactive (like a game), coding it with native SDKs is likely a good option. 
 
-**If you’re interested in learning more about [using Cordova with Ionic and Spring Boot, you can check out my recent tutorial](https://developer.okta.com/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot).**
+**If you’re interested in learning more about [using Cordova with Ionic and Spring Boot, you can check out my recent tutorial](https://developer.okta.com/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html).**
 
 PWAs are useful for apps like Twitter and news sites because they have a lot of text that you’ll read, but not necessarily interact with. Having it as a PWA allows you to open the app, load its data, then read its contents later when you’re offline. This should work in a normal web application, but I’ve noticed that some browsers will try to reload the page when you open them, resulting in a dreaded "server not found" error.
 
@@ -125,7 +125,7 @@ The requirements for a PWA can be quickly added to almost any web application. A
 2. Create and include a JavaScript file with code to cache network requests.
 3. Create and include a web app manifest. 
 
-To see how to add these features to an Angular application, see my [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot) blog post on Okta’s developer blog. This article shows you how to add a service worker, a manifest with icons, and deploy it to CloudFoundry with HTTPS. Not only that, but it scores a 98/100 using the Lighthouse Chrome Extension.
+To see how to add these features to an Angular application, see my [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html) blog post on Okta’s developer blog. This article shows you how to add a service worker, a manifest with icons, and deploy it to CloudFoundry with HTTPS. Not only that, but it scores a 98/100 using the Lighthouse Chrome Extension.
 
 {% img blog/angular-spring-boot-pwa/lighthouse-prod-report.png alt:"Lighthouse Report" width:"800" %}
 
@@ -178,7 +178,7 @@ and try again, or run `ng set apps.0.serviceWorker=false` in your .angular-cli.j
 
 Ionic is a framework that leverages Angular to create native apps with web technologies. It leverages Cordova to run the app on phones but also has built-in service worker and manifest support if you want to deploy your app to the web.
 
-See my [tutorial about developing mobile applications with Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot) to learn more. Below is a screenshot of the completed application in the tutorial.
+See my [tutorial about developing mobile applications with Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html) to learn more. Below is a screenshot of the completed application in the tutorial.
 
 {% img blog/ionic-spring-boot/beer-modal.png alt:"Mmmmm, Guinness" width:"800" %}
 
@@ -219,6 +219,6 @@ Or, you can check out any of these great resources:
 
 Ready to get your feet wet building an app? You can find some interesting PWA tutorials here:
 
-* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot) 
-* [Tutorial: Develop a Mobile App With Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot)
+* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html) 
+* [Tutorial: Develop a Mobile App With Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html)
 * [A Beginner's Guide To Progressive Web Apps](https://www.smashingmagazine.com/2016/08/a-beginners-guide-to-progressive-web-apps/)

--- a/_source/_posts/2017-07-25-oidc-primer-part-1.md
+++ b/_source/_posts/2017-07-25-oidc-primer-part-1.md
@@ -200,10 +200,10 @@ It can be confusing sometimes to distinguish between the different token types. 
 
 ## Continue the OpenID Connect Journey
 
-In this post, we learned some basics about OpenID Connect, its history, and a bit about the various flow types, scopes, and tokens involved. In the [next installment](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2), we see OIDC in action!
+In this post, we learned some basics about OpenID Connect, its history, and a bit about the various flow types, scopes, and tokens involved. In the [next installment](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2.html), we see OIDC in action!
 
 If you want to jump ahead, check out the example at: [https://okta-oidc-fun.herokuapp.com](https://okta-oidc-fun.herokuapp.com)
 
 And, the source code is at: [https://github.com/oktadeveloper/okta-oidc-flows-example](https://github.com/oktadeveloper/okta-oidc-flows-example)
 
-The whole series is live now. Part 2 is [here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2). Part 3 is [here](https://developer.okta.com/blog/2017/08/01/oidc-primer-part-3).
+The whole series is live now. Part 2 is [here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2.html). Part 3 is [here](https://developer.okta.com/blog/2017/08/01/oidc-primer-part-3.html).

--- a/_source/_posts/2017-07-25-oidc-primer-part-2.md
+++ b/_source/_posts/2017-07-25-oidc-primer-part-2.md
@@ -5,7 +5,7 @@ author: dogeared
 tags: [oauth, oauth2, oauth2.0, oauth 2.0, OpenID, OpenID Connect, oidc]
 ---
 
-In the [first installment of this OpenID Connect (OIDC) series](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1), we looked at some OIDC basics, its history, and the various flow types, scopes, and tokens involved. In this post, we'll dive into the mechanics of OIDC and see the various flows in action.
+In the [first installment of this OpenID Connect (OIDC) series](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1.html), we looked at some OIDC basics, its history, and the various flow types, scopes, and tokens involved. In this post, we'll dive into the mechanics of OIDC and see the various flows in action.
 
 The token(s) you get back from an OIDC flow and the contents of the `/userinfo` endpoint are a function of the flow type and scopes requested. You can see this live on the [OIDC flow test site](https://okta-oidc-fun.herokuapp.com). Here, you can set different toggles for `scope` and `response_type`, which determines the type of flow for your app.
 
@@ -131,6 +131,6 @@ You can easily create your own instance of the OIDC tool if you have an Okta ten
 
 You can explore the code or just click the friendly purple button to deploy your own instance.
 
-In the [final installment](https://developer.okta.com/blog/2017/08/01/oidc-primer-part-3), we dig into the various types of tokens and how to validate them.
+In the [final installment](https://developer.okta.com/blog/2017/08/01/oidc-primer-part-3.html), we dig into the various types of tokens and how to validate them.
 
-The whole series is live now. Part 1 is [here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1). Part 3 is [here](https://developer.okta.com/blog/2017/08/01/oidc-primer-part-3).
+The whole series is live now. Part 1 is [here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1.html). Part 3 is [here](https://developer.okta.com/blog/2017/08/01/oidc-primer-part-3.html).

--- a/_source/_posts/2017-08-01-oidc-primer-part-3.md
+++ b/_source/_posts/2017-08-01-oidc-primer-part-3.md
@@ -5,7 +5,7 @@ author: dogeared
 tags: [oauth, oauth2, oauth2.0, oauth 2.0, OpenID, OpenID Connect, oidc]
 ---
 
-In the previous two installments of this OpenID Connect (OIDC) series, we dug deep into the [OIDC flow types](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1) and saw [OIDC in action](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2) using a playground found at: [https://okta-oidc-fun.herokuapp.com/](https://okta-oidc-fun.herokuapp.com/).
+In the previous two installments of this OpenID Connect (OIDC) series, we dug deep into the [OIDC flow types](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1.html) and saw [OIDC in action](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2.html) using a playground found at: [https://okta-oidc-fun.herokuapp.com/](https://okta-oidc-fun.herokuapp.com/).
 
 In this third and final installment, we’ll look at what’s encoded into the various types of tokens and how to control what gets put in them. JWTs, have the benefit of being able to carry information in them. With this information available to your app you can easily enforce token expiration and reduce the number of API calls. Additionally, since they’re cryptographically signed, you can verify that they have not been tampered with.
 
@@ -444,4 +444,4 @@ It took some time, but here is what I consider to be the important takeaways:
 
 All the code used in this series can be found on [github](https://github.com/oktadeveloper/okta-oidc-flows-example). You can use the OIDC sample app to exercise the various flows and scopes discussed throughout these posts. It’s at: [https://okta-oidc-fun.herokuapp.com/](https://okta-oidc-fun.herokuapp.com/). The entire final OIDC spec can be found [here](http://openid.net/specs/openid-connect-core-1_0.html). And you can learn more about OAuth 2.0 at [oauth.com](https://www.oauth.com/).
 
-The whole series is live now. Part 1 is [here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1). Part 2 is [here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2).
+The whole series is live now. Part 1 is [here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1.html). Part 2 is [here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2.html).

--- a/_source/_posts/2017-08-08-secure-spring-microservices.md
+++ b/_source/_posts/2017-08-08-secure-spring-microservices.md
@@ -11,7 +11,7 @@ Are you using Spring Security to lock everything down? Are your microservices lo
 
 This tutorial shows you how you can use Spring Security, Okta, and a few Java libraries to secure your microservices architecture. Not only that, but I'll show you how to secure *everything*, so even your backend services communicate securely. You'll learn how to use JWTs and [Juiser](https://github.com/juiser/juiser) to read an `X-Forwarded-User` header and turn it into a Spring Security `User`.
 
-This tutorial builds off [Build a Microservices Architecture for Microbrews with Spring Boot](/blog/2017/06/15/build-microservices-architecture-spring-boot). A simple microservices architecture with Spring Boot and Spring Cloud looks as follows. It uses Stormpath’s Spring Boot Starter (it’s been modified to work with Okta while we work on building up Okta’s Java support) and Juiser, a library created by [Les Hazlewood](https://twitter.com/lhazlewood). Juiser is independent and open source, and is not tied to a particular identity provider.
+This tutorial builds off [Build a Microservices Architecture for Microbrews with Spring Boot](/blog/2017/06/15/build-microservices-architecture-spring-boot.html). A simple microservices architecture with Spring Boot and Spring Cloud looks as follows. It uses Stormpath’s Spring Boot Starter (it’s been modified to work with Okta while we work on building up Okta’s Java support) and Juiser, a library created by [Les Hazlewood](https://twitter.com/lhazlewood). Juiser is independent and open source, and is not tied to a particular identity provider.
 
 {% img blog/microservices-spring-secure/spring-microservices-diagram.png alt:"Spring Boot + Cloud Microservices Architecture" width:"800" %}
 
@@ -428,7 +428,7 @@ After logging in, you should see a page displaying your user's information.
 Click the **Logout** button to delete the cookies in your browser and end your session.
 ## Add Okta's Sign-In Widget to the Client
 
-Install [Okta's Sign-In Widget](https://developer.okta.com/code/javascript/okta_sign-in_widget) to make it possible to communicate with the secured server.
+Install [Okta's Sign-In Widget](https://developer.okta.com/code/javascript/okta_sign-in_widget.html) to make it possible to communicate with the secured server.
 
 ```bash
 cd client

--- a/_source/_posts/2017-08-09-jax-rs-vs-spring-rest-endpoints.md
+++ b/_source/_posts/2017-08-09-jax-rs-vs-spring-rest-endpoints.md
@@ -442,6 +442,6 @@ Now, comparing a Spring Boot application and an WAR packaged application, isn’
 
 Want to learn more about securing your Spring or JAX-RS applications, Apache Shiro, or REST fundamentals? Take a look at these posts:
 
-- [Protecting a Spring Boot App with Apache Shiro](https://developer.okta.com/blog/2017/07/13/apache-shiro-spring-boot)
+- [Protecting a Spring Boot App with Apache Shiro](https://developer.okta.com/blog/2017/07/13/apache-shiro-spring-boot.html)
 - [Protecting JAX-RS Resources with RBAC and Apache Shiro](https://stormpath.com/blog/protecting-jax-rs-resources-rbac-apache-shiro)
 - [The Fundamentals of REST API Design](https://stormpath.com/blog/fundamentals-rest-api-design)

--- a/_source/_posts/2017-08-22-build-an-ionic-app-with-user-authentication.md
+++ b/_source/_posts/2017-08-22-build-an-ionic-app-with-user-authentication.md
@@ -117,7 +117,7 @@ To make a login page for authentication, create `src/pages/login/login.ts` and `
 ```
 {% endraw %}
 
-You can leverage a couple of open source libraries to perform the actual authentication. The first one is [Manfred Steyer's](https://github.com/manfredsteyer) [angular-oauth2-oidc](https://github.com/manfredsteyer/angular-oauth2-oidc). This library allows you to interact with identity and access tokens easily. The second is the [Okta Auth SDK](/code/javascript/okta_auth_sdk). [OAuth is not an authentication protocol](/blog/2017/06/21/what-the-heck-is-oauth), but OIDC is. Why is it necessary to add Okta's authentication library then? Because OIDC authentication works via redirect (when using in a SPA) and I'd rather perform authentication without redirecting to Okta.
+You can leverage a couple of open source libraries to perform the actual authentication. The first one is [Manfred Steyer's](https://github.com/manfredsteyer) [angular-oauth2-oidc](https://github.com/manfredsteyer/angular-oauth2-oidc). This library allows you to interact with identity and access tokens easily. The second is the [Okta Auth SDK](/code/javascript/okta_auth_sdk.html). [OAuth is not an authentication protocol](/blog/2017/06/21/what-the-heck-is-oauth.html), but OIDC is. Why is it necessary to add Okta's authentication library then? Because OIDC authentication works via redirect (when using in a SPA) and I'd rather perform authentication without redirecting to Okta.
 
 Install `angular-oauth2-oidc` and the Okta Auth SDK using npm.
 
@@ -283,7 +283,7 @@ login(): void {
 }
 ```
 
-You want an identity token so you can have more information about the user. You want an access token so you can use it to access protected APIs that require a Bearer token. For example, in [Adding Authentication to Your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa), there's a `BeerService` that sends an access token when it makes an API request.
+You want an identity token so you can have more information about the user. You want an access token so you can use it to access protected APIs that require a Bearer token. For example, in [Adding Authentication to Your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa.html), there's a `BeerService` that sends an access token when it makes an API request.
 
 ```typescript
 import { Injectable } from '@angular/core';
@@ -650,7 +650,7 @@ After performing these steps, you should be able to run `ionic cordova emulate a
 ## PWAs with Ionic
 Ionic ships with support for creating progressive web apps (PWAs). This means you can deploy your Ionic app as a web app (rather than a mobile app) and make it run offline in [browsers that support service workers](http://caniuse.com/#feat=serviceworkers). 
 
-You can see how to enable service workers and make your app into a PWA by reading the [PWAs section](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot#pwas-with-ionic) of [how to develop a mobile app with Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot). A PWA is a web application that can be “installed” on your system. It works offline when you don't have an internet connection, leveraging data cached during your last interactions with the app. Adding PWA features can make your apps load a lot faster, creating happy users. To learn more about PWAs, see [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications). 
+You can see how to enable service workers and make your app into a PWA by reading the [PWAs section](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html#pwas-with-ionic) of [how to develop a mobile app with Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html). A PWA is a web application that can be “installed” on your system. It works offline when you don't have an internet connection, leveraging data cached during your last interactions with the app. Adding PWA features can make your apps load a lot faster, creating happy users. To learn more about PWAs, see [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html). 
 
 Ionic has invested heavily in supporting PWAs. You can read more about why in [
 What Progressive Web Apps can do for you](http://blog.ionic.io/what-progressive-web-apps-can-do-for-you/).
@@ -663,6 +663,6 @@ You can see the complete source code for this project [on GitHub](https://github
 
 To learn more about Ionic, Angular, or Okta, please see the following resources:
 
-* [Adding Authentication to your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa)
-* [Tutorial: Develop a Mobile App With Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot)
-* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot)
+* [Adding Authentication to your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa.html)
+* [Tutorial: Develop a Mobile App With Ionic and Spring Boot](/blog/2017/05/17/develop-a-mobile-app-with-ionic-and-spring-boot.html)
+* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html)

--- a/_source/_posts/2017-08-23-five-java-tips.md
+++ b/_source/_posts/2017-08-23-five-java-tips.md
@@ -126,7 +126,7 @@ Java has a bit of a reputation (and rightly so) for being verbose. All of the ex
 Shameless plug time: You can also write less code by [integrating Okta for fully featured user management](https://developer.okta.com/signup/). Just connect your apps, choose an IdP (or use ours), add users, configure rules, customize your login page, and then gain insights from our built-in reports. Want to see Okta in action? Check out these tutorials:
 
 * [Build a Secure Notes Application with Kotlin, TypeScript, and Okta](https://scotch.io/tutorials/build-a-secure-notes-application-with-kotlin-typescript-and-okta)
-* [Secure a Spring Microservices Architecture with Spring Security, JWTs, Juiser, and Okta](https://developer.okta.com/blog/2017/08/08/secure-spring-microservices)
-* [What is OpenId Connect](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1)
+* [Secure a Spring Microservices Architecture with Spring Security, JWTs, Juiser, and Okta](https://developer.okta.com/blog/2017/08/08/secure-spring-microservices.html)
+* [What is OpenId Connect](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1.html)
 
 And, as always, if you have any questions or comments you can hit me up on Twitter [@briandemers](https://twitter.com/briandemers), or follow our whole team [@oktadev](https://twitter.com/OktaDev).

--- a/_source/_posts/2017-08-28-developers-guide-to-docker-part-2.md
+++ b/_source/_posts/2017-08-28-developers-guide-to-docker-part-2.md
@@ -9,7 +9,7 @@ Creating a consistent environment for development, testing, staging, and product
 
 A `Dockerfile` (without an extension) is simply a text file with some keywords and rules that Docker uses to create an image. That image is then used to create a container, or multiple containers that all have the same set up. In this tutorial, you'll build a `Dockerfile` that you'll use to create an image for a basic web application.
 
->In [the previous article in this series](https://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1), I told you that images are like blueprints for creating containers. Well really, they *are* containers. Containers frozen in time that you can use to “stamp out a copy” anytime you want.
+>In [the previous article in this series](https://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1.html), I told you that images are like blueprints for creating containers. Well really, they *are* containers. Containers frozen in time that you can use to “stamp out a copy” anytime you want.
 
 To get the base application, just clone it from: [Github](https://github.com/leebrandt/docker-node-sample). This is just a basic Node website. Don’t have Node installed on your machine? Don’t worry, you’re not even going to run this application on your machine, you’re going to run it in a container.
 
@@ -122,6 +122,6 @@ Congratulations! You just built your first container from a base image and added
 
 Obviously, there are a lot of other things the `Dockerfile` can do for you. To find out more about what you can do in a `Dockerfile` check out the [documentation](https://docs.docker.com/engine/reference/builder/). 
 
-Now that you’ve [learned the basics of Docker](https://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1) and built your first `Dockerfile`, you’re ready to [start composing containers](https://docs.docker.com/compose/) and delivering those containers to production!
+Now that you’ve [learned the basics of Docker](https://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1.html) and built your first `Dockerfile`, you’re ready to [start composing containers](https://docs.docker.com/compose/) and delivering those containers to production!
 
 If you have any questions, comments, or suggestions, feel free to reach out to me [via email](mailto:lee.brandt@okta.com), or hit me up in the comments or via Twitter [@leebrandt](https://twitter.com/leebrandt).

--- a/_source/_posts/2017-09-08-nosql-options-for-java-developers.md
+++ b/_source/_posts/2017-09-08-nosql-options-for-java-developers.md
@@ -178,7 +178,7 @@ But I'm not stopping there. I shared this analysis with a few experts I know in 
 
 Please check back in a few weeks! I'll post the answers to these questions from the experts I interviewed. I'll also update this post to point to it when I do. If you're an expert on NoSQL databases, let me know! I'd be happy to include your answers in the interview. Just send me a message to [@mraible on Twitter](https://twitter.com/mraible) or matt.raible@okta.com.
 
-**Update:** [Part II has been published](/blog/2017/10/10/nosql-options-for-java-developers-part-ii). Many thanks to Justin McCarthy, Rafal Glowinski, Vlad Mihalcea, and Laurent Doguin for answering these questions!
+**Update:** [Part II has been published](/blog/2017/10/10/nosql-options-for-java-developers-part-ii.html). Many thanks to Justin McCarthy, Rafal Glowinski, Vlad Mihalcea, and Laurent Doguin for answering these questions!
 
 ## Research & Notes
 
@@ -200,4 +200,4 @@ JAXenter published the results of their annual survey of [top database trends](h
 
 **Changelog:**
 
-* Oct 10, 2017: Updated to link to [Part II blog post](/blog/2017/10/10/nosql-options-for-java-developers-part-ii) with answers from experts.
+* Oct 10, 2017: Updated to link to [Part II blog post](/blog/2017/10/10/nosql-options-for-java-developers-part-ii.html) with answers from experts.

--- a/_source/_posts/2017-09-14-lazy-developers-guide-to-auth-with-vue.md
+++ b/_source/_posts/2017-09-14-lazy-developers-guide-to-auth-with-vue.md
@@ -11,7 +11,7 @@ When I started writing this article, I wanted to show you how to add authenticat
 
 ## Vue CLI + PWA!
 
-Every web app that has mobile users should add PWA support so the app loads faster and works offline. Vue.js has [excellent PWA support](https://github.com/vuejs-templates/pwa). You might recognize me as a fan of PWAs if you’ve read my [Ultimate Guide to Progressive Web Applications](https://developer.okta.com/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications). 
+Every web app that has mobile users should add PWA support so the app loads faster and works offline. Vue.js has [excellent PWA support](https://github.com/vuejs-templates/pwa). You might recognize me as a fan of PWAs if you’ve read my [Ultimate Guide to Progressive Web Applications](https://developer.okta.com/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html). 
 
 I installed [Vue CLI](https://github.com/vuejs/vue-cli) and went to work.
 
@@ -292,7 +292,7 @@ If you open Chrome Developer Tools, you’ll see a message that recommends insta
 
 ## Add Okta for Authentication
 
-To replace the fake, hard-coded authentication in `src/auth.js`, start by installing the [Okta Auth SDK](https://developer.okta.com/code/javascript/okta_auth_sdk)
+To replace the fake, hard-coded authentication in `src/auth.js`, start by installing the [Okta Auth SDK](https://developer.okta.com/code/javascript/okta_auth_sdk.html)
 
 ```bash
 npm install @okta/okta-auth-js --save
@@ -543,5 +543,5 @@ If you’re intrigued by Vue.js, follow [@vuejs](https://twitter.com/vuejs) and 
 
 You can see the code this lazy developer created for this article [on GitHub](https://github.com/oktadeveloper/okta-vue-auth-example). You can also check out some other articles I wrote on PWAs.
 
-* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot)
-* [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications) 
+* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html)
+* [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html) 

--- a/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
+++ b/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
@@ -768,9 +768,9 @@ You now know how to build an Angular client with TypeScript, using Okta’s Sign
 
 If you’re ambitious, you could even turn the client into a progressive web app (PWA), enabling offline access and faster load times. There are a couple of posts about developing PWAs on the this blog if you’re interested in learning more. 
 
-* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot)
-* [Add Authentication to Your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa)
-* [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications)
+* [Build Your First Progressive Web Application with Angular and Spring Boot](/blog/2017/05/09/progressive-web-applications-with-angular-and-spring-boot.html)
+* [Add Authentication to Your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa.html)
+* [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html)
 
 My good buddy [Josh Long](https://twitter.com/starbuxman) and I recently hosted a live-coding session where we developed a Spring Boot microservices architecture on the backend and an Angular PWA on the front-end. The code we wrote is very similar to the code in this article. You can check the video out for reference [on YouTube](https://virtualjug.com/building-robust-apis-and-apps-with-spring-boot-and-angular/). 
 

--- a/_source/_posts/2017-09-28-top-10-javaone-2017-sessions-for-java-hipsters.md
+++ b/_source/_posts/2017-09-28-top-10-javaone-2017-sessions-for-java-hipsters.md
@@ -42,7 +42,7 @@ JHipster leverages [Docker and Docker Compose](http://www.jhipster.tech/docker-c
 
 [Burr Sutter](https://twitter.com/burrsutter) is another great speaker, and in [this session](https://events.rainfocus.com/catalog/oracle/oow17/catalogjavaone17?search=%22Eight%20Steps%20to%20Becoming%20Awesome%20with%20Kubernetes%22&showEnrolled=false) he’s covering one of the most talked about technologies on the web today: Kubernetes! Everybody seems to be rocking with Kubernetes. Even your favorite open source repositories at GitHub are running on top of it. Don’t be the last developer to board this bullet train. Come to this session to learn eight simple and practical steps that will take you from Kubernetes novice to expert.
 
-JHipster has [support for deploying to Kubernetes](http://www.jhipster.tech/kubernetes/). You can learn more about how this works (and see a screencast of deploying to Google Cloud) in an article on this blog: [Develop and Deploy Microservices with JHipster](https://developer.okta.com/blog/2017/06/20/develop-microservices-with-jhipster).
+JHipster has [support for deploying to Kubernetes](http://www.jhipster.tech/kubernetes/). You can learn more about how this works (and see a screencast of deploying to Google Cloud) in an article on this blog: [Develop and Deploy Microservices with JHipster](https://developer.okta.com/blog/2017/06/20/develop-microservices-with-jhipster.html).
 
 **When:** Wednesday, Oct 04, 9:30 a.m. - 10:15 a.m.
 **Where:** Moscone West - Room 2004

--- a/_source/_posts/2017-10-04-aspnet-authorization.md
+++ b/_source/_posts/2017-10-04-aspnet-authorization.md
@@ -14,7 +14,7 @@ In the Okta world, users are separated into `Groups`. By default however, ASP.NE
 
 This second approach is far easier to implement, so that's the approach this article will take.
 
-Start by cloning the application at <https://github.com/oktadeveloper/aspnetcore-oidc-okta-example>. This is the base application with authentication covered in [my previous post](https://developer.okta.com/blog/2017/06/29/oidc-user-auth-aspnet-core). You’ll add authorization to this application.
+Start by cloning the application at <https://github.com/oktadeveloper/aspnetcore-oidc-okta-example>. This is the base application with authentication covered in [my previous post](https://developer.okta.com/blog/2017/06/29/oidc-user-auth-aspnet-core.html). You’ll add authorization to this application.
 
 ## Let ASP.NET Know Where Your Roles Are
 In the `startup.cs` file, where the `OpenIdConfigurationOptions` are set, one of the items being set is the `TokenValidationParameters`. In the new `TokenValidationParameters` add a property called `RoleClaimType` with a value of `ClaimTypes.Role`. This is an enumeration in the `System.Security.Claims` namespace that holds the URL that describes the "role" claim type. Ultimately, your `TokenValidationParameters` property should look like this.

--- a/_source/_posts/2017-10-10-nosql-options-for-java-developers-part-ii.md
+++ b/_source/_posts/2017-10-10-nosql-options-for-java-developers-part-ii.md
@@ -5,7 +5,7 @@ author: mraible
 tags: [nosql, java, redis, mongodb, cassandra, neo4j, postgresql, spring boot, spring data]
 ---
 
-Last month, I wrote about [NoSQL Options for Java Developers](/blog/2017/09/08/nosql-options-for-java-developers). I analyzed the data available from a variety of sources (Indeed jobs, GitHub stars, Stack Overflow tags) to pick the top five options: MongoDB, Redis, Cassandra, Neo4j, and PostgreSQL. After writing this article, I shared it with a few experts I know in the Java and NoSQL communities and asked them the following questions:
+Last month, I wrote about [NoSQL Options for Java Developers](/blog/2017/09/08/nosql-options-for-java-developers.html). I analyzed the data available from a variety of sources (Indeed jobs, GitHub stars, Stack Overflow tags) to pick the top five options: MongoDB, Redis, Cassandra, Neo4j, and PostgreSQL. After writing this article, I shared it with a few experts I know in the Java and NoSQL communities and asked them the following questions:
 
 1. Do you agree with my choices of the top 5 NoSQL options (MongoDB, Redis, Cassandra, Neo4j, and PostgreSQL with its JSON support)?
 2. Do you have any good or bad stories about using any of these databases in production?

--- a/_source/_posts/2017-10-11-developers-guide-to-docker-part-3.md
+++ b/_source/_posts/2017-10-11-developers-guide-to-docker-part-3.md
@@ -187,6 +187,6 @@ If everything completes successfully, you can then go to `http://localhost/users
 Congratulations! You have a complete environment that is defined in your source code. It can be versioned and checked in to source control. This is what people refer to as “Infrastructure as Code”. It also means that recreating this environment on the test, staging and production environments is as easy as running `docker-compose up -d` on the corresponding machine! I _told_ you good developers are lazy!
 
 ## Learn More
-You can learn more about [Docker Compose](https://docs.docker.com/compose/compose-file/) and [Docker](https://docs.docker.com/) in general from their respective documentation. If you want to learn more about the `Dockerfile` used in this project, check out [part two of this series on the `Dockerfile`](https://developer.okta.com/blog/2017/08/28/developers-guide-to-docker-part-2).
+You can learn more about [Docker Compose](https://docs.docker.com/compose/compose-file/) and [Docker](https://docs.docker.com/) in general from their respective documentation. If you want to learn more about the `Dockerfile` used in this project, check out [part two of this series on the `Dockerfile`](https://developer.okta.com/blog/2017/08/28/developers-guide-to-docker-part-2.html).
 
 As always, if you have any questions or comments about this, or any, of my articles, feel free to hit me up on [Twitter](https://twitter.com/leebrandt) or [Github](https://github.com/leebrandt).

--- a/_source/_posts/2017-10-17-add-the-power-of-webhooks-to-your-app-with-oktas-system-log.md
+++ b/_source/_posts/2017-10-17-add-the-power-of-webhooks-to-your-app-with-oktas-system-log.md
@@ -539,6 +539,6 @@ INFO[0000] Sending events matching '.*' to 'https://requestb.in/0ab12345'
 INFO[0000] Started polling for events at: https://dev-12345.oktapreview.com
 ```
 
-I hope that this post has inspired you to think of cool ways you can use webhooks with your own Okta org. I highly suggest checking out [Zapier](https://zapier.com/) and in particular the excellent [Zapier Webhook support](https://zapier.com/blog/how-use-zapier-webhooks/) that Zapier provides. You should also take a look at this post on [the webhooks vs serverless debate](https://developer.okta.com/blog/2017/10/11/why-are-webhooks-better-than-serverless-extensibility) by my friend and colleague Randall Degges.
+I hope that this post has inspired you to think of cool ways you can use webhooks with your own Okta org. I highly suggest checking out [Zapier](https://zapier.com/) and in particular the excellent [Zapier Webhook support](https://zapier.com/blog/how-use-zapier-webhooks/) that Zapier provides. You should also take a look at this post on [the webhooks vs serverless debate](https://developer.okta.com/blog/2017/10/11/why-are-webhooks-better-than-serverless-extensibility.html) by my friend and colleague Randall Degges.
 
 [Let me know](mailto:joel.franusic@okta.com) how you're using `loghook` or if you have any questions or comments about this post. And don't forget to follow our team on Twitter [@oktadev](https://twitter.com/OktaDev). Thanks for reading!

--- a/_source/_posts/2017-10-19-build-a-preact-app-with-authentication.md
+++ b/_source/_posts/2017-10-19-build-a-preact-app-with-authentication.md
@@ -13,7 +13,7 @@ applications, it can be a great choice.
 
 In this tutorial, you'll build a basic Preact application with a couple of pages
 and user authentication using the [Okta Sign-In
-Widget](https://developer.okta.com/code/javascript/okta_sign-in_widget).
+Widget](https://developer.okta.com/code/javascript/okta_sign-in_widget.html).
 
 
 ## Bootstrap Your App With PreactCLI
@@ -603,8 +603,8 @@ the code, Preact or Okta, feel free to reach out to me via
 
 If you’re interested in learning more about authentication using the Okta
 Sign-In Widget with Angular, you can follow Matt Raible’s posts at
-<https://developer.okta.com/blog/2017/03/27/angular-okta-sign-in-widget> or
-<https://developer.okta.com/blog/2017/06/13/add-authentication-angular-pwa>, and
+<https://developer.okta.com/blog/2017/03/27/angular-okta-sign-in-widget.html> or
+<https://developer.okta.com/blog/2017/06/13/add-authentication-angular-pwa.html>, and
 If you want to know more about Okta’s Identity Platform, read Randall Degges
 post at
-<https://developer.okta.com/blog/2017/08/29/meet-the-new-okta-identity-platform>.
+<https://developer.okta.com/blog/2017/08/29/meet-the-new-okta-identity-platform.html>.

--- a/_source/_posts/2017-10-19-use-openid-connect-to-build-a-simple-node-website.md
+++ b/_source/_posts/2017-10-19-use-openid-connect-to-build-a-simple-node-website.md
@@ -486,7 +486,7 @@ One of my good friends and co-workers [Micah
 Silverman](https://twitter.com/afitnerd) recently published a three part primer
 to OIDC which I strongly recommend you read if you're interested in learning
 more about OIDC. You can [check it out
-here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1).
+here](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1.html).
 
 You can also [follow myself](https://twitter.com/rdegges) and
 [Okta](https://twitter.com/oktadev) on Twitter to see more of what I'm working

--- a/_source/_posts/2017-10-20-oidc-with-jhipster.md
+++ b/_source/_posts/2017-10-20-oidc-with-jhipster.md
@@ -34,7 +34,7 @@ I’ve been a committer on the JHipster project ever since I [started writing th
 
 I’m a fan of [OAuth 2.0](https://oauth.net/) and [OpenID Connect](http://openid.net/connect/) (OIDC). It helps that I work for Okta, where we implement both options in our API and allow developers to use our libraries &mdash; or third party libraries &mdash; to connect. I like how OAuth will enable me to use my existing credentials at an Identity Provider (e.g., Google, Facebook, or even Okta) to log in to applications without creating a new account.
 
-> If you want to know more about how OAuth and OIDC work, check out my article [What the Heck is OAuth](https://developer.okta.com/blog/2017/06/21/what-the-heck-is-oauth) or watch Karl McGuinness’s [What the Heck is OpenID Connect talk from Oktane 17](https://www.youtube.com/watch?v=6ypYXxRPKgk). 
+> If you want to know more about how OAuth and OIDC work, check out my article [What the Heck is OAuth](https://developer.okta.com/blog/2017/06/21/what-the-heck-is-oauth.html) or watch Karl McGuinness’s [What the Heck is OpenID Connect talk from Oktane 17](https://www.youtube.com/watch?v=6ypYXxRPKgk). 
 
 About a month ago, I started looking into creating a JHipster Module that’d work with Okta, much like [the one I created at Stormpath](https://stormpath.com/blog/stormpath-jhipster-application). I knew that JHipster had OAuth as one of its authentication options, but I was unfamiliar with how it worked. I discovered when you chose OAuth as your authentication mechanism; it created an OAuth server and an Angular client with the client ID and client secret embedded in the code. 
 
@@ -44,7 +44,7 @@ Embedding a client secret in a SPA (single-page app) is a no-no in OAuth-land, a
 
 Over the last couple years, JHipster has [had](https://github.com/jhipster/generator-jhipster/issues/2465) a [few](https://github.com/jhipster/generator-jhipster/issues/6139) [requests](https://issues.jboss.org/browse/KEYCLOAK-2243?) for Keycloak integration. [Keycloak](http://www.keycloak.org/) is an open source identity and access management solution. It has an Apache 2.0 license and is run by Red Hat. It supports standard protocols like OIDC, OAuth 2.0, and SAML 2.0. You can find its [source code on GitHub](https://github.com/keycloak/keycloak).
 
-JHipster uses [Spring Security](https://github.com/spring-projects/spring-security) and [I knew that it integrated with OAuth very easily](/blog/2017/03/21/spring-boot-oauth). After [a lengthy discussion with the JHipster community](https://github.com/gmarziou/jhipster-keycloak/issues/2#issuecomment-327007722), I decided to implement OAuth / OIDC support for JHipster using Spring Security, and nothing else. We thought about making it so the Angular client embedded a login form that was OIDC-aware, but realized we might have to have different libraries for different UI frameworks and it’d get complicated. By leveraging Spring Security and OAuth’s *[authorization code flow](https://tools.ietf.org/html/rfc6749#section-4.1)*, Spring Security would handle the redirect to the Identity Provider (aka IdP) for sign in, manage the code-for-token exchange, and redirect back to the UI. 
+JHipster uses [Spring Security](https://github.com/spring-projects/spring-security) and [I knew that it integrated with OAuth very easily](/blog/2017/03/21/spring-boot-oauth.html). After [a lengthy discussion with the JHipster community](https://github.com/gmarziou/jhipster-keycloak/issues/2#issuecomment-327007722), I decided to implement OAuth / OIDC support for JHipster using Spring Security, and nothing else. We thought about making it so the Angular client embedded a login form that was OIDC-aware, but realized we might have to have different libraries for different UI frameworks and it’d get complicated. By leveraging Spring Security and OAuth’s *[authorization code flow](https://tools.ietf.org/html/rfc6749#section-4.1)*, Spring Security would handle the redirect to the Identity Provider (aka IdP) for sign in, manage the code-for-token exchange, and redirect back to the UI. 
 
 This turned out to be awesome because all we had to do was define properties for Spring Security (in `src/main/resources/config/application.yml`).
 
@@ -85,7 +85,7 @@ services:
       - 10990:10990
 ```
 
-If you’re unfamiliar with how Docker Compose works, check out Lee Brandt's [Developer’s Guide to Docker Compose](/blog/2017/10/11/developers-guide-to-docker-part-3). 
+If you’re unfamiliar with how Docker Compose works, check out Lee Brandt's [Developer’s Guide to Docker Compose](/blog/2017/10/11/developers-guide-to-docker-part-3.html). 
 
 This means you can start Keycloak in your JHipster app’s root directory using the following command.
 
@@ -170,9 +170,9 @@ Even if you don’t create your next application with JHipster, it’s a great w
 
 I hope you get a chance to get hip with JHipster soon! In the meantime, here are a few related articles about the technologies mentioned in this post: 
 
-* [NoSQL Options for Java Developers](/blog/2017/09/08/nosql-options-for-java-developers), and [Part II that includes Q & A with NoSQL Experts](/blog/2017/10/10/nosql-options-for-java-developers-part-ii) 
-* [Develop and Deploy Microservices with JHipster](/blog/2017/06/20/develop-microservices-with-jhipster)
-* [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications)
+* [NoSQL Options for Java Developers](/blog/2017/09/08/nosql-options-for-java-developers.html), and [Part II that includes Q & A with NoSQL Experts](/blog/2017/10/10/nosql-options-for-java-developers-part-ii.html) 
+* [Develop and Deploy Microservices with JHipster](/blog/2017/06/20/develop-microservices-with-jhipster.html)
+* [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications.html)
 
 Don’t forget to check out the [JHipster Mini-Book](http://www.jhipster-book.com/) too. It’s free after all! 🤓 
 

--- a/_source/_posts/2017-10-27-okta-oauth-zork.md
+++ b/_source/_posts/2017-10-27-okta-oauth-zork.md
@@ -36,7 +36,7 @@ In the spirit of the game, you can choose your own adventure:
 
 ## What the Heck is OAuth?
 
-My colleague at Okta wrote a great in-depth [post that defines what OAuth is and is not](https://developer.okta.com/blog/2017/06/21/what-the-heck-is-oauth). Here, we’ll cover the important points.
+My colleague at Okta wrote a great in-depth [post that defines what OAuth is and is not](https://developer.okta.com/blog/2017/06/21/what-the-heck-is-oauth.html). Here, we’ll cover the important points.
 
 OAuth is a standard that apps can use to provide client applications with “secure delegated access”. It works over HTTPS and authorizes devices, APIs, servers, and applications with access tokens rather than credentials.
 
@@ -188,7 +188,7 @@ state=d8c6d98f-d302-4afb-9624-b12500085a12
 
 This is the “front door” to an OAuth implicit flow. The `response_type` field indicates that an access token will be returned. The `redirect_uri` field indicates where Okta will redirect back to upon successful authentication.
 
-Note the `scope` field. It’s set to `openid`. In OIDC a `scope` field is required and at least `openid` must be present as a scope. For more information on OIDC, check out my three-part series on the [Okta Blog](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1).
+Note the `scope` field. It’s set to `openid`. In OIDC a `scope` field is required and at least `openid` must be present as a scope. For more information on OIDC, check out my three-part series on the [Okta Blog](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1.html).
 
 Assuming authentication is successful and Okta redirects back to your application, there’s some javascript that takes over to display the access token and a command using [HTTPie](https://httpie.org) to interact with the game.
 

--- a/_source/_posts/2017-10-27-secure-spa-spring-boot-oauth.md
+++ b/_source/_posts/2017-10-27-secure-spa-spring-boot-oauth.md
@@ -5,7 +5,7 @@ author: bdemers
 tags: [oauth, oauth2, oauth2.0, oauth 2.0, spring, spring boot, spring security]
 --- 
 
-If you have a JavaScript single-page application (SPA) that needs to securely access resources from a Spring Boot application, you likely want to use the OAuth 2.0 implicit flow! With this flow your client will send a bearer token with each request and your server side application will verify the token with an Identity Provider (IdP). This allows your resource server to trust that your client is authorized to make the request. In OAuth terms your SPA is the client and your Spring Boot application is the Resource Server. For a more detailed explanation on the various OAuth flows take a look at our [What the Heck is OAuth](/blog/2017/06/21/what-the-heck-is-oauth) post.
+If you have a JavaScript single-page application (SPA) that needs to securely access resources from a Spring Boot application, you likely want to use the OAuth 2.0 implicit flow! With this flow your client will send a bearer token with each request and your server side application will verify the token with an Identity Provider (IdP). This allows your resource server to trust that your client is authorized to make the request. In OAuth terms your SPA is the client and your Spring Boot application is the Resource Server. For a more detailed explanation on the various OAuth flows take a look at our [What the Heck is OAuth](/blog/2017/06/21/what-the-heck-is-oauth.html) post.
 
 Today you are going to build two small applications that demonstrate these principles in action: a simple SPA client app with a little bit of JQuery and a backend service with Spring Boot. You'll start out by using the standard Spring OAuth bits and then switch to the Okta Spring Boot Starter and check out its added features. Obviously (this is the Okta developer blog), you'll be using Okta for your IdP, but the first sections will be vendor agnostic.
 
@@ -338,7 +338,7 @@ okta:
 
 Restart your application and the first two concerns have been taken care of!
 
-The last one requires an extra step, you will have to add extra data to Okta's access token. We have a [whole post on this topic](/blog/2017/10/13/okta-groups-spring-security), but the cliff notes are as follows: 
+The last one requires an extra step, you will have to add extra data to Okta's access token. We have a [whole post on this topic](/blog/2017/10/13/okta-groups-spring-security.html), but the cliff notes are as follows: 
 
 Head back over to the Okta Developer Console, on the menu bar click **API** > **Authorization Server**. In this example we have been using the 'default' authorization server, so click edit, then select the 'Claims' tab. Click 'Add Claim' and fill out the form with the following values:
 
@@ -380,8 +380,8 @@ public class MessageOfTheDayController {
 In this post, we created a standard Spring Boot + Spring Security OAuth 2.0 application that uses an OAuth implicit flow, then spiced it up with the `okta-spring-boot-starter` which added (without any code) support for: client side access token validation, OAuth scope support, and Okta group to authority mapping. Next time, I'll create a sample app which uses an OAuth code-flow.
 
 Want to learn more about OAuth?
-- [What the Heck is OAuth](/blog/2017/06/21/what-the-heck-is-oauth)
-- [An OpenID Connect Primer](/blog/2017/07/25/oidc-primer-part-1)
+- [What the Heck is OAuth](/blog/2017/06/21/what-the-heck-is-oauth.html)
+- [An OpenID Connect Primer](/blog/2017/07/25/oidc-primer-part-1.html)
 - [OAuth.net](https://www.oauth.com/)
 
 Questions? Comments? Cool stories about OAuth? Hit me up on Twitter [@briandemers](https://twitter.com/briandemers) and make sure to follow my team [@oktadev](https://twitter.com/oktadev).

--- a/_source/_posts/2017-10-31-add-authentication-to-play-framework-with-oidc.md
+++ b/_source/_posts/2017-10-31-add-authentication-to-play-framework-with-oidc.md
@@ -73,7 +73,7 @@ To figure out which security plugin I should use with Play, I [asked my network 
 
 From this conversation, I learned that [Play’s built-in OAuth support](https://www.playframework.com/documentation/2.6.x/JavaOAuth) is only for OAuth 1.0. I also learned about [play-zhewbacca](https://github.com/zalando-stups/play-zhewbacca) and [Silhouette](https://www.silhouette.rocks/). Secure Social [hasn’t been worked on for several months](https://github.com/jaliss/securesocial/commits/master), so I decided to pass on it. Silhouette has a pretty website and extensive documentation, but it’s not compatible with Java. I wanted to write a Java app for this example.
 
-I decided to try [play-pac4j](https://github.com/pac4j/play-pac4j). My reason was simple, I’m a [lazy developer](/blog/2017/09/14/lazy-developers-guide-to-auth-with-vue), and its README shows an OIDC example that looked easy enough to implement. Its [documentation](http://www.pac4j.org/docs/clients/openid-connect.html) confirmed it didn’t require much.
+I decided to try [play-pac4j](https://github.com/pac4j/play-pac4j). My reason was simple, I’m a [lazy developer](/blog/2017/09/14/lazy-developers-guide-to-auth-with-vue.html), and its README shows an OIDC example that looked easy enough to implement. Its [documentation](http://www.pac4j.org/docs/clients/openid-connect.html) confirmed it didn’t require much.
 
 ```java
 final OidcConfiguration oidcConfiguration = new OidcConfiguration();
@@ -427,9 +427,9 @@ If you have a similar tutorial on using Silhouette or another OIDC library for P
 
 If you’re a Java dev who’s interested in reading more about integrating Okta, I’d love to have you check out these resources:
 
-* [My recent post on using OIDC support with JHipster](/blog/2017/10/20/oidc-with-jhipster)
-* [Micah Silverman’s recent post on RBAC with Thymeleaf and Spring Security](/blog/2017/10/13/okta-groups-spring-security)
-* [Identity, Claims, & Tokens – An OpenID Connect Primer, Part 1 of 3](/blog/2017/07/25/oidc-primer-part-1)
+* [My recent post on using OIDC support with JHipster](/blog/2017/10/20/oidc-with-jhipster.html)
+* [Micah Silverman’s recent post on RBAC with Thymeleaf and Spring Security](/blog/2017/10/13/okta-groups-spring-security.html)
+* [Identity, Claims, & Tokens – An OpenID Connect Primer, Part 1 of 3](/blog/2017/07/25/oidc-primer-part-1.html)
 
 And finally, I’d love to have you follow our whole team on Twitter for more awesome content. Check us out [@oktadev](https://twitter.com/OktaDev)!
 

--- a/_source/_posts/2017-11-20-add-sso-spring-boot-15-min.md
+++ b/_source/_posts/2017-11-20-add-sso-spring-boot-15-min.md
@@ -213,7 +213,7 @@ Now the real fun begins, as you create or onboard new users to your app! Take so
 Interested in learning more? Check out these other Java resources:
 
 * Our [Java Product Documentation](/code/java/)
-* [Secure Your SPA with Spring Boot and OAuth](/blog/2017/10/27/secure-spa-spring-boot-oauth)
-* [Add Role-Based Access Control to Your App with Spring Security and Thymeleaf](/blog/2017/10/13/okta-groups-spring-security)
+* [Secure Your SPA with Spring Boot and OAuth](/blog/2017/10/27/secure-spa-spring-boot-oauth.html)
+* [Add Role-Based Access Control to Your App with Spring Security and Thymeleaf](/blog/2017/10/13/okta-groups-spring-security.html)
 
 And if you have questions about this or any of our other content (or just want to chat!) hit us up on Twitter [@OktaDev](https://twitter.com/OktaDev). We’d love to hear from you!

--- a/_source/_standards/OAuth/index.md
+++ b/_source/_standards/OAuth/index.md
@@ -252,7 +252,7 @@ A custom claim can be configured in the following ways:
 
 ## Validating Access Tokens
 
-For more information on validating access tokens, see our [Authentication Guide](/authentication-guide/tokens/validating-access-tokens).
+For more information on validating access tokens, see our [Authentication Guide](/authentication-guide/tokens/validating-access-tokens.html).
 
 ## Refresh Token
 

--- a/_source/_use_cases/authentication/index.md
+++ b/_source/_use_cases/authentication/index.md
@@ -45,7 +45,7 @@ widget.
 ### Auth SDK
 
 For those who are building a Javascript front end or Single Page App
-(SPA), the light-weight, JavaScript-based [Okta Auth SDK](/code/javascript/okta_auth_sdk)
+(SPA), the light-weight, JavaScript-based [Okta Auth SDK](/code/javascript/okta_auth_sdk.html)
 gives you the added control beyond our sign-in widget to cater to your
 needs.  This Javascript SDK provides all the standard login support
 including password management and strong authentication.  In addition,
@@ -60,7 +60,7 @@ comprehensive [authentication REST API](/docs/api/resources/authn.html)
 exposed through Okta.  Use it as a
 standalone API to provide the identity layer on top of your existing
 application and authentication logic, or use it with the Okta [Sessions API](/docs/api/resources/sessions.html)
-to obtain an Okta [session cookie](/use_cases/authentication/session_cookie) and access apps within Okta.
+to obtain an Okta [session cookie](/use_cases/authentication/session_cookie.html) and access apps within Okta.
 This session integration provides an SSO experience across custom and Okta-managed apps.
 
 ## Building Apps That Support SSO

--- a/_source/documentation/stormpath-import.md
+++ b/_source/documentation/stormpath-import.md
@@ -1,6 +1,7 @@
 ---
 layout: docs_page
 title: Importing Your Stormpath Data Into Okta
+permalink: /documentation/stormpath-import.html
 ---
 
 # Importing Your Stormpath Data Into Okta

--- a/_source/quickstart-fragments/java/spring-auth-code.md
+++ b/_source/quickstart-fragments/java/spring-auth-code.md
@@ -52,4 +52,4 @@ public class ExampleApplication {
 
 That's it! Open an incognito window (to ensure clean browser cache) and browse to `http://localhost:8080/login` you will be  automatically redirected to the Okta login page.
 
-You can read more about [Spring's OAuth 2 support](http://projects.spring.io/spring-security-oauth/docs/oauth2.html) or take a look at this [blog post](https://developer.okta.com/blog/2017/03/21/spring-boot-oauth) that describes the steps and configuration in detail.
+You can read more about [Spring's OAuth 2 support](http://projects.spring.io/spring-security-oauth/docs/oauth2.html) or take a look at this [blog post](https://developer.okta.com/blog/2017/03/21/spring-boot-oauth.html) that describes the steps and configuration in detail.

--- a/_source/quickstart-fragments/java/spring-implicit.md
+++ b/_source/quickstart-fragments/java/spring-implicit.md
@@ -50,6 +50,6 @@ class MessagesRestController {
 
 ### That's it!
 
-Okta's Spring Security integration will [parse the JWT access token](/blog/2017/06/21/what-the-heck-is-oauth#oauth-flows) from the HTTP request's `Authorization: Bearer` header value.
+Okta's Spring Security integration will [parse the JWT access token](/blog/2017/06/21/what-the-heck-is-oauth.html#oauth-flows) from the HTTP request's `Authorization: Bearer` header value.
 
-Check out a [Spring Boot example](https://github.com/okta/okta-spring-boot/tree/master/examples) or this [blog post](/blog/2017/09/19/build-a-secure-notes-application-with-kotlin-typescript-and-okta).
+Check out a [Spring Boot example](https://github.com/okta/okta-spring-boot/tree/master/examples) or this [blog post](/blog/2017/09/19/build-a-secure-notes-application-with-kotlin-typescript-and-okta.html).

--- a/scripts/find-missing-slashes.js
+++ b/scripts/find-missing-slashes.js
@@ -77,10 +77,7 @@ function findBadLinks(file, fileMap) {
     .filter(link => !link.prepped.includes('://'))
 
     // Remove non http protocols (i.e. mailto: and tel:)
-    .filter(link => !link.prepped.includes('mailto:') && !link.prepped.includes('tel:'))
-
-    // Remove links with no extension that resolve to an html file
-    .filter(link => !fileMap[`${link.prepped}.html`]);
+    .filter(link => !link.prepped.includes('mailto:') && !link.prepped.includes('tel:'));
 }
 
 async function run(dir) {


### PR DESCRIPTION
## Description:
Updates all internal links to end in `.html` or `/`. This is required for pages to be served off of S3.
 
The following links are allowed and tested via `npm run find-missing-slashes`
- `developer.okta.com/code/`
- `developer.okta.com/code/sample.html`
- ~`developer.okta.com/code/sample`~ Is **not** allowed

Related to: [OKTA-147264](https://oktainc.atlassian.net/browse/OKTA-147264)

