### PR TITLE
Replace CSS color values with variables

### DIFF
--- a/_source/_assets/css/okta/base/_variables.scss
+++ b/_source/_assets/css/okta/base/_variables.scss
@@ -28,7 +28,7 @@ $font-size:     (
                 'h3':               28px,
                 'h2':               32px,
                 'h1':               36px,
-                
+
                 'new-small':        12px,
                 'new-h2':           28px,
                 'new-h1':           44px,
@@ -51,7 +51,7 @@ $font-weight:   (
                 'semibold':         500,
                 'mediumbold':       600,
                 'bold':             700,
-                
+
                 'new-h2':           500,
                 'new-h1':           500
 );
@@ -66,7 +66,7 @@ $line-height:   (
                 'h2':               42px,
                 'h1':               46px,
                 'large':            56px,
-                
+
                 'new-h1':           52px,
                 'new-h2':           36px,
                 'new-small':        20px,
@@ -81,64 +81,137 @@ $line-height:   (
 
 
 // Project/Client Colors
+
+// Abstract definitions:
+// (These are consistent with Nim. Changes here should be mirrored there - https://github.com/okta/courage/blob/master/assets/sass/nim/abstracts/_colors.scss)
+// Whites
+$white: #ffffff;
+$white-3: #fafafa;
+$white-smoke-4: #eeeeee;
+$white-smoke-6: #f0f0f0;
+$white-smoke-8: #f5f5f5;
+$white-smoke-10: #f4f4f4; // intentional developer color
+$gainsboro-2: #dddddd;
+$gainsboro-8: #e4e4e4;
+// Grays
+$dim-gray-3: #5d5d5d;
+$eclipse-2: #3d3d3d;
+$iron: #c2c3c3;
+$lily-white: #f2f5f5;
+$mortar: #555555;
+$mystic: #dee0df;
+$night-rider: #333333;
+$nobel: #999999;
+$nobel-2: #9a9a9a;
+$shady-lady: #979797;
+$suva-gray: #888888;
+$suva-gray-4: #8f8f8f;
+$very-light-gray: #cccccc;
+// Blacks
+$black: #000000;
+// Reds
+$jazzberry-jam: #990f69;
+$valencia: #d9534f;
+// Oranges
+$burnt-orange: #ff7640;
+$light-coral: #f57f7f;
+$red-orange: #ff3333;
+$sea-buckthorn: #f39c44;
+// Yellows
+$lemon: #f7f01b;
+// Blues
+$blue-whale: #142430; // intentional developer color
+$columbia-blue: #a9e6fd;
+$cerulean-4: #00659d;
+$cerulean-5: #0069aa;
+$curious-blue: #428bca;
+$curious-blue-2: #357ebd;
+$dark-cerulean: #115d8b; // intentional developer color
+$ghost: #d2d2d6; // intentional developer color
+$maya-blue: #4cc3ff;
+$maya-blue-2: #5dd2fc;
+$midnight: #20313b; // intentional developer color
+$mischka: #b3b3b5;
+$navy-blue: #007dc1;
+$pacific-blue-3: #0095e5;
+$pattens-blue: #e0eef6;
+$pattens-blue-2: #deeef6;
+$solitude-4: #dbe3e7;
+$summer-sky: #46b3e9;
+$turquoise: #5ce5bc;
+$white-lilac-2: #e6e6e8;
+// Greens
+$cyprus-2: #153b56; // intentional developer color
+$islamic-green: #009900;
+$puerto-rico: #4cbf9c;
+$puerto-rico-5: #4cbf9d;
+$screamin-green: #59ff99;
+$shamrock: #4cdb82;
+$periglacial-blue: #abadac;
+// Purples
+$cerise: #e22866; // intentional developer color
+$lavender-3: #f7fbfd;
+// Browns
+
+// Functional map:
 $colors:        (
-                'black':                  #000000,
-                'white':                  #fff,
+                'black':                  $black,
+                'white':                  $white,
 
-                'default':                #3D3D3D,
-                'accent':                 #007dc1,
+                'default':                $eclipse-2,
+                'accent':                 $navy-blue,
 
-                'blue-bright':            #007dc1,
-                'blue-bright-hover':      #0095e5,
+                'blue-bright':            $navy-blue,
+                'blue-bright-hover':      $pacific-blue-3,
 
-                'blue-medium':            #46b3e9,
-                'blue-medium-hover':      #4cc3ff,
+                'blue-medium':            $summer-sky,
+                'blue-medium-hover':      $maya-blue,
 
-                'blue-light':             #a9e6fd,
-                'blue-light-hover':       #5dd2fc,
+                'blue-light':             $columbia-blue,
+                'blue-light-hover':       $maya-blue-2,
 
-                'green':                  #4cbf9d,
-                'green-hover':            #5ce5bc,
+                'green':                  $puerto-rico-5,
+                'green-hover':            $turquoise,
 
-                'green-dark':             #4cbf9c,
-                'green-dark-hover':       #5ce5bc,
+                'green-dark':             $puerto-rico,
+                'green-dark-hover':       $turquoise,
 
-                'green-light':            #4cdb82,
-                'green-light-hover':      #59ff99,
+                'green-light':            $shamrock,
+                'green-light-hover':      $screamin-green,
 
-                'charcoal':               #5d5d5d,
-                'charcoal-hover':         #8f8f8f,
+                'charcoal':               $dim-gray-3,
+                'charcoal-hover':         $suva-gray-4,
 
-                'gray-dark':              #abadac,
-                'gray-dark-hover':        #dee0df,
+                'gray-dark':              $periglacial-blue,
+                'gray-dark-hover':        $mystic,
 
-                'gray-medium':            #c2c3c3,
-                'gray-medium-hover':      #f2f5f5,
+                'gray-medium':            $iron,
+                'gray-medium-hover':      $lily-white,
 
-                'gray-light':             #e6e6e8,
-                'gray-light-hover':       #b3b3b5,
+                'gray-light':             $white-lilac-2,
+                'gray-light-hover':       $mischka,
 
-                'gray-lighter':           #e4e4e4,
-                'gray-lighter-hover':     #eee,
+                'gray-lighter':           $gainsboro-8,
+                'gray-lighter-hover':     $white-smoke-4,
 
-                'gray-lightest':          #fafafa,
-                'gray-lightest-hover':    #a9e6fd,
+                'gray-lightest':          $white-3,
+                'gray-lightest-hover':    $columbia-blue,
 
-                'blue-products':          #E0EEF6,
+                'blue-products':          $pattens-blue,
 
-                'new-gray-dark':          #3d3d3d,
+                'new-gray-dark':          $eclipse-2,
 
-                'red':                    #f57f7f,
+                'red':                    $light-coral,
 
                 // 2017-07 Redesign Colors
-                'ebony-clay':             #20313B, // Background
-                'elephant':               #153B56, // Secondary background, table rule
-                'big-stone':              #142430, // Card / table background
-                'matisse':                #115D8B, // Card / table banner
-                'iron':                   #D2D2D6, // Body (type) color (dark bg)
-                'cerise':                 #E22866, // CTA buttons, links
+                'ebony-clay':             $midnight, // Background
+                'elephant':               $cyprus-2, // Secondary background, table rule
+                'big-stone':              $blue-whale, // Card / table background
+                'matisse':                $dark-cerulean, // Card / table banner
+                'iron':                   $ghost, // Body (type) color (dark bg) // Note difference from $iron
+                'cerise':                 $cerise, // CTA buttons, links
 
-                'code-background':        #F4F4F4,
+                'code-background':        $white-smoke-10,
 );
 
 

--- a/_source/_assets/css/okta/components/_Blog.scss
+++ b/_source/_assets/css/okta/components/_Blog.scss
@@ -23,7 +23,7 @@
 
 	&-pagination {
 		@include color('charcoal');
-		border-top: 1px solid #979797;
+		border-top: 1px solid $shady-lady;
 		display: flex;
 		font-size: 18px;
 		justify-content: center;
@@ -59,7 +59,7 @@
 		width: 34px;
 
 		a {
-			color: #9a9a9a;
+			color: $nobel-2;
 			display: block;
 			font-size: 34px;
 			text-decoration: none;

--- a/_source/_assets/css/okta/components/_BlogPost.scss
+++ b/_source/_assets/css/okta/components/_BlogPost.scss
@@ -4,7 +4,7 @@
 	overflow-wrap: break-word;
 
 	& + & {
-		border-top: 1px solid #979797;
+		border-top: 1px solid $shady-lady;
 		margin-bottom: 0;
 		margin-top: get-spacing('medium');
 		padding-top: get-spacing('medium');
@@ -168,8 +168,8 @@
 		/* Same as what docs uses (in _PageContent.scss) */
 		blockquote {
 			margin: 24px 24px;
-			border-left: 8px solid #00659d;
-			background: #DEEEF6;
+			border-left: 8px solid $cerulean-4;
+			background: $pattens-blue-2;
 			padding: 24px;
 			font-size: 1em;
 			p {
@@ -183,7 +183,7 @@
 
 		pre {
 			@include padding(15px);
-			background: #f4f4f4;
+			background: get-color('code-background');
 			display: block;
 			margin: get-spacing('small') 0;
 			max-width: 900px;
@@ -205,82 +205,82 @@
 
 		/* -------------------------- PYGMENTS */
 
-		.highlight pre { color: #3d3d3d; } /* Base Style */
-		.highlight .p { color: #3d3d3d; } /* Punctuation */
-		.highlight .err { color: #3d3d3d; } /* Error */
-		.highlight .n { color: #115D8B; } /* Base Style */
-		.highlight .na { color: #115D8B; } /* Name Attribute */
-		.highlight .nb { color: #115D8B; } /* Name Builtin */
-		.highlight .nc { color: #115D8B; } /* Name Class */
-		.highlight .no { color: #115D8B; } /* Name Constant */
-		.highlight .nd { color: #115D8B; } /* Name Decorator */
-		.highlight .ni { color: #115D8B; } /* Name Entity */
-		.highlight .ne { color: #115D8B; } /* Name Exception */
-		.highlight .nf { color: #115D8B; } /* Name Function */
-		.highlight .nl { color: #115D8B; } /* Name Label */
-		.highlight .nn { color: #4CBF9C; } /* Name Namespace */
-		.highlight .nx { color: #115D8B; } /* Name Other */
-		.highlight .py { color: #115D8B; } /* Name Property */
-		.highlight .nt { color: #115D8B; } /* Name Tag */
-		.highlight .nv { color: #115D8B; } /* Name Variable */
-		.highlight .vc { color: #115D8B; } /* Name Variable Class */
-		.highlight .vg { color: #115D8B; } /* Name Variable Global */
-		.highlight .vi { color: #115D8B; } /* Name Variable Instance */
-		.highlight .bp { color: #115D8B; } /* Name Builtin Pseudo */
-		.highlight .g { color: #3d3d3d; } /* Base Style */
-		.highlight .gd { color: #3d3d3d; } /*  */
-		.highlight .o { color: #3d3d3d; } /* Base Style */
-		.highlight .ow { color: #4CBF9C; } /* Operator Word */
-		.highlight .c { color: #9A9A9A; font-style: italic; }/* Base Style */
-		.highlight .cm { color: #9A9A9A; font-style: italic; } /* Comment Multiline */
-		.highlight .cp { color: #9A9A9A; font-style: italic; } /* Comment Preproc */
-		.highlight .c1 { color: #9A9A9A; font-style: italic; } /* Comment Single */
-		.highlight .cs { color: #9A9A9A; font-style: italic; } /* Comment Special */
-		.highlight .k { color: #4CBF9C; } /* Base Style */
-		.highlight .kc { color: #4CBF9C; } /* Keyword Constant */
-		.highlight .kd { color: #4CBF9C; } /* Keyword Declaration */
-		.highlight .kn { color: #4CBF9C; } /* Keyword Namespace */
-		.highlight .kp { color: #4CBF9C; } /* Keyword Pseudo */
-		.highlight .kr { color: #4CBF9C; } /* Keyword Reserved */
-		.highlight .kt { color: #4CBF9C; } /* Keyword Type */
-		.highlight .l { color: #3d3d3d; } /* Base Style */
-		.highlight .ld { color: #990f69; } /* Literal Date */
-		.highlight .m { color: #990f69; } /* Literal Number */
-		.highlight .mf { color: #990f69; } /* Literal Number Float */
-		.highlight .mh { color: #990f69; } /* Literal Number Hex */
-		.highlight .mi { color: #990f69; } /* Literal Number Integer */
-		.highlight .mo { color: #990f69; } /* Literal Number Oct */
-		.highlight .il { color: #990f69; } /* Literal Number Integer Long */
-		.highlight .s { color: #E22866; } /* Literal String */
-		.highlight .sb { color: #E22866; } /* Literal String Backtick */
-		.highlight .sc { color: #E22866; } /* Literal String Char */
-		.highlight .sd { color: #E22866; } /* Literal String Doc */
-		.highlight .s2 { color: #E22866; } /* Literal String Double */
-		.highlight .se { color: #990f69; } /* Literal String Escape */
-		.highlight .sh { color: #E22866; } /* Literal String Heredoc */
-		.highlight .si { color: #E22866; } /* Literal String Interpol */
-		.highlight .sx { color: #E22866; } /* Literal String Other */
-		.highlight .sr { color: #990f69; } /* Literal String Regex */
-		.highlight .s1 { color: #E22866; } /* Literal String Single */
-		.highlight .ss { color: #E22866; } /* Literal String Symbol */
-		.highlight .g { color: #3d3d3d; } /* Base Style */
-		.highlight .gd { color: #3d3d3d; } /* Generic Deleted */
-		.highlight .ge { color: #3d3d3d; } /* Generic Emph */
-		.highlight .gr { color: #3d3d3d; } /* Generic Error */
-		.highlight .gh { color: #3d3d3d; } /* Generic Heading */
-		.highlight .gi { color: #3d3d3d; } /* Generic Inserted */
-		.highlight .go { color: #3d3d3d; } /* Generic Output */
-		.highlight .gp { color: #3d3d3d; } /* Generic Prompt */
-		.highlight .gs { color: #3d3d3d; } /* Generic Strong */
-		.highlight .gu { color: #3d3d3d; } /* Generic Subheading */
-		.highlight .gt { color: #3d3d3d; } /* Generic Traceback */
-		.highlight .x { color: #3d3d3d; } /* Other */
-		.highlight .w { color: #3d3d3d; } /* Text Whitespace */
+		.highlight pre { color: $eclipse-2; } /* Base Style */
+		.highlight .p { color: $eclipse-2; } /* Punctuation */
+		.highlight .err { color: $eclipse-2; } /* Error */
+		.highlight .n { color: $dark-cerulean; } /* Base Style */
+		.highlight .na { color: $dark-cerulean; } /* Name Attribute */
+		.highlight .nb { color: $dark-cerulean; } /* Name Builtin */
+		.highlight .nc { color: $dark-cerulean; } /* Name Class */
+		.highlight .no { color: $dark-cerulean; } /* Name Constant */
+		.highlight .nd { color: $dark-cerulean; } /* Name Decorator */
+		.highlight .ni { color: $dark-cerulean; } /* Name Entity */
+		.highlight .ne { color: $dark-cerulean; } /* Name Exception */
+		.highlight .nf { color: $dark-cerulean; } /* Name Function */
+		.highlight .nl { color: $dark-cerulean; } /* Name Label */
+		.highlight .nn { color: $puerto-rico; } /* Name Namespace */
+		.highlight .nx { color: $dark-cerulean; } /* Name Other */
+		.highlight .py { color: $dark-cerulean; } /* Name Property */
+		.highlight .nt { color: $dark-cerulean; } /* Name Tag */
+		.highlight .nv { color: $dark-cerulean; } /* Name Variable */
+		.highlight .vc { color: $dark-cerulean; } /* Name Variable Class */
+		.highlight .vg { color: $dark-cerulean; } /* Name Variable Global */
+		.highlight .vi { color: $dark-cerulean; } /* Name Variable Instance */
+		.highlight .bp { color: $dark-cerulean; } /* Name Builtin Pseudo */
+		.highlight .g { color: $eclipse-2; } /* Base Style */
+		.highlight .gd { color: $eclipse-2; } /*  */
+		.highlight .o { color: $eclipse-2; } /* Base Style */
+		.highlight .ow { color: $puerto-rico; } /* Operator Word */
+		.highlight .c { color: $nobel-2; font-style: italic; }/* Base Style */
+		.highlight .cm { color: $nobel-2; font-style: italic; } /* Comment Multiline */
+		.highlight .cp { color: $nobel-2; font-style: italic; } /* Comment Preproc */
+		.highlight .c1 { color: $nobel-2; font-style: italic; } /* Comment Single */
+		.highlight .cs { color: $nobel-2; font-style: italic; } /* Comment Special */
+		.highlight .k { color: $puerto-rico; } /* Base Style */
+		.highlight .kc { color: $puerto-rico; } /* Keyword Constant */
+		.highlight .kd { color: $puerto-rico; } /* Keyword Declaration */
+		.highlight .kn { color: $puerto-rico; } /* Keyword Namespace */
+		.highlight .kp { color: $puerto-rico; } /* Keyword Pseudo */
+		.highlight .kr { color: $puerto-rico; } /* Keyword Reserved */
+		.highlight .kt { color: $puerto-rico; } /* Keyword Type */
+		.highlight .l { color: $eclipse-2; } /* Base Style */
+		.highlight .ld { color: $jazzberry-jam; } /* Literal Date */
+		.highlight .m { color: $jazzberry-jam; } /* Literal Number */
+		.highlight .mf { color: $jazzberry-jam; } /* Literal Number Float */
+		.highlight .mh { color: $jazzberry-jam; } /* Literal Number Hex */
+		.highlight .mi { color: $jazzberry-jam; } /* Literal Number Integer */
+		.highlight .mo { color: $jazzberry-jam; } /* Literal Number Oct */
+		.highlight .il { color: $jazzberry-jam; } /* Literal Number Integer Long */
+		.highlight .s { color: $cerise; } /* Literal String */
+		.highlight .sb { color: $cerise; } /* Literal String Backtick */
+		.highlight .sc { color: $cerise; } /* Literal String Char */
+		.highlight .sd { color: $cerise; } /* Literal String Doc */
+		.highlight .s2 { color: $cerise; } /* Literal String Double */
+		.highlight .se { color: $jazzberry-jam; } /* Literal String Escape */
+		.highlight .sh { color: $cerise; } /* Literal String Heredoc */
+		.highlight .si { color: $cerise; } /* Literal String Interpol */
+		.highlight .sx { color: $cerise; } /* Literal String Other */
+		.highlight .sr { color: $jazzberry-jam; } /* Literal String Regex */
+		.highlight .s1 { color: $cerise; } /* Literal String Single */
+		.highlight .ss { color: $cerise; } /* Literal String Symbol */
+		.highlight .g { color: $eclipse-2; } /* Base Style */
+		.highlight .gd { color: $eclipse-2; } /* Generic Deleted */
+		.highlight .ge { color: $eclipse-2; } /* Generic Emph */
+		.highlight .gr { color: $eclipse-2; } /* Generic Error */
+		.highlight .gh { color: $eclipse-2; } /* Generic Heading */
+		.highlight .gi { color: $eclipse-2; } /* Generic Inserted */
+		.highlight .go { color: $eclipse-2; } /* Generic Output */
+		.highlight .gp { color: $eclipse-2; } /* Generic Prompt */
+		.highlight .gs { color: $eclipse-2; } /* Generic Strong */
+		.highlight .gu { color: $eclipse-2; } /* Generic Subheading */
+		.highlight .gt { color: $eclipse-2; } /* Generic Traceback */
+		.highlight .x { color: $eclipse-2; } /* Other */
+		.highlight .w { color: $eclipse-2; } /* Text Whitespace */
 
 		p, li {
 			code {
 				@include padding(0 xx-small);
-				background: #f4f4f4;
+				background: $white-smoke-10;
 				line-height: 24px;
 			}
 		}
@@ -292,7 +292,7 @@
 			width: 100%;
 
 			thead th {
-				background: #eee;
+				background: $white-smoke-4;
 				padding: 10px 10px 10px;
 				font-weight: bold;
 			}

--- a/_source/_assets/css/okta/components/_Button.scss
+++ b/_source/_assets/css/okta/components/_Button.scss
@@ -11,15 +11,15 @@
 	line-height: 30px;
 	padding: 0 20px;
 	text-decoration: none;
-	
+
 	> a {
 		color: inherit;
 	}
 
 	&:active,
 	&:hover {
-		border-color: #000;
-		color: #000;
+		border-color: $black;
+		color: $black;
 		text-decoration: none;
 	}
 }
@@ -54,7 +54,7 @@
 	height: 54px;
 	line-height: 50px;
 	padding: 0 30px;
-	
+
 	&.Button--rounded {
 		border-radius: 27px;
 	}
@@ -76,7 +76,7 @@
 
 .Button--blueOutline {
 	@extend %Button;
-	
+
 	&,
 	&:active,
 	&:hover {
@@ -101,7 +101,7 @@
 
 .Button--greenOutline {
 	@extend %Button;
-	
+
 	&,
 	&:active,
 	&:hover {
@@ -112,7 +112,7 @@
 
 .Button--white {
 	@extend %Button;
-	
+
 	&,
 	&:active,
 	&:hover {
@@ -124,7 +124,7 @@
 
 .Button--whiteOutline {
 	@extend %Button;
-	
+
 	&,
 	&:active,
 	&:hover {
@@ -136,7 +136,7 @@
 .Button--whiteOutlineOpaque {
 	@extend %Button;
 	background-color: rgba(255,255,255,0.25);
-	
+
 	&,
 	&:active,
 	&:hover {

--- a/_source/_assets/css/okta/components/_DocsPage.scss
+++ b/_source/_assets/css/okta/components/_DocsPage.scss
@@ -65,8 +65,8 @@
 
         &.button-active {
           input[type=submit] {
-            background: #e22866;
-            color: #fff;
+            background: get-color('cerise');
+            color: $white;
           }
         }
       }

--- a/_source/_assets/css/okta/components/_PageContent.scss
+++ b/_source/_assets/css/okta/components/_PageContent.scss
@@ -118,8 +118,8 @@
 
 		blockquote {
 			margin: 24px 24px;
-			border-left: 8px solid #00659D;
-			background: #DEEEF6;
+			border-left: 8px solid $cerulean-4;
+			background: $pattens-blue-2;
 			padding: 24px;
 			font-size: 1em;
 			p {
@@ -142,7 +142,7 @@
 			margin-bottom: 10px;
 			list-style: initial;
 			li {
-				color: #555;
+				color: $mortar;
 				margin-bottom: 5px;
 			}
 		}
@@ -165,7 +165,7 @@
 
 		th {
 			text-align: left;
-			background: #eee;
+			background: $white-smoke-4;
 			padding: 5px;
 			font-weight: bold;
 			vertical-align: top;
@@ -175,9 +175,9 @@
 		}
 
 		tr {
-			border-bottom: 1px dotted #999;
+			border-bottom: 1px dotted $nobel;
 			&:nth-child(even) {
-			    background-color: #F7FBFD;
+			    background-color: $lavender-3;
 			}
 		}
 
@@ -185,13 +185,13 @@
 
 		td {
 			padding: 3px 5px;
-			border-right: 1px dotted #f0f0f0;
+			border-right: 1px dotted $white-smoke-6;
 			vertical-align: top;
 
 			code {
 				word-break: normal;
 				font-size: 12px;
-				color: #333333;
+				color: $night-rider;
 			}
 		}
 
@@ -200,12 +200,12 @@
 		}
 		code {
 			border-radius: 2px;
-			border: 1px solid #dbe3e7;
+			border: 1px solid $solitude-4;
 			white-space: normal;
 			padding: 1px 5px;
 			line-height: 1.428571429;
-			background: #f4f4f4;
-			color: #333333;
+			background: get-color('code-background');
+			color: $night-rider;
 			font-size: 80%;
 			font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 			word-break: break-all;
@@ -231,10 +231,10 @@
 			padding: 9.5px;
 			margin: 0 0 10px;
 			line-height: 1.428571429;
-			color: #333333;
+			color: $night-rider;
 			word-break: break-all;
 			word-wrap: break-word;
-			background-color: #f0f0f0;
+			background-color: $white-smoke-6;
 			border-radius: 4px;
 			white-space: pre;
 			overflow: auto;
@@ -332,33 +332,33 @@
 		}
 
 		.api-label-beta {
-		  background: #f7f01b;
-		  color: black;
+		  background: $lemon;
+		  color: $black;
 		}
 
 		.api-label-ea {
-		  background: #4CBF9C;
+		  background: $puerto-rico;
 		}
 
 		.api-label-deprecated {
-		  background: #ff7640;
+		  background: $burnt-orange;
 		}
 
 		.api-label-cors {
-		  background: #5d5d5d;
+		  background: $dim-gray-3;
 		}
 
 		.api-uri-template {
 			display:inline-block;
-			border-top:1px solid #ccc;
-			border-right:1px solid #ccc;
-			border-bottom:1px solid #ccc;
+			border-top:1px solid $very-light-gray;
+			border-right:1px solid $very-light-gray;
+			border-bottom:1px solid $very-light-gray;
 			border-radius:.25em;
-		    padding-right: 10px;
-			background:#f5f5f5;
+			padding-right: 10px;
+			background:$white-smoke-8;
 			margin-right: 5px;
 			strong {
-				color: #090;
+				color: $islamic-green;
 			}
 			.api-label {
 				border-top-right-radius:0;
@@ -369,42 +369,42 @@
 
 		.api-uri-get {
 			strong {
-				color: #090;
+				color: $islamic-green;
 			}
 			.api-label {
-				background: #090;
+				background: $islamic-green;
 			}
 		}
 
 		.api-uri-post {
 			strong {
-				color: #F39C44;
+				color: $sea-buckthorn;
 			}
 			.api-label {
-				background: #F39C44;
+				background: $sea-buckthorn;
 			}
 		}
 
 		.api-uri-put {
 			strong {
-				color: #0069aa;
+				color: $cerulean-5;
 			}
 			.api-label {
-				background: #0069aa;
+				background: $cerulean-5;
 			}
 		}
 
 		.api-uri-delete {
 			strong {
-				color: #d9534f;
+				color: $valencia;
 			}
 			.api-label {
-				background: #d9534f;
+				background: $valencia;
 			}
 		}
 
 		.panel-default {
-			border-color: #dddddd;
+			border-color: $gainsboro-2;
 		}
 
 		.form-group {
@@ -455,17 +455,17 @@
 			transition: 0.2s all;
 			font-size: 0.92166em;
 			background: none;
-			border: 1px solid #E6E6E8;
+			border: 1px solid $white-lilac-2;
 			border-radius: 3px;
-			color: #000;
+			color: $black;
 			display: inline-block;
 			padding: .4em .8em;
 			text-decoration: none;
 
 			&-primary {
-				color: #ffffff;
-				background-color: #428bca;
-				border-color: #357ebd;
+				color: $white;
+				background-color: $curious-blue;
+				border-color: $curious-blue-2;
 				padding: 1em .8em;
 			}
 
@@ -473,8 +473,8 @@
 			&:focus,
 			&:hover {
 				background: none;
-				border-color: #4cbf9c;
-				color: #4cbf9c;
+				border-color: $puerto-rico;
+				color: $puerto-rico;
 			}
 		}
 
@@ -519,11 +519,11 @@
 			padding: 6px 12px;
 			font-size: 14px;
 			line-height: 1.428571429;
-			color: #555555;
+			color: $mortar;
 			vertical-align: middle;
-			background-color: #ffffff;
+			background-color: $white;
 			background-image: none;
-			border: 1px solid #cccccc;
+			border: 1px solid $very-light-gray;
 			border-radius: 4px;
 			-webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 			box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
@@ -566,26 +566,26 @@
 			font-size: 14px;
 			font-weight: normal;
 			line-height: 1;
-			color: #555555;
+			color: $mortar;
 			text-align: center;
-			background-color: #eeeeee;
-			border: 1px solid #cccccc;
+			background-color: $white-smoke-4;
+			border: 1px solid $very-light-gray;
 			border-radius: 4px;
 		}
 
 		.panel {
 			margin-bottom: 20px;
-			background-color: #ffffff;
-			border: 1px solid #dddddd;
+			background-color: $white;
+			border: 1px solid $gainsboro-2;
 			border-radius: 4px;
 			-webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 			box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 		}
 
 		.panel-default > .panel-heading {
-			color: #333333;
-			background-color: #f5f5f5;
-			border-color: #dddddd;
+			color: $night-rider;
+			background-color: $white-smoke-8;
+			border-color: $gainsboro-2;
 		}
 
 		.panel-heading {
@@ -621,7 +621,7 @@
 			li:before {
 				font-family: fontawesome;
 				font-size: 14px;
-				color: #ccc;
+				color: $very-light-gray;
 				content: '\f097';
 				margin-right: 5px;
 			}
@@ -637,7 +637,7 @@
 		.page-title-block {
 			padding-bottom: .5em;
 			margin-bottom: 2em;
-			border-bottom: 1px solid #888;
+			border-bottom: 1px solid $suva-gray;
 		}
 
 		.table-word-break td{
@@ -663,7 +663,7 @@
 
 		pre {
 			@include padding(15px);
-			background: #f4f4f4;
+			background: get-color('code-background');
 			display: block;
 			margin: get-spacing('large') 0;
 
@@ -685,86 +685,86 @@
 			@include padding(0 xx-small);
 		}
 
-		.highlight pre { color: #3d3d3d; } /* Base Style */
-		.highlight .p { color: #3d3d3d; } /* Punctuation */
-		.highlight .err { color: #3d3d3d; } /* Error */
-		.highlight .n { color: #115D8B; } /* Base Style */
-		.highlight .na { color: #115D8B; } /* Name Attribute */
-		.highlight .nb { color: #115D8B; } /* Name Builtin */
-		.highlight .nc { color: #115D8B; } /* Name Class */
-		.highlight .no { color: #115D8B; } /* Name Constant */
-		.highlight .nd { color: #115D8B; } /* Name Decorator */
-		.highlight .ni { color: #115D8B; } /* Name Entity */
-		.highlight .ne { color: #115D8B; } /* Name Exception */
-		.highlight .nf { color: #115D8B; } /* Name Function */
-		.highlight .nl { color: #115D8B; } /* Name Label */
-		.highlight .nn { color: #4CBF9C; } /* Name Namespace */
-		.highlight .nx { color: #115D8B; } /* Name Other */
-		.highlight .py { color: #115D8B; } /* Name Property */
-		.highlight .nt { color: #115D8B; } /* Name Tag */
-		.highlight .nv { color: #115D8B; } /* Name Variable */
-		.highlight .vc { color: #115D8B; } /* Name Variable Class */
-		.highlight .vg { color: #115D8B; } /* Name Variable Global */
-		.highlight .vi { color: #115D8B; } /* Name Variable Instance */
-		.highlight .bp { color: #115D8B; } /* Name Builtin Pseudo */
-		.highlight .g { color: #3d3d3d; } /* Base Style */
-		.highlight .gd { color: #3d3d3d; } /*  */
-		.highlight .o { color: #3d3d3d; } /* Base Style */
-		.highlight .ow { color: #4CBF9C; } /* Operator Word */
-		.highlight .c { color: #9A9A9A; font-style: italic; }/* Base Style */
-		.highlight .cm { color: #9A9A9A; font-style: italic; } /* Comment Multiline */
-		.highlight .cp { color: #9A9A9A; font-style: italic; } /* Comment Preproc */
-		.highlight .c1 { color: #9A9A9A; font-style: italic; } /* Comment Single */
-		.highlight .cs { color: #9A9A9A; font-style: italic; } /* Comment Special */
-		.highlight .k { color: #4CBF9C; } /* Base Style */
-		.highlight .kc { color: #4CBF9C; } /* Keyword Constant */
-		.highlight .kd { color: #4CBF9C; } /* Keyword Declaration */
-		.highlight .kn { color: #4CBF9C; } /* Keyword Namespace */
-		.highlight .kp { color: #4CBF9C; } /* Keyword Pseudo */
-		.highlight .kr { color: #4CBF9C; } /* Keyword Reserved */
-		.highlight .kt { color: #4CBF9C; } /* Keyword Type */
-		.highlight .l { color: #3d3d3d; } /* Base Style */
-		.highlight .ld { color: #990f69; } /* Literal Date */
-		.highlight .m { color: #990f69; } /* Literal Number */
-		.highlight .mf { color: #990f69; } /* Literal Number Float */
-		.highlight .mh { color: #990f69; } /* Literal Number Hex */
-		.highlight .mi { color: #990f69; } /* Literal Number Integer */
-		.highlight .mo { color: #990f69; } /* Literal Number Oct */
-		.highlight .il { color: #990f69; } /* Literal Number Integer Long */
-		.highlight .s { color: #E22866; } /* Literal String */
-		.highlight .sb { color: #E22866; } /* Literal String Backtick */
-		.highlight .sc { color: #E22866; } /* Literal String Char */
-		.highlight .sd { color: #E22866; } /* Literal String Doc */
-		.highlight .s2 { color: #E22866; } /* Literal String Double */
-		.highlight .se { color: #990f69; } /* Literal String Escape */
-		.highlight .sh { color: #E22866; } /* Literal String Heredoc */
-		.highlight .si { color: #E22866; } /* Literal String Interpol */
-		.highlight .sx { color: #E22866; } /* Literal String Other */
-		.highlight .sr { color: #990f69; } /* Literal String Regex */
-		.highlight .s1 { color: #E22866; } /* Literal String Single */
-		.highlight .ss { color: #E22866; } /* Literal String Symbol */
-		.highlight .g { color: #3d3d3d; } /* Base Style */
-		.highlight .gd { color: #3d3d3d; } /* Generic Deleted */
-		.highlight .ge { color: #3d3d3d; } /* Generic Emph */
-		.highlight .gr { color: #3d3d3d; } /* Generic Error */
-		.highlight .gh { color: #3d3d3d; } /* Generic Heading */
-		.highlight .gi { color: #3d3d3d; } /* Generic Inserted */
-		.highlight .go { color: #3d3d3d; } /* Generic Output */
-		.highlight .gp { color: #3d3d3d; } /* Generic Prompt */
-		.highlight .gs { color: #3d3d3d; } /* Generic Strong */
-		.highlight .gu { color: #3d3d3d; } /* Generic Subheading */
-		.highlight .gt { color: #3d3d3d; } /* Generic Traceback */
-		.highlight .x { color: #3d3d3d; } /* Other */
-		.highlight .w { color: #3d3d3d; } /* Text Whitespace */
+		.highlight pre { color: $eclipse-2; } /* Base Style */
+		.highlight .p { color: $eclipse-2; } /* Punctuation */
+		.highlight .err { color: $eclipse-2; } /* Error */
+		.highlight .n { color: $dark-cerulean; } /* Base Style */
+		.highlight .na { color: $dark-cerulean; } /* Name Attribute */
+		.highlight .nb { color: $dark-cerulean; } /* Name Builtin */
+		.highlight .nc { color: $dark-cerulean; } /* Name Class */
+		.highlight .no { color: $dark-cerulean; } /* Name Constant */
+		.highlight .nd { color: $dark-cerulean; } /* Name Decorator */
+		.highlight .ni { color: $dark-cerulean; } /* Name Entity */
+		.highlight .ne { color: $dark-cerulean; } /* Name Exception */
+		.highlight .nf { color: $dark-cerulean; } /* Name Function */
+		.highlight .nl { color: $dark-cerulean; } /* Name Label */
+		.highlight .nn { color: $puerto-rico; } /* Name Namespace */
+		.highlight .nx { color: $dark-cerulean; } /* Name Other */
+		.highlight .py { color: $dark-cerulean; } /* Name Property */
+		.highlight .nt { color: $dark-cerulean; } /* Name Tag */
+		.highlight .nv { color: $dark-cerulean; } /* Name Variable */
+		.highlight .vc { color: $dark-cerulean; } /* Name Variable Class */
+		.highlight .vg { color: $dark-cerulean; } /* Name Variable Global */
+		.highlight .vi { color: $dark-cerulean; } /* Name Variable Instance */
+		.highlight .bp { color: $dark-cerulean; } /* Name Builtin Pseudo */
+		.highlight .g { color: $eclipse-2; } /* Base Style */
+		.highlight .gd { color: $eclipse-2; } /*  */
+		.highlight .o { color: $eclipse-2; } /* Base Style */
+		.highlight .ow { color: $puerto-rico; } /* Operator Word */
+		.highlight .c { color: $nobel-2; font-style: italic; }/* Base Style */
+		.highlight .cm { color: $nobel-2; font-style: italic; } /* Comment Multiline */
+		.highlight .cp { color: $nobel-2; font-style: italic; } /* Comment Preproc */
+		.highlight .c1 { color: $nobel-2; font-style: italic; } /* Comment Single */
+		.highlight .cs { color: $nobel-2; font-style: italic; } /* Comment Special */
+		.highlight .k { color: $puerto-rico; } /* Base Style */
+		.highlight .kc { color: $puerto-rico; } /* Keyword Constant */
+		.highlight .kd { color: $puerto-rico; } /* Keyword Declaration */
+		.highlight .kn { color: $puerto-rico; } /* Keyword Namespace */
+		.highlight .kp { color: $puerto-rico; } /* Keyword Pseudo */
+		.highlight .kr { color: $puerto-rico; } /* Keyword Reserved */
+		.highlight .kt { color: $puerto-rico; } /* Keyword Type */
+		.highlight .l { color: $eclipse-2; } /* Base Style */
+		.highlight .ld { color: $jazzberry-jam; } /* Literal Date */
+		.highlight .m { color: $jazzberry-jam; } /* Literal Number */
+		.highlight .mf { color: $jazzberry-jam; } /* Literal Number Float */
+		.highlight .mh { color: $jazzberry-jam; } /* Literal Number Hex */
+		.highlight .mi { color: $jazzberry-jam; } /* Literal Number Integer */
+		.highlight .mo { color: $jazzberry-jam; } /* Literal Number Oct */
+		.highlight .il { color: $jazzberry-jam; } /* Literal Number Integer Long */
+		.highlight .s { color: $cerise; } /* Literal String */
+		.highlight .sb { color: $cerise; } /* Literal String Backtick */
+		.highlight .sc { color: $cerise; } /* Literal String Char */
+		.highlight .sd { color: $cerise; } /* Literal String Doc */
+		.highlight .s2 { color: $cerise; } /* Literal String Double */
+		.highlight .se { color: $jazzberry-jam; } /* Literal String Escape */
+		.highlight .sh { color: $cerise; } /* Literal String Heredoc */
+		.highlight .si { color: $cerise; } /* Literal String Interpol */
+		.highlight .sx { color: $cerise; } /* Literal String Other */
+		.highlight .sr { color: $jazzberry-jam; } /* Literal String Regex */
+		.highlight .s1 { color: $cerise; } /* Literal String Single */
+		.highlight .ss { color: $cerise; } /* Literal String Symbol */
+		.highlight .g { color: $eclipse-2; } /* Base Style */
+		.highlight .gd { color: $eclipse-2; } /* Generic Deleted */
+		.highlight .ge { color: $eclipse-2; } /* Generic Emph */
+		.highlight .gr { color: $eclipse-2; } /* Generic Error */
+		.highlight .gh { color: $eclipse-2; } /* Generic Heading */
+		.highlight .gi { color: $eclipse-2; } /* Generic Inserted */
+		.highlight .go { color: $eclipse-2; } /* Generic Output */
+		.highlight .gp { color: $eclipse-2; } /* Generic Prompt */
+		.highlight .gs { color: $eclipse-2; } /* Generic Strong */
+		.highlight .gu { color: $eclipse-2; } /* Generic Subheading */
+		.highlight .gt { color: $eclipse-2; } /* Generic Traceback */
+		.highlight .x { color: $eclipse-2; } /* Other */
+		.highlight .w { color: $eclipse-2; } /* Text Whitespace */
 
 		#scroll-top-button {
 			position: fixed;
 			bottom: 5%;
 			right: 2%;
 			padding: 1em 2em;
-			background: #f0f0f0;
+			background: $white-smoke-6;
 			font-size: 12px;
-			border: 1px solid #ddd;
+			border: 1px solid $gainsboro-2;
 			opacity: 0;
 			-webkit-transition: .2s opacity ease-in,
 			.2s background ease-in,
@@ -788,7 +788,7 @@
 
 		#scroll-top-button:hover {
 			text-decoration: none;
-			background: #fafafa;
+			background: $white-3;
 		}
 	}
 

--- a/_source/_assets/css/okta/components/_ProductSection.scss
+++ b/_source/_assets/css/okta/components/_ProductSection.scss
@@ -84,9 +84,9 @@
 
 .ProductSection--authentication {
 	@include color('white');
-	background: #007DC1;
-	background: -webkit-linear-gradient(top, #46b3e9 0%, #007dc1 74%, #007dc1 100%);
-	background: linear-gradient(to bottom, #46b3e9 0%, #007dc1 74%, #007dc1 100%);
+	background: $navy-blue;
+	background: -webkit-linear-gradient(top, $summer-sky 0%, $navy-blue 74%, $navy-blue 100%);
+	background: linear-gradient(to bottom, $summer-sky 0%, $navy-blue 74%, $navy-blue 100%);
 
 	header h2 {
 		@include color('white');
@@ -162,8 +162,8 @@
 .ProductSection--api {
 	@include color('white');
 	background: get-color('blue-bright');
-	background: -webkit-linear-gradient(top, #46b3e9 0%, #007dc1 74%, #007dc1 100%);
-	background: linear-gradient(to bottom, #46b3e9 0%, #007dc1 74%, #007dc1 100%);
+	background: -webkit-linear-gradient(top, $summer-sky 0%, $navy-blue 74%, $navy-blue 100%);
+	background: linear-gradient(to bottom, $summer-sky 0%, $navy-blue 74%, $navy-blue 100%);
 
 	header {
 		h2 {

--- a/_source/_assets/css/okta/components/_Swiftype.scss
+++ b/_source/_assets/css/okta/components/_Swiftype.scss
@@ -5,7 +5,7 @@
         color: get-color('cerise');
         &:hover,
         &:active {
-          color: #ff3333;
+          color: $red-orange;
         }
       }
     }

--- a/_source/_assets/css/okta/components/_misc.scss
+++ b/_source/_assets/css/okta/components/_misc.scss
@@ -44,7 +44,7 @@ ul.toc {
 			font-family: fontawesome;
 			content: '\f097';
 			@include font-size('new-small');
-			color: #ccc;
+			color: $very-light-gray;
 			margin-right: 6px;
 		}
 	}

--- a/_source/_assets/css/okta/pages/_code.scss
+++ b/_source/_assets/css/okta/pages/_code.scss
@@ -16,7 +16,7 @@ ul.code-list {
   text-decoration:none;
   border: solid;
   border-width: 1px;
-  border-color: #D2D2D6;
+  border-color: $ghost;
   border-radius: 3px;
 
   .code-icon {
@@ -36,15 +36,15 @@ ul.code-list {
   }
 
   &.inverse {
-    background: #115D8B;
-    border: #115D8B;
+    background: $dark-cerulean;
+    border: $dark-cerulean;
 
     .code-icon::before {
-      color: white;
+      color: $white;
     }
 
     &:link, &:active, &:visited {
-      color: white;
+      color: $white;
     }
   }
 }

--- a/_source/_assets/css/okta/pages/_product.scss
+++ b/_source/_assets/css/okta/pages/_product.scss
@@ -37,7 +37,7 @@
 }
 
 .logo-placard {
-    background: #fff;
+    background: $white;
     display: block;
     height: 180px;
     line-height: 120px;

--- a/_source/_assets/css/okta/pages/_quickstarts.scss
+++ b/_source/_assets/css/okta/pages/_quickstarts.scss
@@ -1,18 +1,18 @@
 .code-selector {
-  background-color: rgb(32, 49, 59);
+  background-color: get-color('ebony-clay');
   border-radius: 5px;
   margin-bottom: 10px;
   padding: 20px;
 
   h3 {
-    color: #fff;
+    color: $white;
     font-size: 18px;
     font-weight: lighter;
     margin-bottom: 5px;
   }
 
   a {
-    color: #fff;
+    color: $white;
     display: inline-block;
     height: 42px;
     line-height: 32px;
@@ -26,7 +26,7 @@
     }
     &.active,
     &:hover {
-      border-bottom: 2px solid #fff;
+      border-bottom: 2px solid $white;
     }
     .icon {
       left: 5px;
@@ -88,11 +88,7 @@
   }
   .TableOfContents-item{
     &.active {
-      border-left-color: rgb(0, 125, 193);
+      border-left-color: get-color('accent');
     }
   }
-}
-
-#server-framework-selector {
-  background-color: rgb(54, 69, 78);
 }


### PR DESCRIPTION
## Description:
- Sweeps current sass files and replaces hex values with named variables.
- In `_source/_assets/css/okta/pages/_quickstarts.scss`, removes a declaration that is no longer used.

There should be no visual or user-facing changes, and I've sanity-checked to QA as much as I can.

Does not touch legacy files for safety. After this change, we should no longer need to introduce one-off or hard-coded color values.

Color names are programmatically generated and are universally unique with our design system. cc @edburyenegren-okta 

### Resolves:
* [UX-1083](https://oktainc.atlassian.net/browse/UX-1083)

