### PR TITLE
Adding yarn to the PATH to fix publish.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,8 @@ fi
 # Use latest version of Node
 setup_service node v10.7.0
 
+export PATH="${PATH}:$(yarn global bin)"
+
 # Install required dependencies
 npm install -g @okta/ci-update-package
 npm install -g @okta/ci-pkginfo


### PR DESCRIPTION
## Description:
- Adds yarn to the $PATH to fix `/root/okta/okta.github.io/scripts/publish.sh: line 82: ci-update-package: command not found` error

### Resolves:
* [OKTA-182540](https://oktainc.atlassian.net/browse/OKTA-182540)

Primary reviewers:
@jmelberg-okta 
@bdemers 

Addition reviewers:
@rchild-okta 