### PR TITLE
:white_check_mark: Update publish script to include lint checks

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -3,9 +3,9 @@
 ###############################################################################
 # LINT
 ###############################################################################
+export GENERATED_SITE_LOCATION="dist"
 
 function url_consistency_check() {
-    interject "Checking ${GENERATED_SITE_LOCATION} to make sure documentation uses proper prefixes ('/api/v1', '/oauth2', etc) in example URLs"
     if [ ! -d "$GENERATED_SITE_LOCATION" ]; then
        echo "Directory ${GENERATED_SITE_LOCATION} not found";
        return 1;
@@ -26,16 +26,13 @@ function url_consistency_check() {
         sed -e 's/^\([^:]*\):\([^:]*\).*<\/span> \(.*\)<\/span>.*/\1:\2:\3/' | \
         # Write the results to STDOUT and the $url_consistency_check_file
         tee $url_consistency_check_file
-    interject "Done checking $GENERATED_SITE_LOCATION for proper prefixes in URLs"
     # Return "True" if the file is empty
     return `[ ! -s $url_consistency_check_file ]`
 }
 
 function duplicate_slug_in_url() {
-    interject "Checking ${GENERATED_SITE_LOCATION} to verify duplicate /api/v1 does not exist"
     output_file=`mktemp`
     find $GENERATED_SITE_LOCATION -iname '*.html' | xargs grep '/api/v1/api/v1' | tee $output_file
-    interject "Done checking $GENERATED_SITE_LOCATION for duplicate slugs"
     # Return "True" if the file is empty
     return `[ ! -s $output_file ]`
 }

--- a/scripts/htmlproofer.rb
+++ b/scripts/htmlproofer.rb
@@ -2,13 +2,21 @@
 
 require 'html-proofer'
 
+# Ruby hack to convert params to boolean
+class String
+    def to_bool
+      return true   if self == true   || self =~ (/(true)$/i)
+      return false  if self == false  || self.blank? || self =~ (/(false)$/i)
+      raise ArgumentError.new("invalid value for Boolean: \"#{self}\"")
+    end
+end
+
 options = {
-    :assume_extension => true,
+    :assume_extension => ARGV[0].to_bool,
     :allow_hash_href => true,
     :empty_alt_ignore => true,
     :log_level => :error,
     :only_4xx => true,
-    :cache => { :timeframe => '1d' },
     # 8 threads, any more doesn't seem to make a difference
     :parallel => { :in_processes => 8},
     :file_ignore => [

--- a/scripts/htmlproofer.rb
+++ b/scripts/htmlproofer.rb
@@ -3,16 +3,13 @@
 require 'html-proofer'
 
 # Ruby hack to convert params to boolean
-class String
-    def to_bool
-      return true   if self == true   || self =~ (/(true)$/i)
-      return false  if self == false  || self.blank? || self =~ (/(false)$/i)
-      raise ArgumentError.new("invalid value for Boolean: \"#{self}\"")
-    end
+extensions = true
+if ARGV[0] == 'false'
+    extensions = false
 end
 
 options = {
-    :assume_extension => ARGV[0].to_bool,
+    :assume_extension => extensions,
     :allow_hash_href => true,
     :empty_alt_ignore => true,
     :log_level => :error,

--- a/scripts/post-build-lint.sh
+++ b/scripts/post-build-lint.sh
@@ -41,3 +41,19 @@ then
 else
     echo -e "\xE2\x9C\x94 Passed quickstart sitemap check"
 fi
+
+if ! url_consistency_check ;
+then
+    echo "Failed checking for proper prefixes ('/api/v1', '/oauth2', etc) in example URLs"
+    exit 1
+else
+    echo -e "\xE2\x9C\x94 Passed URL consistency check"
+fi
+
+if ! duplicate_slug_in_url ;
+then
+    echo "Duplicate slugs: /api/v1 exist"
+    exit 1
+else
+    echo -e "\xE2\x9C\x94 Passed duplicate slug checker"
+fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -26,9 +26,6 @@ require_env_var "REPO"
 
 export TEST_SUITE_TYPE="build"
 
-npm install -g @okta/ci-update-package
-npm install -g @okta/ci-pkginfo
-
 # `cd` to the path where Okta's build system has this repository
 cd ${OKTA_HOME}/${REPO}
 
@@ -39,10 +36,34 @@ then
     exit ${BUILD_FAILURE};
 fi
 
+# Copy assets and previous history into dist
+if ! npm run postbuild-prod;
+then
+    exit ${BUILD_FAILURE};
+fi
+
 if ! removeHTMLExtensions;
 then
     echo "Failed removing .html extensions"
     exit ${BUILD_FAILURE};
+fi
+
+# Run Lint checker
+if ! npm run post-build-lint;
+then
+    exit ${BUILD_FAILURE}
+fi
+
+# Run find-missing-slashes to find links that will redirect to okta.github.io
+if ! npm run find-missing-slashes;
+then
+    exit ${BUILD_FAILURE}
+fi
+
+# Run htmlproofer to validate links, scripts, and images
+if ! bundle exec ./scripts/htmlproofer.rb false;
+then
+    exit ${BUILD_FAILURE}
 fi
 
 interject "Generating conductor file in $(pwd)"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -61,6 +61,8 @@ then
 fi
 
 # Run htmlproofer to validate links, scripts, and images
+#   -  Passing in the argument 'false' to prevent adding an '.html' extension to
+#      extension-less files. 
 if ! bundle exec ./scripts/htmlproofer.rb false;
 then
     exit ${BUILD_FAILURE}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,3 +14,10 @@ fi
 if [[ -z "${SUCCESS}" ]]; then
     export SUCCESS=0
 fi
+
+# Use latest version of Node
+setup_service node v8.1.1
+
+# Install required dependencies
+npm install -g @okta/ci-update-package
+npm install -g @okta/ci-pkginfo

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -7,39 +7,20 @@ if [[ $TRAVIS_EVENT_TYPE != 'push' ]]; then
   export CHROME_HEADLESS=true
 fi
 
-# 2. Run the npm install to pull in test dependencies
+# Run the npm install to pull in test dependencies
 fold npm_install npm install
 
-# 3. Build site and Run tests
+# Build site and Run tests
 fold npm_test npm test
 
-export GENERATED_SITE_LOCATION="dist"
-
-# 4. copy assets and previous history into dist
+# Copy assets and previous history into dist
 fold npm_postbuild_prod npm run postbuild-prod
 
-# 5. Run Lint checker
+# Run Lint checker
 fold npm_lint npm run post-build-lint
 
-# 6. Run Travis specific tests
-if ! url_consistency_check || ! duplicate_slug_in_url; then
-  echo "FAILED LINT CHECK!"
-  exit 1;
-fi
-
-# 7. Update file extensions and create redirects
-#
-#    TEMPORARILY DISABLED UNTIL S3 Migration
-#    GitHub Pages does not render extension-less files
-#
-# if ! removeHTMLExtensions;
-# then
-#   echo "Failed removing .html extensions"
-#   exit 1;
-# fi
-
-# 8. Run find-missing-slashes to find links that will redirect to okta.github.io
+# Run find-missing-slashes to find links that will redirect to okta.github.io
 fold npm_find_missing_slashes npm run find-missing-slashes
 
-# 9. Run htmlproofer to validate links, scripts, and images
-fold bundle_exec_htmlproofer bundle exec ./scripts/htmlproofer.rb
+# Run htmlproofer to validate links, scripts, and images
+fold bundle_exec_htmlproofer bundle exec ./scripts/htmlproofer.rb true

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -23,4 +23,6 @@ fold npm_lint npm run post-build-lint
 fold npm_find_missing_slashes npm run find-missing-slashes
 
 # Run htmlproofer to validate links, scripts, and images
+#   -  Passing in the argument 'true' to automatically add the '.html' extension to
+#      extension-less files. 
 fold bundle_exec_htmlproofer bundle exec ./scripts/htmlproofer.rb true


### PR DESCRIPTION
## Description:
- ✅ Adds lint tests to `publish.sh` script after removing `.html` extensions on files.

- When the `publish.sh` script is run on merges into `weekly` and `source`, we deploy the `dist` output to S3.
    - `weekly`: https://developer.trexcloud.com
    - `source`: https://dq3iyfxeowfmd.cloudfront.net/

Bacon commit with passing tests (alerted order of when branch verification is processed): [2a759](http://bacon.aue1e.internal/#!/commits/okta.github.io/sha/2a759ea9958f7437a041a1212bd52486c26089c2).
