### PR TITLE
:bug: Fix quickstart html-proofer

### DIFF
--- a/_source/_posts/2017-08-23-five-java-tips.md
+++ b/_source/_posts/2017-08-23-five-java-tips.md
@@ -48,7 +48,7 @@ server.ssl.key-password=another-secret
 
 ## 3. Build your Java web service with Spring Boot
 
-Spring Boot is an opinionated view of the Spring platform which makes it dead simple to write [twelve-factor apps](https://12factor.net/) in [very few lines](https://virtualjug.com/building-robust-apis-and-apps-with-spring-boot-and-angular/). If you’re still building WAR files you owe it to yourself to check this out. You can create complicated, application wide functions like setting up an OAuth resource server by using a single annotation (`@EnableResourceServer`) or change the server's port with a single property:
+Spring Boot is an opinionated view of the Spring platform which makes it dead simple to write [twelve-factor apps](https://12factor.net/) in [very few lines](https://www.youtube.com/watch?v=yHtSwGn7doc). If you’re still building WAR files you owe it to yourself to check this out. You can create complicated, application wide functions like setting up an OAuth resource server by using a single annotation (`@EnableResourceServer`) or change the server's port with a single property:
 ```ini
 server.port = 8090
 ```

--- a/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
+++ b/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
@@ -768,7 +768,7 @@ If you’re ambitious, you could even turn the client into a progressive web app
 * [Add Authentication to Your Angular PWA](/blog/2017/06/13/add-authentication-angular-pwa)
 * [The Ultimate Guide to Progressive Web Applications](/blog/2017/07/20/the-ultimate-guide-to-progressive-web-applications)
 
-My good buddy [Josh Long](https://twitter.com/starbuxman) and I recently hosted a live-coding session where we developed a Spring Boot microservices architecture on the backend and an Angular PWA on the front-end. The code we wrote is very similar to the code in this article. You can check the video out for reference [on YouTube](https://virtualjug.com/building-robust-apis-and-apps-with-spring-boot-and-angular/). 
+My good buddy [Josh Long](https://twitter.com/starbuxman) and I recently hosted a live-coding session where we developed a Spring Boot microservices architecture on the backend and an Angular PWA on the front-end. The code we wrote is very similar to the code in this article. You can check the video out for reference [on YouTube](https://www.youtube.com/watch?v=yHtSwGn7doc). 
 
 ## Deploy to Production
 

--- a/_source/_posts/2018-03-06-okta-open-source-samples-and-quickstarts.md
+++ b/_source/_posts/2018-03-06-okta-open-source-samples-and-quickstarts.md
@@ -45,7 +45,7 @@ Wow, that's a lot of options! If you click on the first one, its [README](https:
 git clone https://github.com/okta/samples-java-spring.git
 ```
 
-I particularly like that it links to documentation that shows you [how to create an Okta application, for web mode](https://developer.okta.com/authentication-guide/implementing-authentication/auth-code#1-setting-up-your-application).  
+I particularly like that it links to documentation that shows you [how to create an Okta application, for web mode](/authentication-guide/implementing-authentication/auth-code#1-setting-up-your-application).  
 
 What if you're a front-end developer? The [React Sample Applications](https://github.com/okta/samples-js-react) profile is a good starting point.
 
@@ -100,9 +100,9 @@ To see how many of the frameworks were built, you can read the plethora of [quic
 
 The instructions themselves are broken up into two categories: client setup and server setup. 
 
-For client, there's instructions for our [hosted sign-in page](https://developer.okta.com/quickstart/#/okta-sign-in-page), as well as how to use our [sign-in widget](https://developer.okta.com/quickstart/#/widget), which you embed in your application. There are instructions for [iOS](https://developer.okta.com/quickstart/#/ios) and [Android](https://developer.okta.com/quickstart/#/android), as well as for the most popular JavaScript frameworks: [Angular](https://developer.okta.com/quickstart/#/angular), [React](https://developer.okta.com/quickstart/#/react), and [Vue.js](https://developer.okta.com/quickstart/#/vue). 
+For client, there's instructions for our [hosted sign-in page](/quickstart/#/okta-sign-in-page), as well as how to use our [sign-in widget](/quickstart/#/widget), which you embed in your application. There are instructions for [iOS](/quickstart/#/ios) and [Android](/quickstart/#/android), as well as for the most popular JavaScript frameworks: [Angular](/quickstart/#/angular), [React](/quickstart/#/react), and [Vue.js](/quickstart/#/vue). 
 
-For server, there are Node instructions, both for [Express](https://developer.okta.com/quickstart/#/vue/nodejs/express) and [generic Node](https://developer.okta.com/quickstart/#/okta-sign-in-page/nodejs/generic). For Java, there are [Spring Boot](https://developer.okta.com/quickstart/#/okta-sign-in-page/java/spring) and a link to [generic Java](https://developer.okta.com/quickstart/#/okta-sign-in-page/java/generic), but nothing there yet. There are no frameworks for PHP, just [generic support](https://developer.okta.com/quickstart/#/okta-sign-in-page/php/generic) and .NET has both [ASP.NET Core](https://developer.okta.com/quickstart/#/okta-sign-in-page/dotnet/aspnetcore) and [ASP.NET 4.x](https://developer.okta.com/quickstart/#/okta-sign-in-page/dotnet/aspnet4). 
+For server, there are Node instructions, both for [Express](/quickstart/#/vue/nodejs/express) and [generic Node](/quickstart/#/okta-sign-in-page/nodejs/generic). For Java, there are [Spring Boot](/quickstart/#/okta-sign-in-page/java/spring) and a link to [generic Java](/quickstart/#/okta-sign-in-page/java/generic), but nothing there yet. There are no frameworks for PHP, just [generic support](/quickstart/#/okta-sign-in-page/php/generic) and .NET has both [ASP.NET Core](/quickstart/#/okta-sign-in-page/dotnet/aspnetcore) and [ASP.NET 4.x](/quickstart/#/okta-sign-in-page/dotnet/aspnet4). 
 
 ## Developer Experience at Okta
 
@@ -130,6 +130,9 @@ I thought it'd be fun to ask some questions of [Robert Damphousse](https://twitt
 
 ## Learn More
 
-The Developer Experience team at Okta is developing a plethora of framework-specific SDKs, [documentation](https://developer.okta.com/documentation/), and sample applications. They're doing really great work to make your development life simpler. 
+The Developer Experience team at Okta is developing a plethora of framework-specific SDKs, [documentation](/documentation/), and sample applications. They're doing really great work to make your development life simpler. 
 
 However, there's always room for improvement! If you have ideas for improvement, please create pull requests in our SDKs or samples, or ask your questions on our [DevForums](https://devforum.okta.com/). Of course, we'd be happy to have a [quick chat on Twitter too](https://twitter.com/oktadev)!
+
+[This link works](/quickstart/)
+[This link fails](/documentation/#blahblah)

--- a/_source/_posts/2018-03-06-okta-open-source-samples-and-quickstarts.md
+++ b/_source/_posts/2018-03-06-okta-open-source-samples-and-quickstarts.md
@@ -133,6 +133,3 @@ I thought it'd be fun to ask some questions of [Robert Damphousse](https://twitt
 The Developer Experience team at Okta is developing a plethora of framework-specific SDKs, [documentation](/documentation/), and sample applications. They're doing really great work to make your development life simpler. 
 
 However, there's always room for improvement! If you have ideas for improvement, please create pull requests in our SDKs or samples, or ask your questions on our [DevForums](https://devforum.okta.com/). Of course, we'd be happy to have a [quick chat on Twitter too](https://twitter.com/oktadev)!
-
-[This link works](/quickstart/)
-[This link fails](/documentation/#blahblah)

--- a/scripts/htmlproofer.rb
+++ b/scripts/htmlproofer.rb
@@ -26,7 +26,8 @@ options = {
     ],
     :url_ignore => [
         /linkedin.com/, # linked in doesn't play nice with site crawlers
-        /stormpath.com/ # 😢
+        /stormpath.com/, # 😢
+        /\/quickstart\/#.*/ # /quickstart/#/
     ]
 }
 HTMLProofer.check_directory('dist', options).run


### PR DESCRIPTION
## Description:
- Fixes the html-proofer to ignore quickstart links that contain `#`. This is required because the `html-proofer` library expects any URL containing a slash `/` to be a path or file (not a partial)

This PR is broken into the following commits:
1.  🐛 fix
2.  Updates broken links failing the `html-proofer`
3. Introduces a broken link to be caught by Travis
4. Reverts the introduced link for a clean build