### PR TITLE
Add Vue to docs front page

### DIFF
--- a/_source/_assets/css/okta/pages/_docsIndex.scss
+++ b/_source/_assets/css/okta/pages/_docsIndex.scss
@@ -27,7 +27,7 @@
       justify-content: center;
     }
     a {
-      display: block;
+      display: inline-block;
       width: 132px;
 			font-size: 14px;
       font-weight: 600;

--- a/_source/_assets/js/docsIndex.js
+++ b/_source/_assets/js/docsIndex.js
@@ -6,6 +6,7 @@
     { name: 'react',label: 'React' },
     { name: 'ios',  label: 'iOS' },
     { name: 'javascript', label: 'JavaScript' },
+    { name: 'vue', label: 'Vue.js' },
     { name: 'java', label: 'Java' },
     { name: 'dotnet', label: '.NET' },
     { name: 'nodejs', label: 'Node.js' },


### PR DESCRIPTION
## Description:
- Adds Vue.js link to docs front page
- Tweaks language tiles css to provide better fallback for browsers that don't support flex

<img width="1439" alt="vue" src="https://user-images.githubusercontent.com/26014482/37991631-632c6b26-31a5-11e8-8d6d-5c5107a2c9de.png">

### Resolves:
<!-- Required for Okta-generated PRs -->
* [UX-1121](https://oktainc.atlassian.net/browse/UX-1121)
