### PR TITLE
Removing the RSS description property.

### DIFF
--- a/_source/feed-edgar.xml
+++ b/_source/feed-edgar.xml
@@ -5,7 +5,6 @@ layout: null
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ site.title | xml_escape }}</title>
-    <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}</link>
     <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
     {% for post in site.posts %}


### PR DESCRIPTION
This isn't needed for our Edgar feed. Keeping it in makes the feed to
large to be imported.

Is a super tiny fix, should be able to be merged without any impact. Thanks.