### PR TITLE
 Doc support for salted SHA-256 algorithm for password import 

### DIFF
--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -3798,13 +3798,15 @@ The password specified in the value property must meet the default password poli
 Specifies a hashed password that can be imported into Okta.  This allows an existing password to be imported into Okta directly from some other store.
 A hashed password may be specified in a Password Object when creating or updating a user, but not for other operations.  When updating a user with a hashed password the user must have the `STAGED` status.
 
-| Property | DataType | Description | Nullable | Min Value | Max Value |
-|:---------|:---------|:---------|:-------|:---------|:----------------|
-| algorithm    | String   | The algorithm used to hash the password.  Must be set to "BCRYPT" | FALSE     | N/A  | N/A  |
-| workFactor    | Integer   | Governs the strength of the hash, and the time required to compute it | FALSE     | 1  | 20  |
-| salt    | String   | Specifies the password salt used to generate the hash | FALSE     | 22  | 22  |
-| value | String | The actual hashed password| FALSE | N/A | N/A |
+| Property   | DataType | Description                                                                                                 | Required                           | Min Value          | Max Value          |
+|:-----------|:---------|:------------------------------------------------------------------------------------------------------------|:-----------------------------------|:-------------------|:-------------------|
+| algorithm  | String   | The algorithm used to hash the password. Must be set to `BCRYPT` or `SHA-256`                               | TRUE                               | N/A                | N/A                |
+| value      | String   | The actual base64-encoded hashed password                                                                   | TRUE                               | N/A                | N/A                |
+| salt       | String   | Specifies the password salt used to generate the hash                                                       | TRUE                               | 22 (only for `BCRYPT` algorithm) | 22 (only for `BCRYPT` algorithm) |
+| workFactor | Integer  | Governs the strength of the hash, and the time required to compute it. Only relevant for `BCRYPT` algorithm | Only for `BCRYPT` algorithm        | 1                  | 20                 |
+| saltOrder  | String   | Specifies whether salt was pre- or postfixed to password before hashing. Only relevant for `SHA-256` algorithm. Must be set to `PREFIX` or `POSTFIX` | Only for `SHA-256` algorithm      | N/A                | N/A                |
 
+###### BCRYPT Hashed Password Object Example
 
 ~~~sh
 "password" : {
@@ -3817,10 +3819,22 @@ A hashed password may be specified in a Password Object when creating or updatin
 }
 ~~~
 
+###### SHA-256 Hashed Password Object Example
+
+~~~sh
+"password" : {
+  "hash": {
+    "algorithm": "SHA-256",
+    "salt": "MPu13OmY",
+    "saltOrder": "PREFIX",
+    "value": "Gjxo7mxvvzQWa83ovhYRUH2dWUhC1N77Ntc56UfI4sY"
+  }
+}
+~~~
 
 ##### Hashing Function
 
-Okta supports the bcrypt hashing function.
+Okta supports the `BCRYPT` and `SHA-256` hashing functions for password import, when the feature is enabled.
 
 ##### Default Password Policy
 


### PR DESCRIPTION
## Description:
- Doc support for salted SHA-256 algorithm for password import 

### Resolves:
<!-- Required for Okta-generated PRs -->
* [OKTA-158149](https://oktainc.atlassian.net/browse/OKTA-158149)

## Screenshots:
![image](https://user-images.githubusercontent.com/28875915/36702140-b7514868-1b0a-11e8-87ad-61c157b5083f.png)
![image](https://user-images.githubusercontent.com/28875915/36702159-c8e1fa3c-1b0a-11e8-8db7-d9252365318e.png)

## Reviewers:
- @mystiberry-okta 
- @srinivasanagandla-okta 
- @edjohns-okta 
