### PR TITLE
remove old RL info from authn endpoint doc

### DIFF
--- a/_source/_docs/api/resources/authn.md
+++ b/_source/_docs/api/resources/authn.md
@@ -119,8 +119,6 @@ Content-Type: application/json
 
 `429 Too Many Requests` status code may be returned when the rate-limit is exceeded.
 
-> Authentication requests are aggressively rate-limited (e.g. 1 request per username/per second) for security purposes.
-
 ~~~http
 HTTP/1.1 429 Too Many Requests
 Content-Type: application/json


### PR DESCRIPTION
## Description:
- Now that we have https://developer.okta.com/docs/api/getting_started/rate-limits, it's best to eliminate outdated RL references from endpoint doc. 

### Resolves:

 [OKTA-155770](https://oktainc.atlassian.net/browse/OKTA-155770)

