### PR TITLE
Add a step to configure ServicePointManager for TLS 1.2 & .NET <4.6

### DIFF
--- a/_source/quickstart-fragments/dotnet/aspnet4-auth-code.md
+++ b/_source/quickstart-fragments/dotnet/aspnet4-auth-code.md
@@ -111,6 +111,13 @@ public class Startup
 }
 ```
 
+**Note**: If you are using  .NET framework <4.6 and TLS 1.2 make sure to include the following code in the `Application_Start` or `Startup`:
+
+```csharp
+// Enable TLS 1.2
+ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+```
+
 Add these using statements at the top of the file:
 
 ```csharp

--- a/_source/quickstart-fragments/dotnet/aspnet4-auth-code.md
+++ b/_source/quickstart-fragments/dotnet/aspnet4-auth-code.md
@@ -111,7 +111,7 @@ public class Startup
 }
 ```
 
-**Note**: If you are using  .NET framework <4.6 and TLS 1.2 make sure to include the following code in the `Application_Start` or `Startup`:
+**Note**: If you are using .NET framework <4.6 or you are getting the following error: ```The request was aborted: Could not create SSL/TLS secure channel ```. Make sure to include the following code in the `Application_Start` or `Startup`:
 
 ```csharp
 // Enable TLS 1.2


### PR DESCRIPTION
## Description:

Add an additional step to configure the ServicePointManager when using TLS 1.2 and .NET <4.6.

### Resolves:
* #1917 


