### PR TITLE
Removes Symfony sample app links

### DIFF
--- a/_source/_authentication-guide/implementing-authentication/auth-code.md
+++ b/_source/_authentication-guide/implementing-authentication/auth-code.md
@@ -104,4 +104,3 @@ The following web application examples show you the authorization code flow, as 
 | <i class="icon code-dotnet-32"></i> | ASP.NET Core | <https://github.com/oktadeveloper/okta-aspnetcore-mvc-example> |
 | <i class="icon code-nodejs-32"></i> | Express.js   | <https://github.com/okta/samples-nodejs-express-4>             |
 | <i class="icon code-java-32"></i>   | Spring       | <https://github.com/okta/samples-java-spring-mvc>              |
-| <i class="icon code-php-32"></i>    | Symphony     | <https://github.com/okta/samples-php-symfony>                  |

--- a/_source/_change-log/2017-11.md
+++ b/_source/_change-log/2017-11.md
@@ -32,8 +32,7 @@ For a full description of the rate limit changes, see [API Rate Limit Improvemen
    * [https://github.com/okta/samples-nodejs-express-4](https://github.com/okta/samples-nodejs-express-4)
    * [https://github.com/okta/samples-elm](https://github.com/okta/samples-elm)
    * [https://github.com/okta/samples-python-django](https://github.com/okta/samples-python-django)
-   * [https://github.com/okta/samples-haskell-scotty](https://github.com/okta/samples-haskell-scotty)
-   * [https://github.com/okta/samples-js-react](https://github.com/okta/samples-js-react)
+=   * [https://github.com/okta/samples-js-react](https://github.com/okta/samples-js-react)
    * [https://github.com/okta/samples-java-spring-mvc](https://github.com/okta/samples-java-spring-mvc)
 <!-- (OKTA-118575) -->
 

--- a/_source/_code/php/index.md
+++ b/_source/_code/php/index.md
@@ -15,11 +15,6 @@ New to Okta? Our Quick Start Guide will walk you through adding user authenticat
       <span class='code-icon launch-16'></span><span>Authentication Quick Start Guide</span>
     </a>
   </li>
-  <li>
-    <a href='https://github.com/okta/samples-php-symfony' class='code-button'>
-      <span class='fa fa-github'></span><span>PHP Sample App</span>
-    </a>
-  </li>
 </ul>
 
 ## PHP SDK


### PR DESCRIPTION
## Description:
- Remove links for Symfony  ~~and Slim~~(there are no slim references) from the docs as they are soon to be replaced.


