### PR TITLE
Updates PHP quickstart

### DIFF
--- a/_source/quickstart-fragments/php/generic-implicit.md
+++ b/_source/quickstart-fragments/php/generic-implicit.md
@@ -42,7 +42,6 @@ Our client side application is going to be sending us a call to an api endpoint 
 
 Our first step is to include the composer autoload file.  In your new `messages.php` file, add the following:
 
-
 > NOTE: All code blocks will be added progressively to the file. The full file is provided at the end of this quickstart.
 
 ```php?start_inline=true
@@ -96,6 +95,7 @@ try {
     // Setup the JWT Verifier.
     $jwtVerifier = ( new \Okta\JwtVerifier\JwtVerifierBuilder() )
         ->setAdaptor( new \Okta\JwtVerifier\Adaptors\SpomkyLabsJose() )
+        ->setClientId( '{clientId}' )
         ->setIssuer( 'https://{yourOktaDomain}.com/oauth2/default' )
         ->build();
 
@@ -103,16 +103,6 @@ try {
     $jwt = $jwtVerifier->verify( $authData );
 } catch (\Exception $e) {
     // We encountered an error, return a 401.
-    return http_response_code( 401 );
-}
-```
-
-If the verify method was successful, we will now have access to all the claims of the token. We need to check and
-make sure that the `cid` (ClientId) from the token matches what our ClientId is from the authoriztation server.
-
-```php?start_inline=true
-// Check to make sure the client id is valid.
-if( $jwt->getClaims()['cid'] != '{clientId}') {
     return http_response_code( 401 );
 }
 ```
@@ -177,6 +167,7 @@ try {
     // Setup the JWT Verifier.
     $jwtVerifier = ( new \Okta\JwtVerifier\JwtVerifierBuilder() )
         ->setAdaptor( new \Okta\JwtVerifier\Adaptors\SpomkyLabsJose() )
+        ->setClientId( '{clientId}' )
         ->setIssuer( 'https://{yourOktaDomain}.com/oauth2/default' )
         ->build();
 
@@ -188,11 +179,6 @@ try {
     return http_response_code( 401 );
 }
 
-// Check to make sure the client id is valid.
-if( $jwt->getClaims()['cid'] != '{clientId}') {
-    return http_response_code( 401 );
-}
-
 //JWT is valid!
 print json_encode([
     'messages' => [
@@ -200,7 +186,6 @@ print json_encode([
         'message 2'
     ]
 ]);
-
 ```
 
 [PHP Sample Applications for Okta]: https://github.com/okta/samples-php


### PR DESCRIPTION
## Description:
- Moves the `setClientId` method into the main `$jwtVerifier` constructor to match the [`README`](https://github.com/okta/okta-jwt-verifier-php#usage)

### Resolves:
<!-- Required for Okta-generated PRs -->
* [OKTA-172033](https://oktainc.atlassian.net/browse/OKTA-172033)

