### PR TITLE
Misplaced bug for RN

### DIFF
--- a/_source/_change-log/2018-10.md
+++ b/_source/_change-log/2018-10.md
@@ -54,5 +54,5 @@ We have added [an optional URL parameter, `autoPush` ](/docs/api/resources/authn
 ### Bugs Fixed for 2018.10
 
 * GET requests to list 200 or more apps were taking a long time to complete. (OKTA-158391)
-* Invalid IP addresses in the `X-Forwrded-For` header caused a null pointer exception (HTTP 500 `NullPointerException`) during primary authentication. (OKTA-159414)
+* Invalid IP addresses in the `X-Forwarded-For` header caused a null pointer exception (HTTP 500 `NullPointerException`) during primary authentication. (OKTA-159414)
 * [List User with Search requests](/docs/api/resources/users#list-users-with-search) in preview orgs failed to return pagination links. (OKTA-160424)

--- a/_source/_change-log/2018-10.md
+++ b/_source/_change-log/2018-10.md
@@ -54,4 +54,5 @@ We have added [an optional URL parameter, `autoPush` ](/docs/api/resources/authn
 ### Bugs Fixed for 2018.10
 
 * GET requests to list 200 or more apps were taking a long time to complete. (OKTA-158391)
+* Invalid IP addresses in the `X-Forwrded-For` header caused a null pointer exception (HTTP 500 `NullPointerException`) during primary authentication. (OKTA-159414)
 * [List User with Search requests](/docs/api/resources/users#list-users-with-search) in preview orgs failed to return pagination links. (OKTA-160424)


### PR DESCRIPTION
## Description:
- A bug related to X-Forwarded-For header was in IT products RN, should be in API products change log. Verified by team and several others.

### Resolves doc for:
 [OKTA-159414](https://oktainc.atlassian.net/browse/OKTA-159414)

