### PR TITLE
Update blog posts to specify Default AS as issuer

### DIFF
--- a/_source/_posts/2017-03-16-spring-boot-saml.md
+++ b/_source/_posts/2017-03-16-spring-boot-saml.md
@@ -23,7 +23,7 @@ You'll receive an email to activate your account and change your temporary passw
 
 ## Create a SAML Application on Okta
 
-At the time of this writing, the easiest way to create a SAML-aware Spring Boot application is to use Spring Security's [SAML DSL project](https://github.com/spring-projects/spring-security-saml-dsl). It contains a sample project that provides [instructions](https://github.com/spring-projects/spring-security-saml-dsl/blob/master/samples/spring-security-saml-dsl-sample/README.md) for configuring Okta as a SAML provider. These instructions will likely work for you if you're experienced Spring Boot and Okta developer. If you're new to both, this "start from scratch" tutorial might work better for you.
+At the time of this writing, the easiest way to create a SAML-aware Spring Boot application is to use Spring Security's [SAML DSL project](https://github.com/spring-projects/spring-security-saml-dsl). It contains a sample project that provides [instructions](https://github.com/spring-projects/spring-security-saml-dsl/blob/master/samples/spring-security-saml-dsl-sample/README.md) for configuring Okta as a SAML provider. These instructions will likely work for you if you're an experienced Spring Boot and Okta developer. If you're new to both, this "start from scratch" tutorial might work better for you.
 
 Just like I did, the first thing you'll need to do is create a developer account at [https://developer.okta.com](https://developer.okta.com/signup/). After activating your account, log in to it. If you just created an account, you'll see a screen similar to the one below.
 

--- a/_source/_posts/2017-03-27-angular-okta-sign-in-widget.md
+++ b/_source/_posts/2017-03-27-angular-okta-sign-in-widget.md
@@ -99,7 +99,10 @@ export class Okta {
     this.widget = new OktaSignIn({
       baseUrl: 'https://{yourOktaDomain}.com',
       clientId: '{clientId}',
-      redirectUri: 'http://localhost:4200'
+      redirectUri: 'http://localhost:4200',
+      authParams: {
+        issuer: 'default'
+      }
     });
   }
 

--- a/_source/_posts/2017-03-30-react-okta-sign-in-widget.md
+++ b/_source/_posts/2017-03-30-react-okta-sign-in-widget.md
@@ -127,10 +127,11 @@ export default class LoginPage extends React.Component{
     super();
     this.state = {user:null};
     this.widget = new OktaSignIn({
-      baseUrl: 'https://{oktaOrgUrl}',
+      baseUrl: 'https://{yourOktaDomain}.com',
       clientId: '{clientId}',
       redirectUri: 'http://localhost:3000',
       authParams: {
+        issuer: 'https://{yourOktaDomain}.com/oauth2/default'
         responseType: 'id_token'
       }
     });

--- a/_source/_posts/2017-03-30-react-okta-sign-in-widget.md
+++ b/_source/_posts/2017-03-30-react-okta-sign-in-widget.md
@@ -131,7 +131,7 @@ export default class LoginPage extends React.Component{
       clientId: '{clientId}',
       redirectUri: 'http://localhost:3000',
       authParams: {
-        issuer: 'https://{yourOktaDomain}.com/oauth2/default'
+        issuer: 'default'
         responseType: 'id_token'
       }
     });

--- a/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
+++ b/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
@@ -956,7 +956,7 @@ export class OktaAuthWrapper {
   constructor(private oauthService: OAuthService) {
     this.authClient = new OktaAuth({
       url: 'https://{yourOktaDomain}.com',
-      issuer: 'https://{yourOktaDomain}.com/oauth2/default'
+      issuer: 'default'
     });
   }
 

--- a/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
+++ b/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
@@ -775,7 +775,7 @@ import { OAuthService, JwksValidationHandler } from 'angular-oauth2-oidc';
     this.oauthService.redirectUri = window.location.origin;
     this.oauthService.clientId = '{client-id}';
     this.oauthService.scope = 'openid profile email';
-    this.oauthService.issuer = 'https://{yourOktaDomain}.com';
+    this.oauthService.issuer = 'https://{yourOktaDomain}.com/oauth2/default';
     this.oauthService.tokenValidationHandler = new JwksValidationHandler();
 
     // Load Discovery Document and then try to login the user
@@ -955,7 +955,8 @@ export class OktaAuthWrapper {
 
   constructor(private oauthService: OAuthService) {
     this.authClient = new OktaAuth({
-      url: this.oauthService.issuer
+      url: 'https://{yourOktaDomain}.com',
+      issuer: 'https://{yourOktaDomain}.com/oauth2/default'
     });
   }
 

--- a/_source/_posts/2017-06-13-add-authentication-angular-pwa.md
+++ b/_source/_posts/2017-06-13-add-authentication-angular-pwa.md
@@ -239,7 +239,7 @@ Install [Manfred Steyer's](https://github.com/manfredsteyer) project to [add OAu
 npm install --save angular-oauth2-oidc
 ```
 
-Modify `client/src/app/app.component.ts` to import `OAuthService` and configure your app to use your Okta application settings (replacing `[oidc-client-id]` and `[dev-id]` with the values from your "Angular PWA" OIDC app).
+Modify `client/src/app/app.component.ts` to import `OAuthService` and configure your app to use your Okta application settings (replacing `{clientId}` and `{yourOktaDomain}` with the values from your "Angular PWA" OIDC app).
 
 ```typescript
 import { OAuthService } from 'angular-oauth2-oidc';
@@ -248,10 +248,10 @@ import { OAuthService } from 'angular-oauth2-oidc';
 
   constructor(private oauthService: OAuthService) {
     this.oauthService.redirectUri = window.location.origin;
-    this.oauthService.clientId = '[oidc-client-id]';
+    this.oauthService.clientId = '{clientId}';
     this.oauthService.scope = 'openid profile email';
     this.oauthService.oidc = true;
-    this.oauthService.issuer = 'https://dev-[dev-id].oktapreview.com';
+    this.oauthService.issuer = 'https://{yourOktaDomain}.com/oauth2/default';
 
     this.oauthService.loadDiscoveryDocument().then(() => {
       this.oauthService.tryLogin({});
@@ -402,7 +402,7 @@ Click the **Login** button and sign-in with one of the user's that are configure
 This will likely fail with an error similar to the following:
  
 ```
-https://dev-158606.oktapreview.com/.well-known/openid-configuration net::ERR_FAILED
+https://dev-158606.oktapreview.com/oauth2/default/.well-known/openid-configuration net::ERR_FAILED
 error loading discovery document 
 ```
  
@@ -530,7 +530,8 @@ export class HomeComponent {
   loginWithPassword() {
     this.oauthService.createAndSaveNonce().then(nonce => {
       const authClient = new OktaAuth({
-        url: this.oauthService.issuer
+        url: 'https://{yourOktaDomain}.com',
+        issuer: 'default'
       });
       authClient.signIn({
         username: this.username,

--- a/_source/_posts/2017-08-08-secure-spring-microservices.md
+++ b/_source/_posts/2017-08-08-secure-spring-microservices.md
@@ -450,7 +450,7 @@ export class OktaAuthService {
     baseUrl: 'https://{yourOktaDomain}.com',
     clientId: '{clientId}',
     authParams: {
-      issuer: 'https://{yourOktaDomain}',
+      issuer: 'default',
       responseType: ['id_token', 'token'],
       scopes: ['openid', 'email', 'profile']
     }

--- a/_source/_posts/2017-08-22-build-an-ionic-app-with-user-authentication.md
+++ b/_source/_posts/2017-08-22-build-an-ionic-app-with-user-authentication.md
@@ -125,7 +125,7 @@ Install `angular-oauth2-oidc` and the Okta Auth SDK using npm.
 npm install angular-oauth2-oidc@1.0.20 @okta/okta-auth-js --save
 ```
 
-In `src/pages/login/login.ts`, add the basic structure of the `LoginPage` class and a constructor that configures your OIDC settings with the `OAuthService` from angular-oauth2-oidc. You will need to replace “[client-id]” with the Client ID from your Okta OIDC settings and “[dev-id]” with your account's correct URI.
+In `src/pages/login/login.ts`, add the basic structure of the `LoginPage` class and a constructor that configures your OIDC settings with the `OAuthService` from angular-oauth2-oidc. You will need to replace `{clientId}` with the Client ID from your Okta OIDC settings and `{yourOktaDomain}` with your account's correct URI.
 
 ```typescript
 import { Component, ViewChild } from '@angular/core';
@@ -145,9 +145,9 @@ export class LoginPage {
 
   constructor(private navCtrl: NavController, private oauthService: OAuthService) {
     oauthService.redirectUri = window.location.origin;
-    oauthService.clientId = '[client-id]';
+    oauthService.clientId = '{clientId}';
     oauthService.scope = 'openid profile email';
-    oauthService.issuer = 'https://dev-[dev-id].oktapreview.com/oauth2/default';
+    oauthService.issuer = 'https://{yourOktaDomain}.com/oauth2/default';
   }
 
   ionViewDidLoad(): void {

--- a/_source/_posts/2017-09-14-lazy-developers-guide-to-auth-with-vue.md
+++ b/_source/_posts/2017-09-14-lazy-developers-guide-to-auth-with-vue.md
@@ -449,7 +449,7 @@ return authClient.signIn({
 
 You’ll need to create an OIDC App in Okta to get a `{clientId}`. To do this, log in to your Okta Developer account and navigate to **Applications** > **Add Application**. Click **SPA** and click the **Next** button. Give the app a name you’ll remember, and specify `http://localhost:8080` as a Base URI and Login Redirect URI.
 
-{% img blog/vue-auth-sdk/oidc-settings.png alt:"OIDC Settings" width:"600" %}{: .center-image }
+{% img blog/vue-auth-sdk/oidc-settings.png alt:"OIDC Settings" width:"700" %}{: .center-image }
 
 Click **Done** and you’ll be shown a screen with this information as well as a Client ID at the bottom. Copy the Client ID into `src/auth.js`.
 

--- a/_source/_posts/2017-09-14-lazy-developers-guide-to-auth-with-vue.md
+++ b/_source/_posts/2017-09-14-lazy-developers-guide-to-auth-with-vue.md
@@ -298,12 +298,12 @@ To replace the fake, hard-coded authentication in `src/auth.js`, start by instal
 npm install @okta/okta-auth-js --save
 ```
 
-Replace the code in `auth.js` with the following code that uses the Auth SDK to log in and save a session token as the token. If you don’t have an Okta Developer account, [create one](https://developer.okta.com/signup/). Then replace `{yourOktaDomain}` in the code below with your information (for example, https://dev-123456.oktapreview.com).
+Replace the code in `auth.js` with the following code that uses the Auth SDK to log in and save a session token as the token. If you don’t have an Okta Developer account, [create one](https://developer.okta.com/signup/). Then replace `{yourOktaDomain}` in the code below with your information (for example, `dev-123456.oktapreview`).
 
 ```javascript
 /* globals localStorage */
 const OktaAuth = require('@okta/okta-auth-js')
-const authClient = new OktaAuth({url: 'https://{yourOktaDomain}.com'})
+const authClient = new OktaAuth({url: 'https://{yourOktaDomain}.com', issuer: 'default'})
 
 export default {
   login (email, pass, cb) {

--- a/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
+++ b/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
@@ -476,7 +476,7 @@ export class OktaAuthService {
     clientId: '{client-id}',
     redirectUri: 'http://localhost:4200',
     authParams: {
-      issuer: 'https://{yourOktaDomain}.com/oauth2/default',
+      issuer: 'default',
       responseType: ['id_token', 'token'],
       scopes: ['openid', 'email', 'profile']
     }

--- a/_source/_posts/2017-12-04-basic-crud-angular-and-spring-boot.md
+++ b/_source/_posts/2017-12-04-basic-crud-angular-and-spring-boot.md
@@ -93,7 +93,7 @@ public class DemoApplication {
                 car.setName(name);
                 repository.save(car);
             });
-            repository.findAll().forEach(car -> System.out.println(car));
+            repository.findAll().forEach(System.out::println);
         };
     }
 }


### PR DESCRIPTION
## Description:

Update blog posts to specify Default AS as issuer.

I also updated all the README's in each blog posts associated GitHub repo:

* https://github.com/oktadeveloper/okta-angular-sign-in-widget-example
* https://github.com/oktadeveloper/okta-angular-openid-connect-example
* https://github.com/oktadeveloper/okta-spring-boot-angular-pwa-example
* https://github.com/oktadeveloper/okta-ionic-auth-example
* https://github.com/oktadeveloper/okta-vue-auth-example
* https://github.com/oktadeveloper/spring-boot-microservices-example
* https://github.com/oktadeveloper/okta-spring-boot-2-angular-5-example
* https://github.com/oktadeveloper/okta-kotlin-typescript-notes-example
* https://github.com/oktadeveloper/okta-spring-boot-saml-example
* https://github.com/oktadeveloper/okta-spring-boot-oauth-example
* https://github.com/oktadeveloper/okta-spring-security-5-example

I did NOT update the code for the React post Sign-In Widget.

