### PR TITLE
remove repeated line from oauth-client doc

### DIFF
--- a/_source/_docs/api/resources/oauth-clients.md
+++ b/_source/_docs/api/resources/oauth-clients.md
@@ -562,12 +562,11 @@ Content-Type: application/json;charset=UTF-8
 ~~~json
 {
   "client_id": "0jrabyQWm4B9zVJPbotY",
-  "client_secret": "t1hgVNl06UiMTzlsVVj0UywSDDuNdG529lm0bpy8",
+  "client_secret": "5W7XULCEs4BJKnWUXwh8lgmeXRhcGcdViFp84pWe",
   "client_id_issued_at": 1453913425,
   "client_secret_expires_at": 0,
   "client_name": "Updated OAuth Client",
   "client_uri": "https://www.example-application.com",
-  "client_secret": "cdUQIFvE61wGI5P51H33ORC4SRB1RXfX",
   "logo_uri": "https://www.example-application.com/logo.png",
   "application_type": "web",
   "redirect_uris": [


### PR DESCRIPTION
## Description:
- There was an extra client secret in one example. Now there's not.

### Resolves:
 [OKTA-166384](https://oktainc.atlassian.net/browse/OKTA-166384)

![image](https://user-images.githubusercontent.com/17009066/38646603-7ec8c13c-3d9d-11e8-8cde-7c545983e405.png)


