### PR TITLE
:bug: Fix code snippets not showing variables surrounded by {{ }}

### DIFF
--- a/_source/quickstart-fragments/angular/default-example.md
+++ b/_source/quickstart-fragments/angular/default-example.md
@@ -130,6 +130,7 @@ Your Angular application now has an access token in local storage that was issue
 
 Here is what the Angular component could look like for this hypothetical example:
 
+{% raw %}
 ```typescript
 // messagelist.component.ts
 
@@ -159,5 +160,6 @@ export class MessageListComponent {
   }
 }
 ```
+{% endraw %}
 
 In the next section you can select your server technology to see how your server can read this incoming token and validate it.

--- a/_source/quickstart-fragments/vue/default-example.md
+++ b/_source/quickstart-fragments/vue/default-example.md
@@ -142,6 +142,7 @@ When your users are authenticated, your Vue application has an access token that
 
 Here is what the Vue component could look like for this hypothetical example using [axios](https://github.com/axios/axios):
 
+{% raw %}
 ```typescript
 // src/components/MessageList.vue
 
@@ -175,5 +176,6 @@ export default {
 }
 </script>
 ```
+{% endraw %}
 
 In the next section you can select your server technology to see how your server can read this incoming token and validate it.


### PR DESCRIPTION
## Description:
- Fix code blocks in documentation omitting variables surrounded by `{{ }}`


