### PR TITLE
Adds redirects for common 404 pages

### DIFF
--- a/_source/_posts/2015-04-07-android-unit-testing-part-2.md
+++ b/_source/_posts/2015-04-07-android-unit-testing-part-2.md
@@ -3,6 +3,8 @@ layout: blog_post
 title: Android Unit Testing Part II&#58; Escaping Dalvik’s Hold
 author: victor_ronin
 tags: [android, testing]
+redirect_from:
+  - "/blog/2015-04-14-android-unit-testing-part-2"
 ---
 *This is the second of a four part series on Android Unit Testing. In
 these posts, we’ll walk through the key steps engineers should take

--- a/_source/_posts/2015-04-14-android-unit-testing-part-3.md
+++ b/_source/_posts/2015-04-14-android-unit-testing-part-3.md
@@ -3,6 +3,9 @@ layout: blog_post
 title: Android Unit Testing Part III&#58; Disintegration
 author: victor_ronin
 tags: [android, testing]
+redirect_from:
+  - "/blog/2015-04-07-android-unit-testing-part-3"
+  - "/blog/2015-04-23-android-unit-testing-part-3"
 ---
 *This is the third of a four part series on Android Unit Testing. In
 the last two articles I discussed the [general principles of having

--- a/_source/_posts/2015-04-23-android-unit-testing-part-4.md
+++ b/_source/_posts/2015-04-23-android-unit-testing-part-4.md
@@ -3,6 +3,8 @@ layout: blog_post
 title: Android Unit Testing Part IV&#58; Mocking
 author: victor_ronin
 tags: [android, testing]
+redirect_from:
+  - "/blog/2015-04-14-android-unit-testing-part-4"
 ---
 *This is the third of a four part series on Android Unit Testing. In
 the last two articles I discussed the [general principles of having

--- a/_source/_posts/2017-05-10-developers-guide-to-docker-part-1.md
+++ b/_source/_posts/2017-05-10-developers-guide-to-docker-part-1.md
@@ -3,6 +3,8 @@ layout: blog_post
 title: A Developer's Guide To Docker - A Gentle Introduction
 author: leebrandt
 tags: [docker, devops, developer]
+redirect_from:
+  - "/blog/2017/08/28/developers-guide-to-docker-part-1"
 ---
 
 *It works on my machine.* We’ve all heard it. Most of us have said it. It’s been impossible to get around it… until now. Not only can adding Docker to your development environment solve that issue, but it can make it drop-dead simple to onboard new developers, keep a team working forward and allow everyone on the team use their desired tools! 

--- a/_source/_posts/2017-07-25-oidc-primer-part-2.md
+++ b/_source/_posts/2017-07-25-oidc-primer-part-2.md
@@ -3,6 +3,8 @@ layout: blog_post
 title: 'OIDC in Action – An OpenID Connect Primer, Part 2 of 3'
 author: dogeared
 tags: [oauth, oauth2, oauth2.0, oauth 2.0, OpenID, OpenID Connect, oidc]
+redirect_from:
+  - "/blog/2017-08-01-oidc-primer-part-2"
 ---
 
 In the [first installment of this OpenID Connect (OIDC) series](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1), we looked at some OIDC basics, its history, and the various flow types, scopes, and tokens involved. In this post, we'll dive into the mechanics of OIDC and see the various flows in action.

--- a/_source/_posts/2017-08-01-oidc-primer-part-3.md
+++ b/_source/_posts/2017-08-01-oidc-primer-part-3.md
@@ -3,6 +3,8 @@ layout: blog_post
 title: 'What’s in a Token? – An OpenID Connect Primer, Part 3 of 3'
 author: dogeared
 tags: [oauth, oauth2, oauth2.0, oauth 2.0, OpenID, OpenID Connect, oidc]
+redirect_from:
+  - "/blog/2017-07-25-oidc-primer-part-3"
 ---
 
 In the previous two installments of this OpenID Connect (OIDC) series, we dug deep into the [OIDC flow types](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1) and saw [OIDC in action](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-2) using a playground found at: [https://okta-oidc-fun.herokuapp.com/](https://okta-oidc-fun.herokuapp.com/).

--- a/_source/_posts/2017-08-28-developers-guide-to-docker-part-2.md
+++ b/_source/_posts/2017-08-28-developers-guide-to-docker-part-2.md
@@ -3,13 +3,16 @@ layout: blog_post
 title: A Developer's Guide To Docker - The Dockerfile
 author: leebrandt
 tags: [docker, devops, developer]
+redirect_from:
+  - "/blog/2017/05/10/developers-guide-to-docker-part-2"
+  - "/blog/2017/10/11/developers-guide-to-docker-part-2"
 ---
 
 Creating a consistent environment for development, testing, staging, and production is one of the big benefits of using containers. Not only do containers make the *entire* environment portable, they remove *environment-specific problems*, like, "Why does it work in test, but not in production?" Usually, it's a package or framework that's installed on the test machine that is not on the production server. Containers carry all those dependencies with them, minimizing the possibility for those problems. To help create a consistent container, you need an image that is configured in code that can be versioned and distributed. That's where the `Dockerfile` comes in.
 
 A `Dockerfile` (without an extension) is simply a text file with some keywords and rules that Docker uses to create an image. That image is then used to create a container, or multiple containers that all have the same set up. In this tutorial, you'll build a `Dockerfile` that you'll use to create an image for a basic web application.
 
->In [the previous article in this series](https://developer.okta.com/blog/2017/05/10/developers-guide-to-docker-part-1), I told you that images are like blueprints for creating containers. Well really, they *are* containers. Containers frozen in time that you can use to “stamp out a copy” anytime you want.
+>In [the previous article in this series](/blog/2017/05/10/developers-guide-to-docker-part-1), I told you that images are like blueprints for creating containers. Well really, they *are* containers. Containers frozen in time that you can use to “stamp out a copy” anytime you want.
 
 To get the base application, just clone it from: [Github](https://github.com/leebrandt/docker-node-sample). This is just a basic Node website. Don’t have Node installed on your machine? Don’t worry, you’re not even going to run this application on your machine, you’re going to run it in a container.
 

--- a/_source/_posts/2017-09-08-nosql-options-for-java-developers.md
+++ b/_source/_posts/2017-09-08-nosql-options-for-java-developers.md
@@ -3,6 +3,8 @@ layout: blog_post
 title: 'NoSQL Options for Java Developers'
 author: mraible
 tags: [nosql, java, redis, mongodb, cassandra, neo4j, postgresql, spring boot, spring data]
+redirect_from:
+  - "/blog/2017/10/10/nosql-options-for-java-developers-part-i"
 ---
 
 The Java community is one I know and love, so even though a NoSQL database is rarely tied to a language I'm writing this article for you, Java developers around the world. In this article, I'll show you several options for NoSQL databases. After exploring all the options, I'll narrow the choices down to the top five based on Indeed Jobs, GitHub stars, and Stack Overflow tags. Then I'll let you know if they're supported by Spring Data and Spring Boot. 

--- a/_source/_posts/2017-10-10-nosql-options-for-java-developers-part-ii.md
+++ b/_source/_posts/2017-10-10-nosql-options-for-java-developers-part-ii.md
@@ -3,6 +3,9 @@ layout: blog_post
 title: 'NoSQL Options for Java Developers, Part II'
 author: mraible
 tags: [nosql, java, redis, mongodb, cassandra, neo4j, postgresql, spring boot, spring data]
+redirect_from:
+  - "/blog/2017/09/08/nosql-options-for-java-developers-part-ii"
+  - "/blog/2017/10/11/nosql-options-for-java-developers-part-ii"
 ---
 
 Last month, I wrote about [NoSQL Options for Java Developers](/blog/2017/09/08/nosql-options-for-java-developers). I analyzed the data available from a variety of sources (Indeed jobs, GitHub stars, Stack Overflow tags) to pick the top five options: MongoDB, Redis, Cassandra, Neo4j, and PostgreSQL. After writing this article, I shared it with a few experts I know in the Java and NoSQL communities and asked them the following questions:

--- a/_source/_posts/2017-10-11-developers-guide-to-docker-part-3.md
+++ b/_source/_posts/2017-10-11-developers-guide-to-docker-part-3.md
@@ -5,6 +5,7 @@ author: leebrandt
 tags: [docker, devops, developer]
 redirect_from:
     - "/blog/2017/10/10/developers-guide-to-docker-part-3"
+    - "/blog/2017/08/28/developers-guide-to-docker-part-3"
 ---
 
 Good developers care as much about efficiency as they do about writing clean code. Containerization can add efficiency to both your workflow and your application, and has thus become all the rage among modern dev. And, as a good developer, you know that manually creating containers from images using `docker run …` or even using the `Dockerfile` to create containers is less than ideal. How would you like to have one command that tells Docker to build the containers for the UI, the API, the database, and the cache server? Let me show you how that works with Docker Compose!


### PR DESCRIPTION
## Description:
It is common for people who are following our multi-part blog posts to attempt to navigate forward/backward via **part-X** in the URL. Since our pages are located in nested date directories, the common case produces a `404`:

1. User is on `developer.okta.com/blog/2017/08/01/oidc-primer-part-3`
2. Attempt to visit previous post: `developer.okta.com/blog/2017/08/01/oidc-primer-part-2`
3. User sees `404` page.

This PR adds redirects to each multi-part blog post to redirect to the correct page:
1. User is on `developer.okta.com/blog/2017/08/01/oidc-primer-part-3`
2. Attempt to visit previous post `developer.okta.com/blog/2017/08/01/oidc-primer-part-2`
3. User is redirected to `developer.okta.com/blog/2017/07/25/oidc-primer-part-2`
