### PR TITLE
:fire: Remove dead file

### DIFF
--- a/scripts/gh-pages-publish.sh
+++ b/scripts/gh-pages-publish.sh
@@ -25,9 +25,6 @@ then
     exit 1
 fi
 
-# Remove the dead file (THIS IS A ONE-TIME-ONLY THING)
-rm -rf ${GENERATED_SITE_LOCATION}/docs/api/resources/resrouce-server-beta
-
 # commit
 git add .
 git commit -m "Deploy site for ${CURRENT_HASH}"


### PR DESCRIPTION
Reverts okta/okta.github.io#1664

- As noted in #1664, since we cannot remove previously generated `/dist` files/folders, we are working around it. This removes the logic to remove error files, as it will no longer serve a purpose.