### PR TITLE
not working yet: single-source the call to action for support

### DIFF
--- a/_source/_change-log/2018-09.md
+++ b/_source/_change-log/2018-09.md
@@ -121,7 +121,7 @@ This applies to `/authorize` with either the Okta Org Authorization Server or a 
 }
 ~~~
 
-If you don't want these changes, contact Support to opt out.
+If you don't want these changes, contactSupport to opt out.
 
 ### Improved System Log Behavior for Date Queries
 

--- a/_source/_plugins/ApiTags.rb
+++ b/_source/_plugins/ApiTags.rb
@@ -64,6 +64,12 @@ module Okta
     # Replaces all occurences of 'yourOktaDomain' with a searchable span
     pages.output = pages.output.gsub(/https:\/\/{yourOktaDomain}.com/, '<span class="okta-preview-domain">https://{yourOktaDomain}.com</span>')
   end
+
+   Jekyll::Hooks.register [:pages, :posts, :documents], :post_render do |pages|
+    # Replaces all occurences of 'contactSupport' with a searchable span and link for init lower case
+    pages.output = pages.output.gsub(/contactSupport/, '<span class="contact-support"><a href="https://support.okta.com/help/open_case" target="_blank">contact Support</span')
+   end
+
 end
 
 Liquid::Template.register_tag('api_lifecycle', Okta::ApiLifecycleTag)


### PR DESCRIPTION
## Description:
- Every place we say "contact Support", we want that to be a link to where they enter a case. We want to single-source it as that place may change. So I tried to copy the yourOktaDomain code in Api.rb, but my code has a bug--the rest of the sentence is deleted. 

So is this the right way to do this, and if so, can you see what's wrong w/my code? 

### Resolves:

 [OKTA-160463](https://oktainc.atlassian.net/browse/OKTA-160463)

