### PR TITLE
Removing URI fragment from `redirect_from` frontmatter

### DIFF
--- a/_source/_docs/api/getting_started/rate-limits.md
+++ b/_source/_docs/api/getting_started/rate-limits.md
@@ -3,7 +3,7 @@ layout: docs_page
 title: Rate Limiting at Okta
 weight: 3
 redirect_from:
-  - "/docs/getting_started/design_principles#rate-limiting"
+  - "/docs/getting_started/design_principles"
 excerpt: Understand rate limits at Okta and learn how to design for efficient use of resources
 ---
 


### PR DESCRIPTION
This fixes an issue with a redirect URL that was messed up because it included a URI fragment. By removing the fragment we preserve the redirect functionality but we don't generate invalid filenames that will be hard for scripts to parse/modify.