### PR TITLE
:bug: Fix description of retrieving org factors

### DIFF
--- a/_source/_docs/api/resources/factor_admin.md
+++ b/_source/_docs/api/resources/factor_admin.md
@@ -78,7 +78,7 @@ deactivate         | Denies use of this factor for MFA
 
 {% api_operation get /api/v1/org/factors %}
 
-Fetches a factor for the specified user.
+Lists factors in your organization
 
 #### Request Parameters
 {:.api .api-request .api-request-params}


### PR DESCRIPTION
## Description:
- Fix description of retrieving org factors
- See [the confusing line here](https://developer.okta.com/docs/api/resources/factor_admin#get-org-factor)

### Resolves:
* [Issue #1687](#1687 )

