### PR TITLE
remove old ea tags and outdated getting started section and fix postman buttons

### DIFF
--- a/_source/_docs/api/getting_started/api_test_client.md
+++ b/_source/_docs/api/getting_started/api_test_client.md
@@ -78,7 +78,7 @@ Import any Okta API collection for Postman from the following list:
 | Authentication                            |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/f9684487e584101f25a3){:target="_blank"} |
 | API Access Management (OAuth 2.0)         |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/e4d286b1af2294bb14a0){:target="_blank"} |
 | OpenID Connect                            |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/fd92d7c1ab0fbfdecab2){:target="_blank"} |
-| Client Registration {% api_lifecycle ea%} |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/291ba43cde74844dd4a7){:target="_blank"} |
+| Client Registration                   |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/291ba43cde74844dd4a7){:target="_blank"} |
 | Sessions                                  |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/b2e06a22c396bcc94530){:target="_blank"} |
 | Apps                                      |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/4857222012c11cf5e8cd){:target="_blank"} |
 | Events                                    |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/f990a71f061a7a16d0bf){:target="_blank"} |

--- a/_source/_docs/api/resources/oauth-clients.md
+++ b/_source/_docs/api/resources/oauth-clients.md
@@ -15,21 +15,11 @@ Note that clients managed via this API are modeled as applications in Okta and a
 Administrator dashboard. Changes made via the API appear in the UI and vice versa. Tokens issued by these clients
 follow the rules for Access Tokens and ID Tokens.
 
-> This API is an {% api_lifecycle ea%} feature.
-
-Explore the Client Registration API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/291ba43cde74844dd4a7){:target="_blank"}
-
 ## Getting Started
 
-If you are new to OAuth 2.0 or OpenID Connect, read this topic before experimenting with the Postman collection. If you are familiar with the
-flows defined by [the OAuth 2.0 spec](http://oauth.net/documentation) or [OpenID Connect spec](http://openid.net/specs/openid-connect-core-1_0.html), you may want to experiment with the Postman collection first:
-
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/291ba43cde74844dd4a7)
-
+Explore the Client Application API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/291ba43cde74844dd4a7)
 
 ## Client Application Operations
-
-Explore the Client Application API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/7a7f9956c58e49996dc8)
 
 ### Register New Client
 {:.api .api-operation}


### PR DESCRIPTION
Client Registration needed a scrub!

## Description:
- Multiple, outdated postman buttons and getting started text that's no longer needed.
- Remove outdated EA tags.

### Resolves:
 [OKTA-158179](https://oktainc.atlassian.net/browse/OKTA-158179)

tested locally and made sure postman buttons point to the correct collection.

