### PR TITLE
fix broken link to okta for devs

### DIFF
--- a/_source/_posts/2018-02-20-9-talks-i-cant-wait-to-see-at-iterate.md
+++ b/_source/_posts/2018-02-20-9-talks-i-cant-wait-to-see-at-iterate.md
@@ -58,4 +58,4 @@ I sometimes feel like not such a productive person. I get distracted easily and 
 
 So, those are the nine tracks that I will **not** be missing at our inaugural [Iterate Conference](https://www.iterateconf.io/)! It’s possible that they’re also all of the sessions at Iterate. Thank goodness we’ll have the video up on our [Youtube channel](https://www.youtube.com/channel/UC5AMiWqFVFxF1q9Ya1FuZ_Q) immediately after the event!
 
-And, now that I’ve shared mine, I have to know, what talks are on **your** list? Reply in the comments, or hit me up on Twitter [@leebrandt](https://twitter.com/leebrandt). You should also follow my team [@okatdev](https://twitter.com/OktaDev) for some day-of goodness.
+And, now that I’ve shared mine, I have to know, what talks are on **your** list? Reply in the comments, or hit me up on Twitter [@leebrandt](https://twitter.com/leebrandt). You should also follow my team [@oktadev](https://twitter.com/OktaDev) for some day-of goodness.

--- a/_source/_posts/2018-02-20-9-talks-i-cant-wait-to-see-at-iterate.md
+++ b/_source/_posts/2018-02-20-9-talks-i-cant-wait-to-see-at-iterate.md
@@ -56,6 +56,6 @@ Craig Kerstiens is a Heroku alum, Python developer, Postgres expert (*cough* fan
 
 I sometimes feel like not such a productive person. I get distracted easily and it can be hard to get back on track. But the bigger problem is: how can I measure my productivity and efficacy? On the days I *do* feel productive, there nothing really definitively saying I was more productive. Even if I got *more things done*, were they smaller or easier? That's what Mahdi Yusuf is going to talk about. How to measure your efficiency, so you can use that measurement to improve. I'm so there!
 
-So, those are the nine tracks that I will **not** be missing at our inaugural [Iterate Conference](https://www.iterateconf.io/)! It’s possible that they’re also all of the sessions at Iterate. Thank goodness we’ll have the video up on our [Youtube channel](https://www.youtube.com/channel/UC5AMiWqFVFxF1q9Ya1FuZ_Q) immediately after the event!
+So, those are the nine tracks that I will **not** be missing at our inaugural [Iterate Conference](https://www.iterateconf.io/)! It’s possible that they’re also all of the sessions at Iterate. Thank goodness we’ll have the video up on our [YouTube channel](https://www.youtube.com/channel/UC5AMiWqFVFxF1q9Ya1FuZ_Q) immediately after the event!
 
 And, now that I’ve shared mine, I have to know, what talks are on **your** list? Reply in the comments, or hit me up on Twitter [@leebrandt](https://twitter.com/leebrandt). You should also follow my team [@oktadev](https://twitter.com/OktaDev) for some day-of goodness.

--- a/_source/_posts/2018-02-20-9-talks-i-cant-wait-to-see-at-iterate.md
+++ b/_source/_posts/2018-02-20-9-talks-i-cant-wait-to-see-at-iterate.md
@@ -56,6 +56,6 @@ Craig Kerstiens is a Heroku alum, Python developer, Postgres expert (*cough* fan
 
 I sometimes feel like not such a productive person. I get distracted easily and it can be hard to get back on track. But the bigger problem is: how can I measure my productivity and efficacy? On the days I *do* feel productive, there nothing really definitively saying I was more productive. Even if I got *more things done*, were they smaller or easier? That's what Mahdi Yusuf is going to talk about. How to measure your efficiency, so you can use that measurement to improve. I'm so there!
 
-So, those are the nine tracks that I will **not** be missing at our inaugural [Iterate Conference](https://www.iterateconf.io/)! It’s possible that they’re also all of the sessions at Iterate. Thank goodness we’ll have the video up on our [Oktadev Youtube channel](https://www.youtube.com/c/oktafordevelopers) immediately after the event!
+So, those are the nine tracks that I will **not** be missing at our inaugural [Iterate Conference](https://www.iterateconf.io/)! It’s possible that they’re also all of the sessions at Iterate. Thank goodness we’ll have the video up on our [Youtube channel](https://www.youtube.com/channel/UC5AMiWqFVFxF1q9Ya1FuZ_Q) immediately after the event!
 
 And, now that I’ve shared mine, I have to know, what talks are on **your** list? Reply in the comments, or hit me up on Twitter [@leebrandt](https://twitter.com/leebrandt). You should also follow my team [@okatdev](https://twitter.com/OktaDev) for some day-of goodness.


### PR DESCRIPTION
## Description:
- link to youtube channel oktadev changed, apparently.

### Resolves:

blog post, no JIRA.