### PR TITLE
Update rate limit documentation

### DIFF
--- a/_source/_docs/api/getting_started/rate-limits.md
+++ b/_source/_docs/api/getting_started/rate-limits.md
@@ -31,27 +31,34 @@ Rate limits differ depending on the level of service you have purchased from Okt
 
 Note that limits for more specific endpoints override the limits for less specific endpoints. For example, the limit for getting an application by ID (second row) is higher than the more general limit for the `/api/v1/apps` endpoint (first row).
 
-| Action and Okta API Endpoint | Developer (free) | Developer (paid) & One App | Enterprise |
-|----------------------------- | ---------------- | -------------------------- | ---------- |
-| **Creating or listing applications:**<br>`/api/v1/apps` except `/api/v1/apps/{id}`        | 20 | 25 |  50 |
-| **Get, update, or delete an application by ID:**<br>`/api/v1/apps/{id}` only              | 100 | 300 | 600 |
-| **Get System Log data:**<br>`/api/v1/logs`                                                | 20 | 25 | 50 |
-| **Get System Log data:**<br>`/api/v1/events`                                              | 20 | 25 | 50 |
-| **Creating, updating, or deleting users:**<br>`/api/v1/users` except `/api/v1/users/{login}`  | 100  | 300 | 600 |
-| **Get a user by login:**<br>`/api/v1/users/{login}` only                                  | 100 | 300 | 1000 |
-| **Create an organization:**<br>`/api/v1/orgs`                                             | N/A | N/A | 50 |
-| **Authentication with a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/authorize` and `/oauth2/{authServerId}/v1/token` | 100 | 300 | 600 |
-| **All other actions:**<br>`/api/v1/`                                                      | 100 | 300 | 600 |
+| Action and Okta API Endpoint | Developer (free) | Developer (paid) & One App | Enterprise     |
+|----------------------------- | ---------------- | -------------------------- | -------------- |
+| **Create or list applications:**<br>`/api/v1/apps` except `/api/v1/apps/{id}`                     | 20  | 25  | 50   |
+| **Get, update, or delete an application by ID:**<br>`/api/v1/apps/{id}` only                      | 100 | 300 | 600  |
+| **Authenticate different end users**<br>`/api/v1/authn`                                           | 100 | 300 | 600  |
+| **Verify factors**:<br>`/api/v1/authn/factors/{id}/verify` only                                   | 100 | 300 | 600  |
+| **Create or list groups**:<br>`/api/v1/groups` except `/api/v1/groups/{id}`                       | 100 | 300 | 600  |
+| **Get, update, or delete a group by ID**:<br>`/api/v1/groups/{id}` only                           | 100 | 300 | 600  |
+| **Create or list users**:<br>Only GET or POST to `/api/v1/users`                                  | 100 | 300 | 600  |
+| **Get a user by ID or login**:<br>Only GET to `/api/v1/users/{idOrLogin}`                         | 100 | 300 | 1000 |
+| **Update or delete a user by ID or login**:<br>Only PUT or DELETE to `/api/v1/users/{idOrLogin}`  | 100 | 300 | 600  |
+| **Get System Log data:**<br>`/api/v1/logs`                                                        | 20  | 25  | 50   |
+| **Get System Log data:**<br>`/api/v1/events`                                                      | 20  | 25  | 50   |
+| **Get session information:**<br>`/api/v1/sessions`                                                | 100 | 300 | 600  |
+| **Create an organization:**<br>`/api/v1/orgs`                                                     | N/A | N/A | 50   |
+| **Authorize request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/authorize`  | 100 | 300 | 600  |
+| **Token request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/token`          | 100 | 300 | 600  |
+| **All other actions:**<br>`/api/v1/`                                                              | 100 | 300 | 600  |
 
-These rate limits apply to all new Okta organizations. For orgs created before 2018-05-22, the [previous rate limits](#okta-api) still apply.
+These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#okta-api) still apply.
 
 ### Okta API Endpoints and Per-User Limits
 API endpoints that take username and password credentials, including the [Authentication API](/docs/api/resources/authn) and the [OAuth 2.0 resource owner password flow](/authentication-guide/implementing-authentication/password), have a per-username rate limit to prevent brute force attacks with the user's password:
 
 | Action                                                                      | Okta API Endpoint  | Per User Limits (All Orgs) |
 | --------------------------------------------------------------------------- | ------------------ | -------------------------: |
-| Generate or refresh an OAuth 2.0 token for the resource owner password flow | `/oauth2/v1/token` | 4 per second               |
 | Authenticate the same user                                                  | `/api/v1/authn`    | 4 per second               |
+| Generate or refresh an OAuth 2.0 token for the resource owner password flow | `/oauth2/v1/token` | 4 per second               |
 
 ### Okta Rate Limits for All Other Endpoints
 
@@ -61,27 +68,27 @@ Finally, for all endpoints not listed in the tables above, the API rate limit is
 | ---------------- | ----------------------------- | ---------- |
 | 1000             | 3,000                         | 6,000      |
 
-For organizations created before 2018-05-22, and all IT Products orgs, the limit is 10,000 requests per minute.
+For organizations created before 2018-05-17, the limit is 10,000 requests per minute.
 
 ### Okta Home Page Endpoints and Per-Minute Limits
 
 The following endpoints are used by the Okta home page for authentication and sign on, and have org-wide rate limits:
 
-| Okta Home Page Endpoints                 | Developer (free) | Developer (paid) & One App | Enterprise |
-| ---------------------------------------- | ---------------- | -------------------------- | ---------- |
-| `/app/{app}/{key}/sso/saml`              | 100              | 300                     | 600           |
-| `/app/office365/{key}/sso/wsfed/active`  | N/A              | N/A                     | 2000          |
-| `/app/office365/{key}/sso/wsfed/passive` | N/A              | N/A                     | 250           |
-| `/app/template_saml_2_0/{key}/sso/saml`  | 100              | 300                     | 600           |
-| `/login/do-login`                        | 100              | 300                     | 600           |
-| `/login/login.htm`                       | 100              | 300                     | 600           |
-| `/login/sso_iwa_auth`                    | 100              | 300                     | 600           |
-| `/api/plugin/{protocolVersion}/form-cred/{appUserIds}/{formSiteOption}` | 100 | 300   | 600           |
-| `/api/plugin/{protocolVersion}/sites`    | 20               | 50                      | 100           |
-| `/bc/image/fileStoreRecord`              | 100              | 300                     | 600           |
-| `/bc/globalFileStoreRecord`              | 100              | 300                     | 600           |
+| Okta Home Page Endpoints                 | Developer (free) | Developer (paid) & One App | Enterprise    |
+| ---------------------------------------- | ---------------- | -------------------------- | ------------- |
+| `/app/{app}/{key}/sso/saml`              | 100              | 300                        | 600           |
+| `/app/office365/{key}/sso/wsfed/active`  | N/A              | N/A                        | 2000          |
+| `/app/office365/{key}/sso/wsfed/passive` | N/A              | N/A                        | 250           |
+| `/app/template_saml_2_0/{key}/sso/saml`  | 100              | 300                        | 600           |
+| `/login/do-login`                        | 100              | 300                        | 600           |
+| `/login/login.htm`                       | 100              | 300                        | 600           |
+| `/login/sso_iwa_auth`                    | 100              | 300                        | 600           |
+| `/api/plugin/{protocolVersion}/form-cred/{appUserIds}/{formSiteOption}` | 100 | 300      | 600           |
+| `/api/plugin/{protocolVersion}/sites`    | 20               | 50                         | 100           |
+| `/bc/image/fileStoreRecord`              | 100              | 300                        | 600           |
+| `/bc/globalFileStoreRecord`              | 100              | 300                        | 600           |
 
-These rate limits apply to all new Okta organizations. For orgs created before 2018-05-22, the [previous rate limits](#home-page-endpoints) still apply.
+These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#home-page-endpoints) still apply.
 
 ### End-User Rate Limit
 
@@ -300,7 +307,7 @@ To request an exception, {{site.contact_support_lc}} 10 days before you need the
 
 ## Legacy Enterprise Limits
 
-These are the rate limits for orgs created before 2018-05-22.
+These are the rate limits for orgs created before 2018-05-17.
 
 ### Okta API
 

--- a/_source/_docs/api/getting_started/rate-limits.md
+++ b/_source/_docs/api/getting_started/rate-limits.md
@@ -29,7 +29,7 @@ Rate limits differ depending on the level of service you have purchased from Okt
 
 ### Okta API Endpoints and Per Minute Limits
 
-Note that limits for more specific endpoints override the limits for less specific endpoints. For example, the limit for getting an application by ID (second row) is higher than the more general limit for the `/api/v1/apps` endpoint (first row).
+Note that limits for more specific endpoints override the limits for less specific endpoints. For example, the limit for getting an application by ID is higher than the more general limit for the `/api/v1/apps` endpoint.
 
 | Action and Okta API Endpoint | Developer (free) | Developer (paid) | One App | Enterprise     |
 |----------------------------- | ---------------- | ---------------- | ------- | -------------- |
@@ -50,7 +50,7 @@ Note that limits for more specific endpoints override the limits for less specif
 | **Token request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/token`              | 100 | 300 | 300 | 600  |
 | **All other actions:**<br>`/api/v1/`                                                                  | 100 | 300 | 300 | 600  |
 
-These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#okta-api) still apply.
+These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#previous-rate-limits) still apply.
 
 ### Okta API Endpoints and Per-User Limits
 API endpoints that take username and password credentials, including the [Authentication API](/docs/api/resources/authn) and the [OAuth 2.0 resource owner password flow](/authentication-guide/implementing-authentication/password), have a per-username rate limit to prevent brute force attacks with the user's password:
@@ -113,7 +113,9 @@ For concurrent rate limits, traffic is measured in three different areas. Counts
 
 The first request to exceed the concurrent limit returns an HTTP 429 error, and the first error every sixty seconds is written to the log. Reporting concurrent rate limits once a minute keeps log volume manageable.
 
-> Important: Under normal circumstances, customers don't exceed the concurrency limits. Exceeding them may be an indication of a problem which requires investigation.
+> Under normal circumstances, customers don't exceed the concurrency limits. Exceeding them may be an indication of a problem which requires investigation.
+
+These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#previous-rate-limits) still apply.
 
 ## Check Your Rate Limits with Okta's Rate Limit Headers
 
@@ -305,11 +307,11 @@ To request an exception, {{site.contact_support_lc}} 10 days before you need the
 * End date and time
 * Business justification: why you need the temporary increase
 
-## Legacy Enterprise Limits
+## Previous Rate Limits
 
 These are the rate limits for orgs created before 2018-05-17.
 
-### Okta API
+### Org-Wide Rate Limits (Older Orgs)
 
 Extensions to the base URLs listed below are included in the specified limit, unless the URL is followed by "only." For example, `/api/v1/apps/{id}` has a per-minute rate limit of `500` as listed in the second line in the table. However, `/api/v1/apps/{id}/users` falls under the more general first line of the table. This pattern applies to all the URLs.
 
@@ -328,7 +330,11 @@ Extensions to the base URLs listed below are included in the specified limit, un
 | Create an org (ISVs only)           | `/api/v1/orgs`                          |   50 |
 | All other actions | `/api/v1/`                                               |  1200 |
 
-### Home Page Endpoints
+### Concurrent Rate Limits (Older Orgs)
+
+For older orgs, the limit is 75 concurrent transactions.
+
+### Home Page Endpoint Limits (Older Orgs)
 
 The following endpoints are used by the Okta home page for authentication and sign on, and have org-wide rate limits:
 

--- a/_source/_docs/api/getting_started/rate-limits.md
+++ b/_source/_docs/api/getting_started/rate-limits.md
@@ -88,7 +88,7 @@ The following endpoints are used by the Okta home page for authentication and si
 | `/bc/image/fileStoreRecord`              | 100              | 300              | 300     | 600           |
 | `/bc/globalFileStoreRecord`              | 100              | 300              | 300     | 600           |
 
-These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#home-page-endpoints) still apply.
+These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#previous-rate-limits) still apply.
 
 ### End-User Rate Limit
 

--- a/_source/_docs/api/getting_started/rate-limits.md
+++ b/_source/_docs/api/getting_started/rate-limits.md
@@ -31,42 +31,42 @@ Rate limits differ depending on the level of service you have purchased from Okt
 
 Note that limits for more specific endpoints override the limits for less specific endpoints. For example, the limit for getting an application by ID (second row) is higher than the more general limit for the `/api/v1/apps` endpoint (first row).
 
-| Action and Okta API Endpoint | Developer (free) | Developer (paid) & One App | Enterprise     |
-|----------------------------- | ---------------- | -------------------------- | -------------- |
-| **Create or list applications:**<br>`/api/v1/apps` except `/api/v1/apps/{id}`                     | 20  | 25  | 50   |
-| **Get, update, or delete an application by ID:**<br>`/api/v1/apps/{id}` only                      | 100 | 300 | 600  |
-| **Authenticate different end users**<br>`/api/v1/authn`                                           | 100 | 300 | 600  |
-| **Verify factors**:<br>`/api/v1/authn/factors/{id}/verify` only                                   | 100 | 300 | 600  |
-| **Create or list groups**:<br>`/api/v1/groups` except `/api/v1/groups/{id}`                       | 100 | 300 | 600  |
-| **Get, update, or delete a group by ID**:<br>`/api/v1/groups/{id}` only                           | 100 | 300 | 600  |
-| **Create or list users**:<br>Only GET or POST to `/api/v1/users`                                  | 100 | 300 | 600  |
-| **Get a user by ID or login**:<br>Only GET to `/api/v1/users/{idOrLogin}`                         | 100 | 300 | 1000 |
-| **Update or delete a user by ID or login**:<br>Only PUT or DELETE to `/api/v1/users/{idOrLogin}`  | 100 | 300 | 600  |
-| **Get System Log data:**<br>`/api/v1/logs`                                                        | 20  | 25  | 50   |
-| **Get System Log data:**<br>`/api/v1/events`                                                      | 20  | 25  | 50   |
-| **Get session information:**<br>`/api/v1/sessions`                                                | 100 | 300 | 600  |
-| **Create an organization:**<br>`/api/v1/orgs`                                                     | N/A | N/A | 50   |
-| **Authorize request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/authorize`  | 100 | 300 | 600  |
-| **Token request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/token`          | 100 | 300 | 600  |
-| **All other actions:**<br>`/api/v1/`                                                              | 100 | 300 | 600  |
+| Action and Okta API Endpoint | Developer (free) | Developer (paid) | One App | Enterprise     |
+|----------------------------- | ---------------- | ---------------- | ------- | -------------- |
+| **Authenticate different end users:**<br>`/api/v1/authn`                                              | 100 | 300 | 300 | 600  |
+| **Verify a factor:**<br>`/api/v1/authn/factors/{id}/verify` only                                      | 100 | 300 | 300 | 600  |
+| **Create or list applications:**<br>`/api/v1/apps` except `/api/v1/apps/{id}`                         | 20  | 25  | 25  | 50   |
+| **Get, update, or delete an application by ID:**<br>`/api/v1/apps/{id}` only                          | 100 | 300 | 300 | 600  |
+| **Create or list groups:**<br>`/api/v1/groups` except `/api/v1/groups/{id}`                           | 100 | 300 | 300 | 600  |
+| **Get, update, or delete a group by ID:**<br>`/api/v1/groups/{id}` only                               | 100 | 300 | 300 | 600  |
+| **Create or list users:**<br>Only `GET` or `POST` to `/api/v1/users`                                  | 100 | 300 | 300 | 600  |
+| **Get a user by ID or login:**<br>Only `GET` to `/api/v1/users/{idOrLogin}`                           | 100 | 300 | 300 | 1000 |
+| **Update or delete a user by ID or login:**<br>Only `PUT` or `DELETE` to `/api/v1/users/{idOrLogin}`  | 100 | 300 | 300 | 600  |
+| **Get System Log data:**<br>`/api/v1/logs`                                                            | 20  | 25  | 25  | 50   |
+| **Get System Log data:**<br>`/api/v1/events`                                                          | 20  | 25  | 25  | 50   |
+| **Get session information:**<br>`/api/v1/sessions`                                                    | 100 | 300 | 300 | 600  |
+| **Create an organization:**<br>`/api/v1/orgs`                                                         | N/A | N/A | N/A | 50   |
+| **Authorize request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/authorize`      | 100 | 300 | 300 | 600  |
+| **Token request to a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/token`              | 100 | 300 | 300 | 600  |
+| **All other actions:**<br>`/api/v1/`                                                                  | 100 | 300 | 300 | 600  |
 
 These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#okta-api) still apply.
 
 ### Okta API Endpoints and Per-User Limits
 API endpoints that take username and password credentials, including the [Authentication API](/docs/api/resources/authn) and the [OAuth 2.0 resource owner password flow](/authentication-guide/implementing-authentication/password), have a per-username rate limit to prevent brute force attacks with the user's password:
 
-| Action                                                                      | Okta API Endpoint  | Per User Limits (All Orgs) |
-| --------------------------------------------------------------------------- | ------------------ | -------------------------: |
-| Authenticate the same user                                                  | `/api/v1/authn`    | 4 per second               |
-| Generate or refresh an OAuth 2.0 token for the resource owner password flow | `/oauth2/v1/token` | 4 per second               |
+| Action and Okta API Endpoint                                      | Per User Limits (All Orgs) |
+| ----------------------------------------------------------------- | -------------------------: |
+| **Authenticate the same user:**<br>`/api/v1/authn`                | 4 per second               |
+| **Generate or refresh an OAuth 2.0 token:**<br>`/oauth2/v1/token` | 4 per second               |
 
 ### Okta Rate Limits for All Other Endpoints
 
 Finally, for all endpoints not listed in the tables above, the API rate limit is a combined rate limit:
 
-| Developer (free) | Developer (paid) & One App    | Enterprise |
-| ---------------- | ----------------------------- | ---------- |
-| 1000             | 3,000                         | 6,000      |
+| Developer (free) | Developer (paid) | One App    | Enterprise |
+| ---------------- | ---------------- | ---------- | ---------- |
+| 1000             | 3000             | 3000       | 6000       |
 
 For organizations created before 2018-05-17, the limit is 10,000 requests per minute.
 
@@ -74,19 +74,19 @@ For organizations created before 2018-05-17, the limit is 10,000 requests per mi
 
 The following endpoints are used by the Okta home page for authentication and sign on, and have org-wide rate limits:
 
-| Okta Home Page Endpoints                 | Developer (free) | Developer (paid) & One App | Enterprise    |
-| ---------------------------------------- | ---------------- | -------------------------- | ------------- |
-| `/app/{app}/{key}/sso/saml`              | 100              | 300                        | 600           |
-| `/app/office365/{key}/sso/wsfed/active`  | N/A              | N/A                        | 2000          |
-| `/app/office365/{key}/sso/wsfed/passive` | N/A              | N/A                        | 250           |
-| `/app/template_saml_2_0/{key}/sso/saml`  | 100              | 300                        | 600           |
-| `/login/do-login`                        | 100              | 300                        | 600           |
-| `/login/login.htm`                       | 100              | 300                        | 600           |
-| `/login/sso_iwa_auth`                    | 100              | 300                        | 600           |
-| `/api/plugin/{protocolVersion}/form-cred/{appUserIds}/{formSiteOption}` | 100 | 300      | 600           |
-| `/api/plugin/{protocolVersion}/sites`    | 20               | 50                         | 100           |
-| `/bc/image/fileStoreRecord`              | 100              | 300                        | 600           |
-| `/bc/globalFileStoreRecord`              | 100              | 300                        | 600           |
+| Okta Home Page Endpoints                 | Developer (free) | Developer (paid) | One App | Enterprise    |
+| ---------------------------------------- | ---------------- | ---------------- | ------- | ------------- |
+| `/app/{app}/{key}/sso/saml`              | 100              | 300              | 300     | 600           |
+| `/app/office365/{key}/sso/wsfed/active`  | N/A              | N/A              | N/A     | 2000          |
+| `/app/office365/{key}/sso/wsfed/passive` | N/A              | N/A              | N/A     | 250           |
+| `/app/template_saml_2_0/{key}/sso/saml`  | 100              | 300              | 300     | 600           |
+| `/login/do-login`                        | 100              | 300              | 300     | 600           |
+| `/login/login.htm`                       | 100              | 300              | 300     | 600           |
+| `/login/sso_iwa_auth`                    | 100              | 300              | 300     | 600           |
+| `/api/plugin/{protocolVersion}/form-cred/{appUserIds}/{formSiteOption}` | 100 | 300 | 300 | 600          |
+| `/api/plugin/{protocolVersion}/sites`    | 20               | 50               | 50      | 100           |
+| `/bc/image/fileStoreRecord`              | 100              | 300              | 300     | 600           |
+| `/bc/globalFileStoreRecord`              | 100              | 300              | 300     | 600           |
 
 These rate limits apply to all new Okta organizations. For orgs created before 2018-05-17, the [previous rate limits](#home-page-endpoints) still apply.
 
@@ -107,9 +107,9 @@ For concurrent rate limits, traffic is measured in three different areas. Counts
 * For Office365 traffic, the limit is 75 concurrent transactions per org.
 * For all other traffic, including API requests, the limit is described in the table below.
 
-| Developer (free) | Developer (paid) & One App    | Enterprise |
-| ---------------- | ----------------------------- | ---------- |
-| 15               | 35                            | 75         |
+| Developer (free) | Developer (paid) | One App    | Enterprise |
+| ---------------- | ---------------- | ---------- | ---------- |
+| 15               | 35               | 35         | 75         |
 
 The first request to exceed the concurrent limit returns an HTTP 429 error, and the first error every sixty seconds is written to the log. Reporting concurrent rate limits once a minute keeps log volume manageable.
 
@@ -313,40 +313,35 @@ These are the rate limits for orgs created before 2018-05-17.
 
 Extensions to the base URLs listed below are included in the specified limit, unless the URL is followed by "only." For example, `/api/v1/apps/{id}` has a per-minute rate limit of `500` as listed in the second line in the table. However, `/api/v1/apps/{id}/users` falls under the more general first line of the table. This pattern applies to all the URLs.
 
-| Action and Okta API Endpoint                                                                           | Legacy Enterprise |
-| ------------------------------------------------------------------------------------------------------ | :---------------: |
-| **Create or list apps:**<br>`/api/v1/apps` except `/api/v1/apps/{id}`                                  | 100               |
-| **Get, update, or delete an application:**<br>`/api/v1/apps/{id}`                                      | 500               |
-| **Authenticate different end users:**<br>`/api/v1/authn`                                               | 500               |
-| **Verify factors:**<br>`/api/v1/authn/factors/{ID}/verify` only                                        | No limit          |
-| **Creating or listing groups:**<br>`/api/v1/groups` except  `/api/v1/groups/{id}`                      | 500               |
-| **Get, update, or delete a group:**<br>`/api/v1/groups/{id}` only                                      | 1000              |
-| **Get System Log data:**<br>`/api/v1/logs`                                                             | 120               |
-| **Get System Log data:**<br>`/api/v1/events`                                                           | No limit          |
-| **Get session information:**<br>`/api/v1/sessions`                                                     | 750               |
-| **Create or list users:**<br>`/api/v1/users` except `/api/v1/users/{id}` and `/api/v1/users/{login}`   | 600               |
-| **Get a user by user ID or login (combined):**<br>`/api/v1/users/{id}` or `/api/v1/users/{login}` only | 2000              |
-| **Update or delete a user by ID:**<br>`/api/v1/users/{id}` only                                        | 600               |
-| **Create an org (ISVs only):**<br>`/api/v1/orgs` (not available in One App)                            | 50                |
-| **Authentication with Custom Authorization Servers:**<br>`/oauth2/{authServerId}/v1/authorize`         | No limit          |
-| **Authentication with Custom Authorization Servers:**<br>`/oauth2/{authServerId}/v1/token`             | No limit          |
-| **All other actions:**<br>`/api/v1/`                                                                   | 1000              |
+| Action | Okta API Endpoint                                             | Per Minute Limit (Older Orgs) |
+|:---------|:--------------------------------------------------------------|-----------------------:|
+| Create or list applications | `/api/v1/apps`   except `/api/v1/apps/{id}`                                     |   100 |
+| Get, update, or delete an application | `/api/v1/apps/{id}` only   |   500 |
+| Authenticate different end users | `/api/v1/authn`                       |   500 |
+| Creating or listing groups | `/api/v1/groups` except  `/api/v1/groups/{id}` |  500 |
+| Get, update, or delete a group | `/api/v1/groups/{id}` only          | 1000 |
+| Get System Log data | `/api/v1/logs`                                           | 120 |
+| Get session information | `/api/v1/sessions`                               |   750 |
+| Create or list users | `/api/v1/users` except `/api/v1/users/{id}` and `/api/v1/users/{login}`    |   600 |
+| Get a user by user ID or login (combined) | `/api/v1/users/{id}` or `/api/v1/users/{login}`  only   | 2000 |
+| Update or delete a user by ID | `/api/v1/users/{id}` only     |   600 |
+| Create an org (ISVs only)           | `/api/v1/orgs`                          |   50 |
+| All other actions | `/api/v1/`                                               |  1200 |
 
 ### Home Page Endpoints
 
 The following endpoints are used by the Okta home page for authentication and sign on, and have org-wide rate limits:
 
-| Okta Home Page Endpoints                                                | Legacy Enterprise |
-| ----------------------------------------------------------------------- | ----------------: |
-| `/api/v1/apps` access by Admins only (no end-user access)               | 100               |
-| `/app/{app}/{key}/sso/saml`                                             | 750               |
-| `/app/office365/{key}/sso/wsfed/active`                                 | 2000              |
-| `/app/office365/{key}/sso/wsfed/passive`                                | 250               |
-| `/app/template_saml_2_0/{key}/sso/saml`                                 | 2500              |
-| `/login/do-login`                                                       | 200               |
-| `/login/login.htm`                                                      | 850               |
-| `/login/sso_iwa_auth`                                                   | 500               |
-| `/api/plugin/{protocolVersion}/form-cred/{appUserIds}/{formSiteOption}` | 650               |
-| `/api/plugin/{protocol version}/sites`                                  | 150               |
-| `/bc/image/fileStoreRecord`                                             | 500               |
-| `/bc/globalFileStoreRecord`                                             | 500               |
+| Okta Home Page Endpoints                 | Per-Minute Limit |
+|:-----------------------------------------|------:|
+| `/app/{app}/{key}/sso/saml`              |   750 |
+| `/app/office365/{key}/sso/wsfed/active`  |  2000 |
+| `/app/office365/{key}/sso/wsfed/passive` |   250 |
+| `/app/template_saml_2_0/{key}/sso/saml`  |  2500 |
+| `/login/do-login`                        |   200 |
+| `/login/login.htm`                       |   850 |
+| `/login/sso_iwa_auth`                    |   500 |
+| `/api/plugin/{protocolVersion}/form-cred/{appUserIds}/{formSiteOption}`     |   650 |
+| `/api/plugin/{protocolVersion}/sites`    |   150 |
+| `/bc/fileStoreRecord`                          |    500 |
+| `/bc/globalFileStoreRecord`               |    500 |

--- a/_source/_docs/api/getting_started/rate-limits.md
+++ b/_source/_docs/api/getting_started/rate-limits.md
@@ -22,65 +22,73 @@ Rate limits may be changed to protect customers. We provide advance warning of c
 
 API rate limits apply per minute or per second to the endpoints in an org.
 
-If an org-wide rate limit is exceeded, an HTTP 429 Status Code is returned.
+If an org-wide rate limit is exceeded, an HTTP 429 status code is returned.
 You can anticipate hitting the rate limit by checking [Okta's rate limiting headers](#check-your-rate-limits-with-oktas-rate-limit-headers).
 
-When reading the following tables, remember that a more specific limit is considered separately from a more general limit on the same base URI. For example, when you are updating an application, the rate limit for creating or listing an application is not also applied.
+Rate limits differ depending on the level of service you have purchased from Okta. See the [pricing page](https://developer.okta.com/pricing/) for more details.
 
 ### Okta API Endpoints and Per Minute Limits
 
-Extensions to the base URLs listed below are included in the specified limit, unless the URL is followed by "only." For example, `/api/v1/apps/{id}` has a per-minute rate limit of 500 as listed in the second line in the table. However, `/api/v1/apps/{id}/users` falls under the more general first line of the table. This pattern applies to all the URLs.
+Note that limits for more specific endpoints override the limits for less specific endpoints. For example, the limit for getting an application by ID (second row) is higher than the more general limit for the `/api/v1/apps` endpoint (first row).
 
-| Action | Okta API Endpoint                                             | Per Minute Limit |
-|:---------|:--------------------------------------------------------------|-----------------------:|
-| Create or list applications | `/api/v1/apps`   except `/api/v1/apps/{id}`                                     |   100 |
-| Get, update, or delete an application | `/api/v1/apps/{id}` only   |   500 |
-| Authenticate different end users | `/api/v1/authn`                       |   500 |
-| Creating or listing groups | `/api/v1/groups` except  `/api/v1/groups/{id}` |  500 |
-| Get, update, or delete a group | `/api/v1/groups/{id}` only          | 1000 |
-| Get System Log data | `/api/v1/logs`                                           | 120 |
-| Get session information | `/api/v1/sessions`                               |   750 |
-| Create or list users | `/api/v1/users` except `/api/v1/users/{id}` and `/api/v1/users/{login}`    |   600 |
-| Get a user by user ID or login (combined) | `/api/v1/users/{id}` or `/api/v1/users/{login}`  only   | 2000 |
-| Update or delete a user by ID | `/api/v1/users/{id}` only     |   600 |
-| Create an org (ISVs only)           | `/api/v1/orgs`                          |   50 |
-| All other actions | `/api/v1/`                                               |  1200 |
+| Action and Okta API Endpoint | Developer (free) | Developer (paid) & One App | Enterprise |
+|----------------------------- | ---------------- | -------------------------- | ---------- |
+| **Creating or listing applications:**<br>`/api/v1/apps` except `/api/v1/apps/{id}`        | 20 | 25 |  50 |
+| **Get, update, or delete an application by ID:**<br>`/api/v1/apps/{id}` only              | 100 | 300 | 600 |
+| **Get System Log data:**<br>`/api/v1/logs`                                                | 20 | 25 | 50 |
+| **Get System Log data:**<br>`/api/v1/events`                                              | 20 | 25 | 50 |
+| **Creating, updating, or deleting users:**<br>`/api/v1/users` except `/api/v1/users/{login}`  | 100  | 300 | 600 |
+| **Get a user by login:**<br>`/api/v1/users/{login}` only                                  | 100 | 300 | 1000 |
+| **Create an organization:**<br>`/api/v1/orgs`                                             | N/A | N/A | 50 |
+| **Authentication with a custom Authorization Server:**<br>`/oauth2/{authServerId}/v1/authorize` and `/oauth2/{authServerId}/v1/token` | 100 | 300 | 600 |
+| **All other actions:**<br>`/api/v1/`                                                      | 100 | 300 | 600 |
+
+These rate limits apply to all new Okta organizations. For orgs created before 2018-05-22, the [previous rate limits](#okta-api) still apply.
 
 ### Okta API Endpoints and Per-User Limits
 API endpoints that take username and password credentials, including the [Authentication API](/docs/api/resources/authn) and the [OAuth 2.0 resource owner password flow](/authentication-guide/implementing-authentication/password), have a per-username rate limit to prevent brute force attacks with the user's password:
 
-| Action | Okta API Endpoint                           | Per Second Limit |
-|:-------- | :----------------------------------------------------------|-------:|
-| Generate or refresh an OAuth 2.0 token for the resource owner password flow | `/oauth2/v1/token`    |      4 |
-| Authenticate the same user | `/api/v1/authn/`           |      4 |
+| Action                                                                      | Okta API Endpoint  | Per User Limits (All Orgs) |
+| --------------------------------------------------------------------------- | ------------------ | -------------------------: |
+| Generate or refresh an OAuth 2.0 token for the resource owner password flow | `/oauth2/v1/token` | 4 per second               |
+| Authenticate the same user                                                  | `/api/v1/authn`    | 4 per second               |
 
 ### Okta Rate Limits for All Other Endpoints
-Finally, for all endpoints not listed in the tables above, the API rate limit is a combined 10,000 requests per minute. 
+
+Finally, for all endpoints not listed in the tables above, the API rate limit is a combined rate limit:
+
+| Developer (free) | Developer (paid) & One App    | Enterprise |
+| ---------------- | ----------------------------- | ---------- |
+| 1000             | 3,000                         | 6,000      |
+
+For organizations created before 2018-05-22, and all IT Products orgs, the limit is 10,000 requests per minute.
 
 ### Okta Home Page Endpoints and Per-Minute Limits
 
 The following endpoints are used by the Okta home page for authentication and sign on, and have org-wide rate limits:
 
-| Okta Home Page Endpoints                 | Per-Minute Limit |
-|:-----------------------------------------|------:|
-| `/app/{app}/{key}/sso/saml`              |   750 |
-| `/app/office365/{key}/sso/wsfed/active`  |  2000 |
-| `/app/office365/{key}/sso/wsfed/passive` |   250 |
-| `/app/template_saml_2_0/{key}/sso/saml`  |  2500 |
-| `/login/do-login`                        |   200 |
-| `/login/login.htm`                       |   850 |
-| `/login/sso_iwa_auth`                    |   500 |
-| `/api/plugin/{protocol version}/form-cred/{app user IDs}/{form site option}`     |   650 |
-| `/api/plugin/{protocol version}/sites`    |   150 |
-| `/bc/fileStoreRecord`                          |    500 |
-| `/bc/globalFileStoreRecord`               |    500 |
+| Okta Home Page Endpoints                 | Developer (free) | Developer (paid) & One App | Enterprise |
+| ---------------------------------------- | ---------------- | -------------------------- | ---------- |
+| `/app/{app}/{key}/sso/saml`              | 100              | 300                     | 600           |
+| `/app/office365/{key}/sso/wsfed/active`  | N/A              | N/A                     | 2000          |
+| `/app/office365/{key}/sso/wsfed/passive` | N/A              | N/A                     | 250           |
+| `/app/template_saml_2_0/{key}/sso/saml`  | 100              | 300                     | 600           |
+| `/login/do-login`                        | 100              | 300                     | 600           |
+| `/login/login.htm`                       | 100              | 300                     | 600           |
+| `/login/sso_iwa_auth`                    | 100              | 300                     | 600           |
+| `/api/plugin/{protocolVersion}/form-cred/{appUserIds}/{formSiteOption}` | 100 | 300   | 600           |
+| `/api/plugin/{protocolVersion}/sites`    | 20               | 50                      | 100           |
+| `/bc/image/fileStoreRecord`              | 100              | 300                     | 600           |
+| `/bc/globalFileStoreRecord`              | 100              | 300                     | 600           |
+
+These rate limits apply to all new Okta organizations. For orgs created before 2018-05-22, the [previous rate limits](#home-page-endpoints) still apply.
 
 ### End-User Rate Limit
 
-Okta limits the number of requests from the administrator UI to 40 requests per user per 10 seconds per endpoint. This rate limit protects users from each other, and from other API requests in the system. 
+Okta limits the number of requests from the administrator and end-user UI to 40 requests per user per 10 seconds per endpoint. This rate limit protects users from each other, and from other API requests in the system.
 
 If a user exceeds this limit, they receive an HTTP 429 response without affecting other users in your org.
-A message is written to the System Log indicating that the end-user rate limit was encountered. 
+A message is written to the System Log indicating that the end-user rate limit was encountered.
 
 ## Concurrent Rate Limits
 
@@ -90,9 +98,11 @@ For concurrent rate limits, traffic is measured in three different areas. Counts
 
 * For agent traffic, Okta has set the limit based on typical org usage. This limit varies from agent to agent.
 * For Office365 traffic, the limit is 75 concurrent transactions per org.
-* For all other traffic including API requests, the limit is 75 concurrent transactions per org.
+* For all other traffic, including API requests, the limit is described in the table below.
 
-Okta has verified that these limits are sufficient based on current usage. As a result of verification, we increased the limit for some orgs to 150 transactions.
+| Developer (free) | Developer (paid) & One App    | Enterprise |
+| ---------------- | ----------------------------- | ---------- |
+| 15               | 35                            | 75         |
 
 The first request to exceed the concurrent limit returns an HTTP 429 error, and the first error every sixty seconds is written to the log. Reporting concurrent rate limits once a minute keeps log volume manageable.
 
@@ -100,7 +110,7 @@ The first request to exceed the concurrent limit returns an HTTP 429 error, and 
 
 ## Check Your Rate Limits with Okta's Rate Limit Headers
 
-Okta provides three headers in each response to report on both concurrent and org-wide rate limits. 
+Okta provides three headers in each response to report on both concurrent and org-wide rate limits.
 
 For org-wide rate limits, the three headers show the limit that is being enforced, when it resets, and how close you are to hitting the limit:
 * `X-Rate-Limit-Limit` - the rate limit ceiling that is applicable for the current request.
@@ -111,28 +121,28 @@ For example:
 
 ~~~ http
 HTTP/1.1 200 OK
-X-Rate-Limit-Limit  10000
-X-Rate-Limit-Remaining  9999
-X-Rate-Limit-Reset  1516307596
+X-Rate-Limit-Limit: 10000
+X-Rate-Limit-Remaining: 9999
+X-Rate-Limit-Reset: 1516307596
 ~~~
 
 The best way to be sure about org-wide rate limits is to check the relevant headers in the response. The System Log doesn't report every
 API request. Rather, it typically reports completed or attempted real-world events such as configuration changes, user logins, or user lockouts.
-The System Log doesn’t report the rate at which you’ve been calling the API.
+The System Log doesn't report the rate at which you've been calling the API.
 
 Instead of the accumulated counts for time-based rate limits, when a request exceeds the limit for concurrent requests,
-`X-Rate-Limit-Limit`, `X-Rate-Limit-Remaining`, and `X-Rate-Limit-Reset` report the concurrent values. 
+`X-Rate-Limit-Limit`, `X-Rate-Limit-Remaining`, and `X-Rate-Limit-Reset` report the concurrent values.
 
 The three headers behave a little differently for concurrent rate limits: when the number of unfinished requests is below the concurrent rate limit, request headers only report org-wide rate limits.
 When you exceed a concurrent rate limit threshold, the headers report that the limit has been exceeded. When you drop back down below the concurrent rate limit, the headers  switch back to reporting the time-based rate limits.
 Additionally, the `X-Rate-Limit-Reset` time for concurrent rate limits is only a suggestion. There's no guarantee that enough requests will complete to stop exceeding the concurrent rate limit at the time indicated.
 
-### Example Rate Limit Header with Org-Wide Rate Limit  
+### Example Rate Limit Header with Org-Wide Rate Limit
 
 This example shows the relevant portion of a rate limit header being returned with  for a request that hasn't exceeded the org-wide rate limit for the `/api/v1/users` endpoint:
 
 ~~~http
-HTTP/1.1 200 
+HTTP/1.1 200
 Date: Tue, 27 Jan 2018 21:33:25 GMT
 X-Rate-Limit-Limit: 600
 X-Rate-Limit-Remaining: 598
@@ -142,19 +152,19 @@ X-Rate-Limit-Reset: 1516308901
 The following example show a rate limit header being returned for a request that has exceeded the rate limit for the `/api/v1/users` endpoint:
 
 ~~~http
-HTTP/1.1 429 
+HTTP/1.1 429
 Date: Tue, 27 Jan 2018 21:33:25 GMT
 X-Rate-Limit-Limit: 600
 X-Rate-Limit-Remaining: 0
 X-Rate-Limit-Reset: 1516308966
 ~~~
 
-### Example Rate Limit Header with Concurrent Rate Limit  
+### Example Rate Limit Header with Concurrent Rate Limit
 
 This example shows the relevant portion of a rate limit header being returned with the error for a request that exceeded the concurrent rate limit. If the rate limit wasn't being exceeded, the headers would contain information about the org-wide rate limit. You won't ever see non-error concurrent rate limits in the headers.
 
 ~~~http
-HTTP/1.1 429 
+HTTP/1.1 429
 Date: Tue, 26 Jan 2018 21:33:25 GMT
 X-Rate-Limit-Limit: 0
 X-Rate-Limit-Remaining: 0
@@ -203,77 +213,77 @@ The error condition resolves itself as soon as there is another concurrent threa
 
 ~~~json
 {
-        "actor": {
-            "alternateId": "test.user@test.com",
-            "detailEntry": null,
-            "displayName": "Test User",
-            "id": "00u1qqxig80SMWArY0g7",
-            "type": "User"
+    "actor": {
+        "alternateId": "test.user@test.com",
+        "detailEntry": null,
+        "displayName": "Test User",
+        "id": "00u1qqxig80SMWArY0g7",
+        "type": "User"
+    },
+    "authenticationContext": {
+        "authenticationProvider": null,
+        "authenticationStep": 0,
+        "credentialProvider": null,
+        "credentialType": null,
+        "externalSessionId": "trs2TSSLkgWR5iDuebwuH9Vsw",
+        "interface": null,
+        "issuer": null
+    },
+    "client": {
+        "device": "Unknown",
+        "geographicalContext": null,
+        "id": null,
+        "ipAddress": "4.15.16.10",
+        "userAgent": {
+            "browser": "UNKNOWN",
+            "os": "Unknown",
+            "rawUserAgent": "Apache-HttpClient/4.5.2 (Java/1.7.0_76)"
         },
-        "authenticationContext": {
-            "authenticationProvider": null,
-            "authenticationStep": 0,
-            "credentialProvider": null,
-            "credentialType": null,
-            "externalSessionId": "trs2TSSLkgWR5iDuebwuH9Vsw",
-            "interface": null,
-            "issuer": null
-        },
-        "client": {
-            "device": "Unknown",
-            "geographicalContext": null,
-            "id": null,
-            "ipAddress": "4.15.16.10",
-            "userAgent": {
-                "browser": "UNKNOWN",
-                "os": "Unknown",
-                "rawUserAgent": "Apache-HttpClient/4.5.2 (Java/1.7.0_76)"
+        "zone": "null"
+    },
+    "debugContext": {
+        "debugData": {
+            "requestUri": "/api/v1/users"
+        }
+    },
+    "displayMessage": "Too many requests in flight",
+    "eventType": "core.concurrency.org.limit.violation",
+    "legacyEventType": "core.concurrency.org.limit.violation",
+    "outcome": null,
+    "published": "2018-01-26T20:21:32.783Z",
+    "request": {
+        "ipChain": [
+            {
+                "geographicalContext": null,
+                "ip": "4.15.16.10",
+                "source": null,
+                "version": "V4"
             },
-            "zone": "null"
-        },
-        "debugContext": {
-            "debugData": {
-                "requestUri": "/api/v1/users"
+            {
+                "geographicalContext": null,
+                "ip": "52.22.142.162",
+                "source": null,
+                "version": "V4"
             }
-        },
-        "displayMessage": "Too many requests in flight",
-        "eventType": "core.concurrency.org.limit.violation",
-        "legacyEventType": "core.concurrency.org.limit.violation",
-        "outcome": null,
-        "published": "2018-01-26T20:21:32.783Z",
-        "request": {
-            "ipChain": [
-                {
-                    "geographicalContext": null,
-                    "ip": "4.15.16.10",
-                    "source": null,
-                    "version": "V4"
-                },
-                {
-                    "geographicalContext": null,
-                    "ip": "52.22.142.162",
-                    "source": null,
-                    "version": "V4"
-                }
-            ]
-        },
-        "securityContext": {
-            "asNumber": null,
-            "asOrg": null,
-            "domain": null,
-            "isProxy": null,
-            "isp": null
-        },
-        "severity": "INFO",
-        "target": null,
-        "transaction": {
-            "detail": {},
-            "id": "Wcq2zDtj7xjvEu-gRMigPwAACYM",
-            "type": "WEB"
-        },
-        "uuid": "dc7e2385-74ba-4b77-827f-fb84b37a4b3b",
-        "version": "0"
-    }
+        ]
+    },
+    "securityContext": {
+        "asNumber": null,
+        "asOrg": null,
+        "domain": null,
+        "isProxy": null,
+        "isp": null
+    },
+    "severity": "INFO",
+    "target": null,
+    "transaction": {
+        "detail": {},
+        "id": "Wcq2zDtj7xjvEu-gRMigPwAACYM",
+        "type": "WEB"
+    },
+    "uuid": "dc7e2385-74ba-4b77-827f-fb84b37a4b3b",
+    "version": "0"
+}
 ~~~
 
 ## Requesting Exceptions
@@ -282,8 +292,54 @@ You can request a temporary rate limit increase. For example, if you are importi
 
 To request an exception, {{site.contact_support_lc}} 10 days before you need the increase, and provide the following details:
 
-* Your Org Name: the entire URL, for example https://cloudcompany.okta.com or https://unicorn.oktapreview.com
-* Endpoints and Rates: the URI that need to have their limits increased and how much of an increase is required
+* Your Org Name: the entire URL, for example `https://cloudcompany.okta.com` or `https://unicorn.oktapreview.com`
+* Endpoints and rates: the URI that need to have their limits increased and how much of an increase is required
 * Start date and time
 * End date and time
-* Business Justification: why you need the temporary increase
+* Business justification: why you need the temporary increase
+
+## Legacy Enterprise Limits
+
+These are the rate limits for orgs created before 2018-05-22.
+
+### Okta API
+
+Extensions to the base URLs listed below are included in the specified limit, unless the URL is followed by "only." For example, `/api/v1/apps/{id}` has a per-minute rate limit of `500` as listed in the second line in the table. However, `/api/v1/apps/{id}/users` falls under the more general first line of the table. This pattern applies to all the URLs.
+
+| Action and Okta API Endpoint                                                                           | Legacy Enterprise |
+| ------------------------------------------------------------------------------------------------------ | :---------------: |
+| **Create or list apps:**<br>`/api/v1/apps` except `/api/v1/apps/{id}`                                  | 100               |
+| **Get, update, or delete an application:**<br>`/api/v1/apps/{id}`                                      | 500               |
+| **Authenticate different end users:**<br>`/api/v1/authn`                                               | 500               |
+| **Verify factors:**<br>`/api/v1/authn/factors/{ID}/verify` only                                        | No limit          |
+| **Creating or listing groups:**<br>`/api/v1/groups` except  `/api/v1/groups/{id}`                      | 500               |
+| **Get, update, or delete a group:**<br>`/api/v1/groups/{id}` only                                      | 1000              |
+| **Get System Log data:**<br>`/api/v1/logs`                                                             | 120               |
+| **Get System Log data:**<br>`/api/v1/events`                                                           | No limit          |
+| **Get session information:**<br>`/api/v1/sessions`                                                     | 750               |
+| **Create or list users:**<br>`/api/v1/users` except `/api/v1/users/{id}` and `/api/v1/users/{login}`   | 600               |
+| **Get a user by user ID or login (combined):**<br>`/api/v1/users/{id}` or `/api/v1/users/{login}` only | 2000              |
+| **Update or delete a user by ID:**<br>`/api/v1/users/{id}` only                                        | 600               |
+| **Create an org (ISVs only):**<br>`/api/v1/orgs` (not available in One App)                            | 50                |
+| **Authentication with Custom Authorization Servers:**<br>`/oauth2/{authServerId}/v1/authorize`         | No limit          |
+| **Authentication with Custom Authorization Servers:**<br>`/oauth2/{authServerId}/v1/token`             | No limit          |
+| **All other actions:**<br>`/api/v1/`                                                                   | 1000              |
+
+### Home Page Endpoints
+
+The following endpoints are used by the Okta home page for authentication and sign on, and have org-wide rate limits:
+
+| Okta Home Page Endpoints                                                | Legacy Enterprise |
+| ----------------------------------------------------------------------- | ----------------: |
+| `/api/v1/apps` access by Admins only (no end-user access)               | 100               |
+| `/app/{app}/{key}/sso/saml`                                             | 750               |
+| `/app/office365/{key}/sso/wsfed/active`                                 | 2000              |
+| `/app/office365/{key}/sso/wsfed/passive`                                | 250               |
+| `/app/template_saml_2_0/{key}/sso/saml`                                 | 2500              |
+| `/login/do-login`                                                       | 200               |
+| `/login/login.htm`                                                      | 850               |
+| `/login/sso_iwa_auth`                                                   | 500               |
+| `/api/plugin/{protocolVersion}/form-cred/{appUserIds}/{formSiteOption}` | 650               |
+| `/api/plugin/{protocol version}/sites`                                  | 150               |
+| `/bc/image/fileStoreRecord`                                             | 500               |
+| `/bc/globalFileStoreRecord`                                             | 500               |

--- a/_source/_docs/api/resources/system_log.md
+++ b/_source/_docs/api/resources/system_log.md
@@ -527,7 +527,7 @@ The following sections outline the major event types captured by the system log.
 
 Rate limit warnings are sent at different times, depending on the org type. For One App and Enterprise orgs, the warning is sent when the org is at 60% of its limit.
 
-> Note: For orgs created before 2018-05-22, the warning is sent at 90%.
+> Note: For orgs created before 2018-05-17, the warning is sent at 90%.
 
 Rate limit violations are sent when a rate limit is exceeded.
 

--- a/_source/_docs/api/resources/system_log.md
+++ b/_source/_docs/api/resources/system_log.md
@@ -9,10 +9,10 @@ title: System Log
 
 The Okta System Log records system events related to your organization in order to provide an audit trail that can be used to understand platform activity and to diagnose problems.
 
-The Okta System Log API provides near real-time read-only access to your organization's system log and is the programmatic counterpart of the [System Log UI](https://help.okta.com/en/prod/Content/Topics/Reports/Reports_SysLog.htm). 
+The Okta System Log API provides near real-time read-only access to your organization's system log and is the programmatic counterpart of the [System Log UI](https://help.okta.com/en/prod/Content/Topics/Reports/Reports_SysLog.htm).
 
-Often the terms "event" and "log event" are used interchangeably. In the context of this API, an "event" is an occurrence of interest within the system and "log" or "log event" is the recorded fact.  
- 
+Often the terms "event" and "log event" are used interchangeably. In the context of this API, an "event" is an occurrence of interest within the system and "log" or "log event" is the recorded fact.
+
 Notes on the System Log API:
 
 * It contains much more [structured data](#logevent-object) than the [Events API](/docs/api/resources/events#event-model).
@@ -22,7 +22,7 @@ Notes on the System Log API:
   * System monitoring.
   * Development debugging.
   * Event introspection and audit.
-* It is not intended to be used as a Database as a Service (DBaaS), or otherwise directly serve data to downstream consumers without an intermediate data store. 
+* It is not intended to be used as a Database as a Service (DBaaS), or otherwise directly serve data to downstream consumers without an intermediate data store.
 
 ## Getting Started
 
@@ -32,7 +32,7 @@ The System Log API has one endpoint:
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/9cfb0dd661a5432a77c6){:target="_blank"}
 
-This collection resource is backed by a [LogEvent object](#logevent-object) model and associated [event types](#event-types). 
+This collection resource is backed by a [LogEvent object](#logevent-object) model and associated [event types](#event-types).
 
 See [Examples](#examples) for ways you can use the System Log API. For common use cases see [Useful System Log Queries](https://support.okta.com/help/Documentation/Knowledge_Article/Useful-System-Log-Queries).
 
@@ -518,6 +518,19 @@ The following sections outline the major event types captured by the system log.
 * `policy.evaluate_sign_on` provides context on the values used and evaluated in the context of the Okta sign on policy. For example, you can determine which network zones were matched for this event.
 * For `policy.lifecycle` and `policy.rule` events, the corresponding policy is listed in the target object.
 
+### System Events
+
+| Event              | Description                         |
+|:-------------------|:------------------------------------|
+| system.org.rate_limit.warning | An endpoint is near its [rate limit](/docs/api/getting_started/rate-limits).  |
+| system.org.rate_limit.violation | An endpoint has exceeded its [rate limit](/docs/api/getting_started/rate-limits). |
+
+Rate limit warnings are sent at different times, depending on the org type. For One App and Enterprise orgs, the warning is sent when the org is at 60% of its limit.
+
+> Note: For orgs created before 2018-05-22, the warning is sent at 90%.
+
+Rate limit violations are sent when a rate limit is exceeded.
+
 ### User Events
 
 | Event                     | Description                                               |
@@ -594,7 +607,7 @@ The table below summarizes the supported query parameters:
 
 ###### Expression Filter
 
-An expression filter is useful for performing structured queries where constraints on LogEvent attribute values can be explicitly targeted.  
+An expression filter is useful for performing structured queries where constraints on LogEvent attribute values can be explicitly targeted.
 
 The following expressions are supported for events with the `filter` query parameter:
 
@@ -812,4 +825,4 @@ curl -v -X GET \
 
 and retrieve the next page of events through the [`Link` response header](/docs/api/getting_started/design_principles#link-header) value with the `next` link relation. Continue this process until no events are returned.
 
-> Do not attempt to transfer data by manually paginating using `since` and `until` as this may lead to skipped or duplicated events. Instead, always follow the `next` links. 
+> Do not attempt to transfer data by manually paginating using `since` and `until` as this may lead to skipped or duplicated events. Instead, always follow the `next` links.


### PR DESCRIPTION
## Description:
- Update rate limits for Enterprise orgs, and add limits for Developer (free), Developer (paid), and One App orgs.
- Some limits are now the same, and don't need to be printed separately. Those rows have been removed.
- Clean up minor bugs in text.

### Resolves:
[OKTA-169183](https://oktainc.atlassian.net/browse/OKTA-169183)

