### PR TITLE
change post to put

### DIFF
--- a/_source/_docs/how-to/creating-token-with-groups-claim.md
+++ b/_source/_docs/how-to/creating-token-with-groups-claim.md
@@ -93,7 +93,7 @@ The following example names the group whitelist `groupwhitelist`, but you can na
 Request Example:
 
 ~~~sh
-curl -X POST \
+curl -X PUT \
   https://{yourOktaDomain}.com/api/v1/apps/0oabskvc6442nkvQO0h7 \
   -H 'accept: application/json' \
   -H 'authorization: SSWS ${api_token}' \


### PR DESCRIPTION
## Description:
- POST should be PUT for step two (add the whitelist to your app profile)
- I tested and confirmed POST always returns a "HTTP method not supported" error, and PUT does work.

### Resolves:

[OKTA-155553](https://oktainc.atlassian.net/browse/OKTA-155553)

