### PR TITLE
Updating Scope object with new property

### DIFF
--- a/_source/_docs/api/resources/oauth2.md
+++ b/_source/_docs/api/resources/oauth2.md
@@ -1487,10 +1487,10 @@ curl -v -X PUT \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
--d `{
+-d '{
   "description": "Order car",
-  "name": "car:order"
-     }'
+  "name": "car:order",
+  "metadataPublish": "ALL_CLIENTS"
 }' "https://{yourOktaDomain}.com/api/v1/authorizationServers/ausnsopoM6vBRB3PD0g3/scopes/scpanemfdtktNn7w10h7"
 ~~~
 
@@ -2281,6 +2281,7 @@ Token limits:
 | default                              | Whether the scope is a default scope                                                              | Boolean |            | FALSE                         |
 | displayName {% api_lifecycle beta %} | Name of the end user displayed in a consent dialog                                                | String  |            | FALSE                         |
 | consent {% api_lifecycle beta %}     | Indicates whether a consent dialog is needed for the scope. Valid values: `REQUIRED`, `IMPLICIT`. | Enum    | `IMPLICIT` | FALSE                         |
+| metadataPublish                      | Whether or not the scope should be included in the metadata. Valid values: `NO_CLIENTS`, `ALL_CLIENTS` | Enum    | `NO_CLIENTS` | TRUE except for create        |
 
 * {% api_lifecycle beta %} A consent dialog is displayed depending on the values of three elements:
     * `prompt`, a query parameter used in requests to [`/oauth2/:authorizationServerId/v1/authorize`](/docs/api/resources/oauth2#obtain-an-authorization-grant-from-a-user)(custom authorization server) or [`/oauth2/v1/authorize`](/docs/api/resources/oidc#authentication-request) (Org authorization server)

--- a/_source/_docs/api/resources/oauth2.md
+++ b/_source/_docs/api/resources/oauth2.md
@@ -2265,7 +2265,8 @@ Token limits:
     "system": false,
     "default": false,
     "displayName": "Saml Jackson",
-    "consent": "REQUIRED"
+    "consent": "REQUIRED",
+    "metadataPublish": "ALL_CLIENTS"
   }
 ]
 ~~~


### PR DESCRIPTION
## Description:
- Adding `metadataPublish` property to Scope object.

**NOTE:** @petermiller-okta did this, but I asked him to make a PR against the merged API before I realized that this is related to a weekly release. So there's a PR to weekly with the change, and [a separate one](https://github.com/okta/okta.github.io/pull/1667) to my merged API branch.

### Resolves:

* [OKTA-106548](https://oktainc.atlassian.net/browse/OKTA-106548)

