### PR TITLE
Fix Okta Signup and Playground links in Secure Spring Boot post

### DIFF
--- a/_source/_posts/2018-07-30-10-ways-to-secure-spring-boot.md
+++ b/_source/_posts/2018-07-30-10-ways-to-secure-spring-boot.md
@@ -177,9 +177,9 @@ spring:
 
 **NOTE:** Using `issuer-uri` is only supported in Spring Security 5.1, which is under active development and scheduled for release in September 2018.
 
-You can set up your own OIDC Server using an open source system like [Keycloak](https://www.keycloak.org/). If you'd rather not maintain your own server in production, you can use Okta's Developer APIs. Sign up today for a free account and get 1000 active users per month at developer.okta.com/signup!
+You can set up your own OIDC Server using an open source system like [Keycloak](https://www.keycloak.org/). If you'd rather not maintain your own server in production, you can use Okta's Developer APIs. Sign up today for a free account and get 1000 active users per month at [developer.okta.com/signup](https://developer.okta.com/signup/)!
 
-If you want to play with OAuth 2.0, OIDC, and the different flows it allows, see https://www.oauth.com/playground/. This site does not require you to create an account, but it does use Okta's Developer APIs under the covers.
+If you want to play with OAuth 2.0, OIDC, and the different flows it allows, see [https://www.oauth.com/playground](https://www.oauth.com/playground/). This site does not require you to create an account, but it does use Okta's Developer APIs under the covers.
 
 ## 7. Managing Passwords? Use Password Hashing!
 


### PR DESCRIPTION
Links seem to work when using a desktop browser, but not on mobile Safari.