### PR TITLE
Update .NET JWT validation guide

### DIFF
--- a/_source/_code/dotnet/jwt-validation.md
+++ b/_source/_code/dotnet/jwt-validation.md
@@ -8,40 +8,37 @@ support_email: developers@okta.com
 
 # Overview
 
-When you use the Okta API to [obtain an authorization grant for a user](/docs/api/resources/oidc#authorize), the response contains a signed JWT (`id_token` and/or `access_token`).
+When you use Okta to [get OAuth 2.0 or OpenID Connect tokens for a user](/authentication-guide/implementing-authentication/), the response contains a signed JWT (`id_token` and/or `access_token`).
 
-A common practice is to send one of these tokens in the `Bearer` header of future requests, to authorize the request for that user. Your server must then validate the token to make sure it's authentic and hasn't expired.
+If you are writing low-level code that retrieves or uses these tokens, it's important to validate the tokens before you trust them. This guide will show you how to validate tokens manually.
 
-> Note: This guide is specific to the .NET environment.  If you need general information, please see [Working With OAuth 2.0 Tokens](/authentication-guide/tokens/).
+> Note: This guide is specific to .NET and C#.  If you need general information, read [Working With OAuth 2.0 Tokens](/authentication-guide/tokens/) instead.
 
 ## Who should use this guide
 
 You _don't_ need to validate tokens manually if:
 
-* You are using <a href='/quickstart/#/widget/dotnet/aspnet4' data-proofer-ignore>ASP.NET</a> or <a href='/quickstart/#/widget/dotnet/aspnetcore' data-proofer-ignore>ASP.NET Core</a> with the `JwtBearer` or `OpenIdConnect` middleware
-* You want to send tokens to Okta to be validated (this is called [token introspection](/docs/api/resources/oidc#introspect))
+* You are using <a href='/quickstart/#/widget/dotnet/aspnet4' data-proofer-ignore>ASP.NET</a> or <a href='/quickstart/#/widget/dotnet/aspnetcore' data-proofer-ignore>ASP.NET Core</a> - follow our quickstarts instead!
+* You send the tokens to Okta to be validated (this is called [token introspection](/docs/api/resources/oidc#introspect))
 
 If you need to validate a token manually, and don't want to make a network call to Okta, this guide will help you validate tokens locally.
 
-## What you'll need
+### What you'll need
 
-* Your authorization server URL
-* A JWT (string)
+* Your authorization server URL (see [Composing Your Base URL](/docs/api/resources/oidc#composing-your-base-url))
+* A token (JWT string)
 * Libraries for retrieving the signing keys and validating the token
 
-When you create a [new Okta developer org](https://www.okta.com/developer/signup), Okta creates an authorization server called `default`. The URL for this authorization server is `https://{yourOktaDomain}.com/oauth2/default`. You can always find the full authorization server URL (also called an Issuer URI) in the Okta developer console by opening the **API** menu and choosing **Authorization Servers**.
+This guide will use the official Microsoft OpenID Connect and JWT libraries, but you can adapt it to other key and token parsing libraries.
 
-In this guide, you'll use the official Microsoft OpenID Connect and JWT libraries, but you can adapt it to your preferred key parser and JWT validation libraries as well.
+### Get the signing keys
 
-## Get the signing keys
-
-Okta signs JWTs using [asymmetric encryption (RS256)](https://stackoverflow.com/a/39239395/3191599), and publishes the public signing keys in a JWKS (JSON Web Key set) as part of the OAuth 2.0 and OpenID Connect discovery documents. The signing keys are rotated on a regular basis. The first step to verify a signed JWT is to retrieve the current signing keys.
+Okta signs JWTs using [asymmetric encryption (RS256)](https://stackoverflow.com/a/39239395/3191599), and publishes the public signing keys in a JWKS (JSON Web Key Set) as part of the OAuth 2.0 and OpenID Connect discovery documents. The signing keys are rotated on a regular basis. The first step to verify a signed JWT is to retrieve the current signing keys.
 
 The `OpenIdConnectConfigurationRetriever` class in the [Microsoft.IdentityModel.Protocols.OpenIdConnect](https://www.nuget.org/packages/Microsoft.IdentityModel.Protocols.OpenIdConnect/) package will download and parse the discovery document to get the key set. You can use it in conjunction with the `ConfigurationManager` class, which will handle caching the response and refreshing it regularly:
 
 ```csharp
 // Replace with your authorization server URL:
-
 var issuer = "https://{yourOktaDomain}.com/oauth2/default";
 
 var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
@@ -52,7 +49,7 @@ var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
 
 Once you've instantiated the `configurationManager`, keep it around as a singleton. You only need to set it up once.
 
-## Validate a token
+### Validate a token
 
 The `JwtSecurityTokenHandler` class in the [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt) package will handle the low-level details of validating a JWT.
 
@@ -82,7 +79,6 @@ private static async Task<JwtSecurityToken> ValidateToken(
         // (a lower value is better; we recommend five minutes or less)
         ClockSkew = TimeSpan.FromMinutes(5),
         // See additional validation for aud below
-        ValidateAudience = false,
     };
 
     try
@@ -115,25 +111,26 @@ if (validatedToken == null)
 else
 {
     // Additional validation...
-
     Console.WriteLine("Token is valid!");
 }
 ```
 
 This method will return an instance of `JwtSecurityToken` if the token is valid, or `null` if it is invalid. Returning `JwtSecurityToken` makes it possible to retrieve claims from the token later.
 
-Depending on your application, you could change this method to return a `bool`, log specific exceptions like `SecurityTokenExpiredException` with a message, or handle validation failures in some other way.
+Depending on your application, you could change this method to return a boolean, log specific exceptions like `SecurityTokenExpiredException` with a message, or handle validation failures in some other way.
 
 ### Additional validation for access tokens
 
-If you are validating access tokens, you should verify that the `aud` (Audience) claim equals the Audience that is configured for your Authorization Server in the Okta Developer Dashboard. For example, if your Authorization Server Audience is set to `MyAwesomeApi`, add this to the validation parameters:
+If you are validating access tokens, you should verify that the `aud` (audience) claim equals the audience that is configured for your Authorization Server in the Okta Developer Console.
+
+For example, if your Authorization Server audience is set to `MyAwesomeApi`, add this to the validation parameters:
 
 ```csharp
 ValidateAudience = true,
 ValidAudience = "MyAwesomeApi",
 ```
 
-You can also optionally verify that the `cid` claim matches the expected Client ID of the current application. You'll have to perform this check after the `ValidateToken` method returns a validated token:
+You also must verify that the `cid` claim matches the expected Client ID of the current application. You'll have to perform this check after the `ValidateToken` method returns a validated token:
 
 ```csharp
 var validatedToken = await ValidateToken(accessToken, issuer, configurationManager);
@@ -151,14 +148,16 @@ if (!clientIdMatches)
 
 ### Additional validation for ID tokens
 
-When validating an ID token, you should verify that the `aud` (Audience) claim equals the Client ID of the current application. Add this to the validation parameters:
+When validating an ID token, you should verify that the `aud` (Audience) claim equals the Client ID of the current application.
+
+Add this to the validation parameters:
 
 ```csharp
 ValidateAudience = true,
 ValidAudience = "xyz123", // This Application's Client ID
 ```
 
-If you specified a nonce during the initial code exchange when your application retrieved the ID token, you can verify that the nonce matches:
+If you specified a nonce during the initial code exchange when your application retrieved the ID token, you should verify that the nonce matches:
 
 ```csharp
 var validatedToken = await ValidateToken(accessToken, issuer, configurationManager);
@@ -198,3 +197,5 @@ foreach (var claim in validatedToken.Claims)
 ## Conclusion
 
 This guide provides the basic steps required to locally verify an access or ID token signed by Okta. It uses packages from Microsoft for key parsing and token validation, but the general principles should apply to any JWT validation library.
+
+Most applications don't need to follow this guide. If you are using our <a href='/quickstart/#/widget/dotnet/aspnet4' data-proofer-ignore>ASP.NET quickstart</a> or <a href='/quickstart/#/widget/dotnet/aspnetcore' data-proofer-ignore>ASP.NET Core quickstart</a> to connect your application to Okta, all of these validation steps are done automatically for you.


### PR DESCRIPTION
Fixes #1780. Specific fix here (line 133): https://github.com/okta/okta.github.io/compare/1780-fix-dotnet-validation-instructions?expand=1#diff-074effc5fbc657560c2beb988d711e38R133