### PR TITLE
Change blockquote so it matches doc CSS

### DIFF
--- a/_source/_assets/css/okta/components/_BlogPost.scss
+++ b/_source/_assets/css/okta/components/_BlogPost.scss
@@ -165,21 +165,19 @@
 			border-bottom: 0;
 		}
 
+		/* Same as what docs uses (in _PageContent.scss) */
 		blockquote {
-			@include margin(large auto);
-			@include padding(large);
-			background: #ECF2F6;
-			border-left: 18px solid #115D8B;
-			font-style: normal;
-			max-width: 800px;
-
+			margin: 20px 0;
+			border-left: 7px solid #46B3E9;
+			background: #F7FBFD;
+			padding: 20px;
+			font-size: .9em;
 			p {
-				font-size: 24px;
-				line-height: 40px;
-			}
-
-			cite {
-				font-size: 20px;
+				color: get-color('black');
+				font-size: 1em;
+				&:last-child {
+					margin-bottom: 0;
+				}
 			}
 		}
 

--- a/_source/_assets/css/okta/components/_BlogPost.scss
+++ b/_source/_assets/css/okta/components/_BlogPost.scss
@@ -167,11 +167,11 @@
 
 		/* Same as what docs uses (in _PageContent.scss) */
 		blockquote {
-			margin: 20px 0;
-			border-left: 7px solid #46B3E9;
-			background: #F7FBFD;
-			padding: 20px;
-			font-size: .9em;
+			margin: 24px 24px;
+			border-left: 8px solid #00659d;
+			background: #DEEEF6;
+			padding: 24px;
+			font-size: 1em;
 			p {
 				color: get-color('black');
 				font-size: 1em;

--- a/_source/_assets/css/okta/components/_PageContent.scss
+++ b/_source/_assets/css/okta/components/_PageContent.scss
@@ -117,11 +117,14 @@
 		}
 
 		blockquote {
-			border-left: 7px solid #46B3E9;
-			background: #F7FBFD;
-			padding: 20px;
+			margin: 24px 24px;
+			border-left: 8px solid #00659D;
+			background: #DEEEF6;
+			padding: 24px;
+			font-size: 1em;
 			p {
 				color: get-color('black');
+				font-size: 1em;
 				&:last-child {
 					margin-bottom: 0;
 				}


### PR DESCRIPTION
Contributes to fixing #1694. Screenshot below.

![image](https://user-images.githubusercontent.com/17892/35743653-72023014-07fb-11e8-9614-0eb38adf446d.png)

This is what it looks like before this change:

![image](https://user-images.githubusercontent.com/7525482/35581777-b545abaa-05a1-11e8-9d2a-fb70b419f66f.png)