### PR TITLE
Changes to remove the references to ON_NETWORK and OFF_NETWORK

### DIFF
--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -830,11 +830,10 @@ Specific zone ids to include or exclude are enumerated in the respective arrays.
 
 Parameter | Description | Data Type | Required |
 | --- | --- | --- | ---
-connection | Network selection mode | `ANYWHERE`, `ZONE`, `ON_NETWORK`, or `OFF_NETWORK` | No |
+connection | Network selection mode | `ANYWHERE`, `ZONE` | No |
 include | The zones to include | Array | Only if connection data type is `ZONE` |
 exclude | The zones to exclude | Array | Only if connection data type is `ZONE` |
 
-> The `ON_NETWORK` and `OFF_NETWORK` data types are part of a {% api_lifecycle deprecated %} feature. Backward compatibility is maintained, but using `ZONE` is preferred.
 > The connection parameter may be set to the `ZONE` data type to select individual network zones.
 
 #### Network Condition Object Example
@@ -848,6 +847,21 @@ exclude | The zones to exclude | Array | Only if connection data type is `ZONE` 
     ]
   }
 ~~~
+
+If you want to include or exclude all zones, you should pass in "ALL_ZONES" as the only element in the include or exclude array
+
+#### Network Condition Object Example (exclude all zones)
+{: #NetworkConditionObjectExample }
+
+~~~json
+  "network": {
+    "connection": "ZONE",
+    "exclude": [
+      "ALL_ZONES"
+    ]
+  }
+~~~
+
 
 #### Authentication Provider Condition Object
 {: #AuthProviderConditionObject }


### PR DESCRIPTION
Related to OKTA-173191
Bacon: test

## Description:
- Remove the support for ON_NETWORK and OFF_NETWORK in policy API.

NOTE: npm start fails locally and could not build the local version of the site. Will investigate that before merging this in.

### Resolves:
* [OKTA-173191](https://oktainc.atlassian.net/browse/OKTA-173191)

@jakubvul @eklein-okta @dannavarro-okta @richardblaylock-okta please review

