### PR TITLE
Nate's basket of documentation fixes no. 3

### DIFF
--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -496,8 +496,8 @@ HTTP 200 OK
 HTTP 401 Unauthorized
 Content-Type: application/json;charset=UTF-8
 {
-    "error" : "invalid_client",
-    "error_description" : "No client credentials found."
+    "error": "invalid_client",
+    "error_description": "No client credentials found."
 }
 ~~~
 
@@ -508,36 +508,35 @@ Content-Type: application/json;charset=UTF-8
 
 > This endpoint's base URL will vary depending on whether you are using a custom authorization server or not. For more information, see [Composing Your Base URL](#composing-your-base-url).
 
-The API takes an ID token and logs the user out of the Okta session if the subject matches the current Okta session. A `post_logout_redirect_uri` may be specified to redirect the User after the logout has been performed. Otherwise, the user is redirected to the Okta login page.
-
 Use this operation to log out a user by removing their Okta browser session.
+
+This endpoint takes an ID token and logs the user out of Okta if the subject matches the current Okta session. A `post_logout_redirect_uri` may be specified to redirect the browser after the logout has been performed. Otherwise, the browser is redirected to the Okta login page.
+
+If no Okta session exists, this endpoint has no effect and the browser is redirected immediately to the Okta login page or the `post_logout_redirect_uri` (if specified).
 
 #### Request Parameters
 
-The following parameters can be posted as a part of the URL-encoded form values to the API.
+The following parameters can be included in the query string of the request:
 
-| Parameter                | Description                                                                                                                                     | Type   | Required |
-|:-------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|:-------|:---------|
-| id_token_hint            | A valid ID token with a subject matching the current session.                                                                                   | String | TRUE     |
-| post_logout_redirect_uri | Callback location to redirect to after the logout has been performed. It must match the value preregistered in Okta during client registration. | String | FALSE    |
-| state                    | If the request contained a `state` parameter, then the same unmodified value is returned back in the response.                                  | String | FALSE    |
+| Parameter                | Description                                                                                                                              | Type   |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-------|
+| id_token_hint            | **Required**. A valid ID token with a subject matching the current session.                                                              | String |
+| post_logout_redirect_uri | Location to redirect to after the logout has been performed. It must match the value preregistered in Okta during client registration.   | String |
+| state                    | Any `state` value is included in the redirect to the `post_logout_redirect_uri`.                                                         | String |
 
 #### Request Examples
 
-This request initiates a logout and will redirect to the Okta login page on success.
+This request initiates a logout and will redirect to the Okta login page.
 
 ~~~sh
-curl -v -X GET \
-"https://{baseUrl}/logout?
-  id_token_hint=${id_token_hint}
+GET https://{baseUrl}/logout?id_token_hint=${id_token}
 ~~~
 
-This request initiates a logout and will redirect to the `post_logout_redirect_uri` on success.
+This request initiates a logout and will redirect to the `post_logout_redirect_uri`.
 
 ~~~sh
-curl -v -X GET \
-"https://{baseUrl}/logout?
-  id_token_hint=${id_token_hint}&
+GET https://{baseUrl}/logout?
+  id_token_hint=${id_token}&
   post_logout_redirect_uri=${post_logout_redirect_uri}&
   state=${state}
 ~~~
@@ -545,24 +544,17 @@ curl -v -X GET \
 #### Response Example (Success)
 
 ~~~http
-HTTP 302 FOUND
+HTTP 302 Found
+Location: https://...
 ~~~
 
-Followed by either a redirect to your org's login URL, or (if applicable) the specified logout redirect URI.
+This will redirect the browser to either the Okta login page or the specified logout redirect URI.
 
-#### Response Example (Error)
+#### Error Conditions
 
-~~~http
-HTTP 403 Forbidden
-Content-Type: application/json;charset=UTF-8
-{
-    "errorCode": "E0000005",
-    "errorSummary": "Invalid session",
-    "errorLink": "E0000005",
-    "errorId": "oae4uSVaLVbRTOoRB_EsrXMWw",
-    "errorCauses": []
-}
-~~~
+If the Okta session has expired (or does not exist), a logout request will simply redirect to the Okta login page or the `post_logout_redirect_uri` (if specified).
+
+If the ID token passed via `id_token_hint` is invalid or expired, the browser will be redirected to an error page.
 
 ### /keys
 {:.api .api-operation}

--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -518,11 +518,11 @@ If no Okta session exists, this endpoint has no effect and the browser is redire
 
 The following parameters can be included in the query string of the request:
 
-| Parameter                | Description                                                                                                                              | Type   |
-|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-------|
-| id_token_hint            | **Required**. A valid ID token with a subject matching the current session.                                                              | String |
-| post_logout_redirect_uri | Location to redirect to after the logout has been performed. It must match the value preregistered in Okta during client registration.   | String |
-| state                    | Any `state` value is included in the redirect to the `post_logout_redirect_uri`.                                                         | String |
+| Parameter                | Description                                                                                                                              | Type   | Required
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:-------|:--------
+| id_token_hint            | A valid ID token with a subject matching the current session.                                                                            | String | TRUE
+| post_logout_redirect_uri | Location to redirect to after the logout has been performed. It must match the value preregistered in Okta during client registration.   | String | FALSE
+| state                    | An optional value that is returned as a query parameter during the redirect to the `post_logout_redirect_uri`.                           | String | FALSE
 
 #### Request Examples
 
@@ -545,7 +545,7 @@ GET https://{baseUrl}/logout?
 
 ~~~http
 HTTP 302 Found
-Location: https://...
+Location: https://example.com/post_logout/redirect&state=${state}
 ~~~
 
 This will redirect the browser to either the Okta login page or the specified logout redirect URI.

--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -23,6 +23,10 @@ The policy API supports the following **rule operations**:
 * Create, read, update, and delete a rule for a policy
 * Activate and deactivate a rule
 
+## Getting Started
+
+Explore the Policy API: [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/0dfd99e544a12ea3db5b)
+
 ## Policy API Operations
 
 ### Get a Policy

--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -2726,12 +2726,11 @@ Lists all grants for the specified user
 | userId    | ID of the user for whom you are fetching grants                                              | URL        | String   | TRUE     |         |
 | expand    | Valid value: `scope`. If specified, scope details are included in the `_embedded` attribute. | Query      | String   | FALSE    |         |
 | scopeId   | The scope ID to filter on                                                                    | Query      | String   | FALSE    |         |
-| limit     | The maximum number of grants to return                                                       | Query      | Number   | FALSE    | 20      |
+| limit     | The number of grants to return (maximum 200)                                                       | Query      | Number   | FALSE    | 20      |
 | after     | Specifies the pagination cursor for the next page of grants                                  | Query      | String   | FALSE    |         |
 
-> Note: The after cursor should treated as an opaque value and obtained through [the next link relation](/docs/api/getting_started/design_principles#pagination).
+> Note: `after` should treated as a cursor (an opaque value) and obtained through [the next link relation](/docs/api/getting_started/design_principles#pagination).
 
-* The maximum value for `limit` is 200.
 
 #### Request Example
 {:.api .api-request .api-request-example}
@@ -2898,10 +2897,8 @@ Lists all grants for a specified user and client
 | userId    | ID of the user whose grants you are listing for the specified `clientId`                     | URL            | String   | TRUE     |         |
 | clientId  | ID of the client whose grants you are listing for the specified `userId`                     | URL            | String   | TRUE     |         |
 | expand    | Valid value: `scope`. If specified, scope details are included in the `_embedded` attribute. | Query          | String   | FALSE    |         |
-| limit     | The maximum number of tokens to return                                                       | Query          | Number   | FALSE    | 20      |
+| limit     | The number of tokens to return (maximum 200)                                                       | Query          | Number   | FALSE    | 20      |
 | after     | Specifies the pagination cursor for the next page of tokens                                  | Query          | String   | FALSE    |         |
-
-* The maximum value for `limit` is 200.
 
 #### Request Example
 {:.api .api-request .api-request-example}
@@ -3094,12 +3091,11 @@ Lists all tokens for the specified user and client
 | userId    | ID of the user for whom you are fetching tokens                                              | URL        | String   | TRUE     |         |
 | clientId  | ID of the client                                                                             | URL        | String   | TRUE     |         |
 | expand    | Valid value: `scope`. If specified, scope details are included in the `_embedded` attribute. | Query      | String   | FALSE    |         |
-| limit     | The maximum number of tokens to return                                                       | Query      | Number   | FALSE    | 20      |
+| limit     | The number of tokens to return (maximum 200)                                                       | Query      | Number   | FALSE    | 20      |
 | after     | Specifies the pagination cursor for the next page of tokens                                  | Query      | String   | FALSE    |         |
 
-> Note: The after cursor should treated as an opaque value and obtained through [the next link relation](/docs/api/getting_started/design_principles#pagination).
+> Note: `after` should treated as a cursor (an opaque value) and obtained through [the next link relation](/docs/api/getting_started/design_principles#pagination).
 
-* The maximum value for `limit` is 200.
 
 #### Request Example
 {:.api .api-request .api-request-example}
@@ -3181,12 +3177,11 @@ Gets a token for the specified user and client
 | clientId  | ID of the client                                                                             | URL        | String   | TRUE     |         |
 | tokenId   | ID of the token                                                                             | URL        | String   | TRUE     |         |
 | expand    | Valid value: `scope`. If specified, scope details are included in the `_embedded` attribute. | Query      | String   | FALSE    |         |
-| limit     | The maximum number of grants to return                                                       | Query      | Number   | FALSE    | 20      |
+| limit     | The number of grants to return (maximum 200)                                                      | Query      | Number   | FALSE    | 20      |
 | after     | Specifies the pagination cursor for the next page of grants                                  | Query      | String   | FALSE    |         |
 
-> Note: The after cursor should treated as an opaque value and obtained through [the next link relation](/docs/api/getting_started/design_principles#pagination).
+> Note: `after` should treated as a cursor (an opaque value) and obtained through [the next link relation](/docs/api/getting_started/design_principles#pagination).
 
-* The maximum value for `limit` is 200.
 
 #### Request Example
 {:.api .api-request .api-request-example}
@@ -4156,27 +4151,28 @@ Specifies the authentication provider that validates the user's password credent
 
 ### Links Object
 
-Specifies link relations (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the current status of a user.  The Links Object is used for dynamic discovery of relaed resources and lifecycle or credential operations.  The Links Object is **read-only**.
+Specifies link relations (See [Web Linking](http://tools.ietf.org/html/rfc5988)) available for the current status of a user.  The Links object is used for dynamic discovery of related resources, lifecycle operations, and credential operations.  The Links object is read-only.
 
-#### Individual Users vs Collection of Users
+#### Individual Users vs. Collection of Users
 
-For an individual User result, the Links Object contains a full set of link relations available for that User as determined by Policy. For a collection of Users, the Links Object contains only the self link. Operations that return a collection of Users include [List Users](#list-users) and [List Group Members](groups#list-group-members).
+For an individual User result, the Links object contains a full set of link relations available for that User as determined by your policies. For a collection of Users, the Links object contains only the `self` link. Operations that return a collection of Users include [List Users](#list-users) and [List Group Members](groups#list-group-members).
 
+Here are some links that may be available on a User, as determined by your policies:
 
-| Link Relation Type     | Description                                                                                                                                           |
-|:-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------|
-| self                   | The actual user                                                                                                                                       |
-| activate               | [Lifecycle action](#activate-user) to transition user to `ACTIVE` status                                                                              |
-| deactivate             | [Lifecycle action](#deactivate-user) to transition user to `DEPROVISIONED` status                                                                     |
-| suspend                | [Lifecycle action](#suspend-user) to transition user to `SUSPENDED` status                                                                            |
-| unsuspend              | [Lifecycle action](#unsuspend-user) to return a user to `ACTIVE` status when their current status is `SUSPENDED`                                      |
-| resetPassword          | [Lifecycle action](#reset-password) to transition user to `RECOVERY` status                                                                           |
-| expirePassword         | [Lifecycle action](#expire-password) to transition user to `PASSWORD_EXPIRED` status                                                                  |
-| resetFactors           | [Lifecycle action](#reset-factors) to reset all the MFA factors for the user                                                                          |
-| unlock                 | [Lifecycle action](#unlock-user) to return a user to `ACTIVE` status when their current status is `LOCKED_OUT` due to exceeding failed login attempts |
-| forgotPassword         | [Resets a user&#8217;s password](#forgot-password) by validating the user&#8217;s recovery credential.                                                |
-| changePassword         | [Changes a user&#8217;s password](#change-password) validating the user&#8217;s current password                                                      |
-| changeRecoveryQuestion | [Changes a user&#8217;s recovery credential](#change-recovery-question) by validating the user&#8217;s current password                               |
+| Link Relation Type     | Description                                                                                                           |
+|:-----------------------|:----------------------------------------------------------------------------------------------------------------------|
+| self                   | A self-referential link to this user                                                                                  |
+| activate               | Lifecycle action to [activate the user](#activate-user)                                                               |
+| deactivate             | Lifecycle action to [deactivate the user](#deactivate-user)                                                           |
+| suspend                | Lifecycle action to [suspend the user](#suspend-user)                                                                 |
+| unsuspend              | Lifecycle action to [unsuspend the user](#unsuspend-user)                                                             |
+| resetPassword          | Lifecycle action to [trigger a password reset](#reset-password)                                                       |
+| expirePassword         | Lifecycle action to [expire the user's password](#expire-password)                                                    |
+| resetFactors           | Lifecycle action to [reset all MFA factors](#reset-factors)                                                           |
+| unlock                 | Lifecycle action to [unlock a locked-out user](#unlock-user)                                                          |
+| forgotPassword         | [Resets a user's password](#forgot-password) by validating the user's recovery credential.                            |
+| changePassword         | [Changes a user's password](#change-password) validating the user's current password                                  |
+| changeRecoveryQuestion | [Changes a user's recovery credential](#change-recovery-question) by validating the user's current password           |
 
 ### User-Consent Grant Object
 

--- a/_source/_reference/postman_collections/index.md
+++ b/_source/_reference/postman_collections/index.md
@@ -23,6 +23,7 @@ Import any Okta API collection for Postman from the following list:
 | Identity Providers (IdP)                  |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/00a7a643fc0ab3bb54c8){:target="_blank"} |
 | Linked Objects                            |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/ed4c5606d25d1014b7ea){:target="_blank"} |
 | Logs                                      |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/9cfb0dd661a5432a77c6){:target="_blank"} |
+| Policy                                    |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/0dfd99e544a12ea3db5b){:target="_blank"} |
 | Administrator Roles                               |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/04f5ec85685ac6f2827e){:target="_blank"} |
 | Schemas                                   |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/443242e60287fb4b8d6d){:target="_blank"} |
 | Users                                     |   [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/1755573c5cf5fbf7968b){:target="_blank"} |


### PR DESCRIPTION
Policy API reference
* Add links to the Postman collection for the Policy API 

OIDC reference
* Clean up for formatting and accuracy
* Update logout endpoint to reflect changes in OKTA-180521: expired or no Okta session results in a redirect, not a JSON error. Invalid ID tokens result in an error page redirect.

User API reference
* Minor cleanup of formatting/typos
* Clarify that links returned on the User object may vary depending on your policies

### Resolves
- [OKTA-180521](https://oktainc.atlassian.net/browse/OKTA-180521)