### PR TITLE
:bug: Fixes 404 when accessing /standards/

### DIFF
--- a/_source/_standards/OIDC/index.md
+++ b/_source/_standards/OIDC/index.md
@@ -3,6 +3,7 @@ layout: docs_page
 title: OpenID Connect and Okta
 excerpt: This simple identity layer on top of the OAuth 2.0 protocol makes identity management easier.
 icon: /assets/img/icons/openid.svg
+redirect_from: /standards/
 ---
 
 # OpenID Connect and Okta


### PR DESCRIPTION
## Description:
- The url https://developer.okta.com/standards/ currently `404`s because there is no `index.html` file produced.

Added a `redirect_from` attribute to drop the visitor directly to the OIDC page.
