### PR TITLE
Fix for Issue #1881

### DIFF
--- a/_source/quickstart-fragments/dotnet/aspnet4-auth-code.md
+++ b/_source/quickstart-fragments/dotnet/aspnet4-auth-code.md
@@ -65,7 +65,7 @@ public class Startup
             {
                 RedirectToIdentityProvider = context =>
                 {
-                    if (context.ProtocolMessage.RequestType == OpenIdConnectRequestType.LogoutRequest)
+                    if (context.ProtocolMessage.RequestType == OpenIdConnectRequestType.Logout)
                     {
                         var idToken = context.OwinContext.Authentication.User.Claims
                             .FirstOrDefault(c => c.Type == "id_token")?.Value;


### PR DESCRIPTION
## Description:
- Changed quickstart for .NET 4.x to use `Logout` instead of `LogoutRequest`.

### Resolves:
* [Issue #1881 ](#1881)
* CC @laura-rodriguez 