### PR TITLE
Lock down Angular CLI version since v6 has been released

### DIFF
--- a/_source/_posts/2017-03-27-angular-okta-sign-in-widget.md
+++ b/_source/_posts/2017-03-27-angular-okta-sign-in-widget.md
@@ -23,7 +23,7 @@ Angular 4 was [recently released](http://angularjs.blogspot.com/2017/03/angular-
 **NOTE:** This post has been updated to use [Angular 5](https://blog.angular.io/version-5-0-0-of-angular-now-available-37e414935ced) and [Angular CLI 1.5.5](https://github.com/angular/angular-cli/releases/tag/v1.5.5).
 
 ```bash
-npm install -g @angular/cli
+npm install -g @angular/cli@1.5.5
 ```
 
 After this command completes, you can create a new application.

--- a/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
+++ b/_source/_posts/2017-04-17-angular-authentication-with-oidc.md
@@ -25,7 +25,7 @@ git clone https://github.com/mraible/ng-demo.git
 * About 20 minutes
 * A favorite text editor or IDE. I recommend [IntelliJ IDEA](https://www.jetbrains.com/idea/)
 * [Node.js](https://nodejs.org) and npm installed. I recommend using [nvm](https://github.com/creationix/nvm)
-* [Angular CLI](https://cli.angular.io/) installed. If you don’t have Angular CLI installed, install it using `npm install -g @angular/cli`
+* [Angular CLI](https://cli.angular.io/) installed. If you don’t have Angular CLI installed, install it using `npm install -g @angular/cli@1.7.3`
 
 Create a new project using the `ng new` command:
 

--- a/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
+++ b/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
@@ -348,10 +348,10 @@ I hope you’ve enjoyed this quick tour of Kotlin and saw how its concise syntax
 Install Angular CLI using [Facebook’s Yarn](https://yarnpkg.com).
 
 ```bash
-yarn add global @angular/cli
+yarn add global @angular/cli@1.5.5
 ```
 
-Or using npm (`npm install -g @angular/cli`).
+Or using npm (`npm install -g @angular/cli@1.5.5`).
 
 Then create a new project using its `ng` command.
 


### PR DESCRIPTION
It's likely that tutorials don't work with v6, so prevent users from installing it.