### PR TITLE
Small fixes

### DIFF
--- a/_source/_posts/2018-02-15-build-crud-app-vuejs-node.md
+++ b/_source/_posts/2018-02-15-build-crud-app-vuejs-node.md
@@ -15,7 +15,7 @@ I've danced the JavaScript framework shuffle for years starting with jQuery, the
 This tutorial will take you step by step through scaffolding a Vue.js project, offloading secure authentication to [Okta's OpenID Connect API (OIDC)](/docs/api/resources/oidc), locking down protected routes, and performing CRUD operations through a backend REST API server. This tutorial uses the following technologies but doesn't require intimate knowledge to follow along:
 
 - Vue.js with [vue-cli](https://github.com/vuejs/vue-cli), [vue-router](https://github.com/vuejs/vue-router), and [Okta Vue SDK](https://github.com/okta/okta-oidc-js/tree/master/packages/okta-vue)
-- Node with [Express](https://github.com/expressjs/express), [Okta JWT Verifier](https://github.com/okta/okta-auth-js), [Sequelize](https://github.com/sequelize/sequelize), and [Epiloge](https://github.com/dchester/epilogue)
+- Node with [Express](https://github.com/expressjs/express), [Okta JWT Verifier](https://github.com/okta/okta-auth-js), [Sequelize](https://github.com/sequelize/sequelize), and [Epilogue](https://github.com/dchester/epilogue)
 
 
 ## About Vue.js
@@ -28,7 +28,7 @@ This tutorial covers two primary builds, a frontend web app and backend REST API
 
 [Okta's OpenID Connect (OIDC)](/docs/api/resources/oidc) will handle our web app's authentication through the use of [Okta's Vue SDK](https://github.com/okta/okta-oidc-js/tree/master/packages/okta-vue). If an unauthenticated user navigates to the posts manager, the web app should attempt to authenticate the user.
 
-The server will run [Express](https://www.express.com/) with [Sequelize](http://docs.sequelizejs.com/) and [Epilogue](https://github.com/dchester/epilogue). At a high level, with Sequelize and Epilogue you can quickly generate dynamic REST endpoints with just a few lines of code.
+The server will run [Express](https://www.expressjs.com/) with [Sequelize](http://docs.sequelizejs.com/) and [Epilogue](https://github.com/dchester/epilogue). At a high level, with Sequelize and Epilogue you can quickly generate dynamic REST endpoints with just a few lines of code.
 
 You will use JWT-based authentication when making requests from the web app and [Okta's JWT Verifier](https://github.com/okta/okta-oidc-js/tree/master/packages/jwt-verifier) in an Express middleware to validate the token. Your app will expose the following endpoints which all require requests to have a valid access token.
 


### PR DESCRIPTION
## Description:
- After publish I noticed that the first mention of Epilogue was misspelled 'Epiloge'
- I also noticed that the link for ExpressJS was linking to express.com. Should be expressjs.com


