### PR TITLE
Change initial clone command to v1.0 tag on repo

### DIFF
--- a/_source/_posts/2017-08-08-secure-spring-microservices.md
+++ b/_source/_posts/2017-08-08-secure-spring-microservices.md
@@ -28,7 +28,7 @@ In this tutorial, you'll build a microservices architecture with Spring Boot and
 To begin, you'll need to clone the aforementioned article's completed project.
 
 ```bash
-git clone https://github.com/oktadeveloper/spring-boot-microservices-example.git
+git clone -b v1.0 https://github.com/oktadeveloper/spring-boot-microservices-example.git
 ```
 
 [Create an Okta Developer account](https://developer.okta.com/signup/), and [create a "Native" application that works with the Stormpath Spring Boot Starter](https://github.com/stormpath/stormpath-sdk-java/blob/okta/OktaGettingStarted.md). Here's an abbreviated list of steps:


### PR DESCRIPTION
This PR updates [Secure a Spring Microservices Architecture with Spring Security, JWTs, Juiser, and Okta](https://developer.okta.com/blog/2017/08/08/secure-spring-microservices) to pin the starting point to [v1.0](https://github.com/oktadeveloper/spring-boot-microservices-example/releases/tag/v1.0) of the spring-boot-microservices-example repo, which uses Spring Boot 1.5.10.

This is necessary because the Stormpath Zuul Starter and Juiser do not work with Spring Boot 2.0. However, it is possible to update the [preceding tutorial](https://developer.okta.com/blog/2017/06/15/build-microservices-architecture-spring-boot) and the [OAuth version](https://developer.okta.com/blog/2018/02/13/secure-spring-microservices-with-oauth) to use Spring Boot 2.0.
