### PR TITLE
Added autopush parameter for verify call and autoPushEnabled in JSON …

### DIFF
--- a/_source/_docs/api/resources/authn.md
+++ b/_source/_docs/api/resources/authn.md
@@ -1202,6 +1202,39 @@ User is assigned to a Sign-On Policy or App Sign-On Policy that requires additio
          }
       },
       "factors":[
+         {  
+            "id":"opf1cla0gggOBWxuC1d8",
+            "factorType":"push",
+            "provider":"OKTA",
+            "vendorName":"OKTA",
+            "profile":{  
+               "credentialId":"abcd@okta.com",
+               "deviceType":"SmartPhone_Android",
+               "keys":[  
+                  {  
+                     "kty":"PKIX",
+                     "use":"sig",
+                     "kid":"default",
+                     "x5c":[  
+                        "Mdkkdfjkdjf"
+                     ]
+                  }
+               ],
+               "name":"SM-N9005",
+               "platform":"ANDROID",
+               "version":"21"
+            },
+            "_links":{  
+               "verify":{  
+                  "href":"https://{yourOktaDomain}.okta.com/api/v1/authn/factors/opf1cla0yyvOBWxuC1d8/verify",
+                  "hints":{  
+                     "allow":[  
+                        "POST"
+                     ]
+                  }
+               }
+            }
+         },
          {
             "id":"smsph8F1esz8LlSjo0g3",
             "factorType":"sms",
@@ -1225,7 +1258,12 @@ User is assigned to a Sign-On Policy or App Sign-On Policy that requires additio
       "policy":{
          "allowRememberDevice":true,
          "rememberDeviceLifetimeInMinutes":1440,
-         "rememberDeviceByDefault":false
+         "rememberDeviceByDefault":false,
+         "factorsPolicyInfo": {
+             "opf1cla0gggOBWxuC1d8": {
+                 "autoPushEnabled": true
+             }
+         }
       },
       "target":{
          "type":"APP",
@@ -3562,6 +3600,15 @@ Parameter      | Description                                         | Param Typ
 fid            | `id` of factor returned from enrollment             | URL        | String   | TRUE     |
 stateToken     | [state token](#state-token) for current transaction | Body       | String   | TRUE     |
 rememberDevice | user&#8217;s decision to remember device            | URL        | Boolean  | FALSE    |
+autoPush       | user&#8217;s decision to send push to device automatically | URL | Boolean  | FALSE    |
+
+**Okta Verify Push Details Pertaining to Auto-Push**
+
+* If you pass the `autoPush` query param when verifying an Okta Verify Push factor, Okta will save this value as the user's preference to have the push notification sent automatically if the verification is successful (i.e. the user presses "Approve" on their phone).
+* If there is already a saved Auto-Push preference, the successful verify call will override the current preference if it is different from the value of `autoPush`.
+* This saved Auto-Push preference is always returned in the `/api/v1/authn/` response's `autoPushEnabled` field if the user is enrolled for the Okta Verify Push factor [example here](#response-example-for-factor-challenge-for-step-up-authentication-with-okta-session).  If the user's Auto-Push preference has not explicitly been set before, `autoPushEnabled` will have a value of false.
+* Please note, the `autoPush` flag will have no effect when trying to verify a factor other than Okta Verify Push (factorId prefix = "opf").
+* It is only necessary to pass the `autoPush` flag to Okta if you have a custom sign-in flow that does not use the Okta sign-in widget, but want Okta to keep track of this preference.  The custom sign-in flow must still handle the logic to actually send the Auto-Push.  
 
 
 ##### Request Example for Verify Push Factor


### PR DESCRIPTION
…response for primary auth call.

## Description:
- Added Okta Verify Factor and`autoPushEnabled` key to be returned in one of the existing primary auth responses so I could use that as an example when showing customers how they can see the Auto-Push preference that they have set earlier during poll calls.  
- Added `autoPush` as a param to the documentation for Verifying a Push Notification
- Added extra details about how `autoPush` and `autoPushEnabled` are related and in what use case are they necessary.

### Documentation for....:
* [OKTA-155563](https://oktainc.atlassian.net/browse/OKTA-155563)

### Reviewers
Primary: @nandagopalseshagiri-okta @ericcarroll-okta @mystiberry-okta @travismorrow-okta 
Secondary: @mauriciocastillosilva-okta @gowthamidommety-okta .

Pictures showing changes below (stuff in red box is new stuff I've added).

![tophalfdevdocchanges](https://user-images.githubusercontent.com/19472516/36051341-a4b4f61a-0d9e-11e8-856e-ca49ee4bd080.png)


![bottomhalfdevdocchanges](https://user-images.githubusercontent.com/19472516/36053455-9f58e99e-0da6-11e8-98a5-d652d8a6551e.png)


Backend logic Snippet for when we return `autoPushEnabled` in /api/v1/authn
```
Cookie cookie = CookieUtil.getCookie(request, autoPushCookieKey);

boolean autoPushSettingsCookieValue;
autoPushSettingsCookieValue = cookie != null ? Boolean.valueOf(cookie.getValue()) : false;

Map<String, Object> autoPushEnabledSettings = new HashMap<String, Object>();

autoPushEnabledSettings.put(AuthFactorsMediationService.OKTA_VERIFY_AUTO_PUSH_ENABLED_KEY, autoPushSettingsCookieValue);

factorsPolicyInfo.put(userFactor.getId(), autoPushEnabledSettings);
```
