### PR TITLE
Specify version for Angular Material so tutorials work

### DIFF
--- a/_source/_posts/2017-05-09-progressive-web-applications-with-angular-and-spring-boot.md
+++ b/_source/_posts/2017-05-09-progressive-web-applications-with-angular-and-spring-boot.md
@@ -89,7 +89,7 @@ Installing [Angular Material](https://material.angular.io/) is not a necessary s
 
 ```bash
 npm install
-npm install --save @angular/material @angular/cdk
+npm install --save-exact @angular/material@5.2.0 @angular/cdk@5.2.0
 ```
 
 Add imports for the modules you'll be using in `app.module.ts`:

--- a/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
+++ b/_source/_posts/2017-09-19-build-a-secure-notes-application-with-kotlin-typescript-and-okta.md
@@ -740,7 +740,7 @@ After signing in, you should see the notes list, but no records in it.
 
 {% img blog/kotlin-secure-notes/notes-list-plain.png alt:"Empty Notes List" %}{: .center-image }
 
-To make sure I could add, edit, and delete notes, I wrote a bunch of TypeScript and HTML. I also added [Angular Material](https://material.angular.io) using `yarn add @angular/material @angular/cdk`. 
+To make sure I could add, edit, and delete notes, I wrote a bunch of TypeScript and HTML. I also added [Angular Material](https://material.angular.io) using `yarn add @angular/material@5.0.0 @angular/cdk@5.0.0`.
 
 You can see the results in [the GitHub repository for this article](https://github.com/oktadeveloper/okta-kotlin-typescript-notes-example). In particular, the code in the following files:
 

--- a/_source/_posts/2017-12-04-basic-crud-angular-and-spring-boot.md
+++ b/_source/_posts/2017-12-04-basic-crud-angular-and-spring-boot.md
@@ -209,7 +209,7 @@ After the client is created, navigate into its directory and install Angular Mat
 
 ```bash
 cd client
-npm install --save @angular/material @angular/cdk
+npm install --save-exact @angular/material@5.2.4 @angular/cdk@5.2.4
 ```
 
 You'll use Angular Material's components to make the UI look better, especially on mobile phones. If you'd like to learn more about Angular Material, see <https://material.angular.io>. It has extensive documentation on its various components and how to use them.


### PR DESCRIPTION
Without versions, people will get Angular Material 6 + doom and gloom.

