### PR TITLE
Allow blog post titles to have a single quote

### DIFF
--- a/_source/_includes/blog_post.html
+++ b/_source/_includes/blog_post.html
@@ -31,7 +31,7 @@
     <div id="disqus">
         <div id="disqus_thread"></div>
         <script type="text/javascript">
-            var disqus_title = '{{ page.title }}';
+            var disqus_title = "{{ page.title }}";
             var disqus_url = '{{ page.url | prepend: site.url }}';
 
             (function () {


### PR DESCRIPTION
Comments don't render when there are single quotes in the title. This fixes the issue.

<img width="1455" alt="screen shot 2018-03-12 at 8 55 59 am" src="https://user-images.githubusercontent.com/17892/37291145-a471deb4-25d3-11e8-9646-add81c8ee8a9.png">
<img width="1455" alt="screen shot 2018-03-12 at 8 56 03 am" src="https://user-images.githubusercontent.com/17892/37291151-a66c754e-25d3-11e8-9057-b348475ed765.png">
