### PR TITLE
System Log API: improve sessionId and tx.id info

### DIFF
--- a/_source/_docs/api/resources/system_log.md
+++ b/_source/_docs/api/resources/system_log.md
@@ -223,7 +223,7 @@ LogEvent objects are read-only. The following properties are available:
 
 > The actor and/or target of an event is dependent on the action performed. All events have actors but not all have targets.
 
-> The `authenticationContext.externalSessionId` identifies events that occurred in the same session. A single `transaction.id` identifies events that occurred together as part of an operation (e.g. a request to Okta's servers). Use `authenticationContext.externalSessionId` to link events that occurred in the same session, and the `transaction.id` to link events that occurred as part of the same operation.
+> See [Event Correlation](#event-correlation) for more on `authenticationContext.externalSessionId` and `transaction.id`.
 
 ### Actor Object
 
@@ -340,8 +340,11 @@ Describes the result of an action and the reason for that result.
 
 ### Transaction Object
 
-The `transaction` object contains metadata associated with the event. This is useful for sourcing and identifying events. For example, a transaction object such as
+The `transaction` field contains a Transaction Object.
 
+A Transaction Object comprises contextual information associated with its respective event. This information is useful for understanding sequences of correlated events (see [Event Correlation](#event-correlation) for more on this).
+
+For example, a Transaction Object such as:
 ```json
 {
     "id": "Wn4f-0RQ8D8lTSLkAmkKdQAADqo",
@@ -350,15 +353,15 @@ The `transaction` object contains metadata associated with the event. This is us
 }
 ```
 
-indicates that a single web request with requestId `Wn4f-0RQ8D8lTSLkAmkKdQAADqo` was responsible for creating this event.
+indicates that a `WEB` request with `id` `Wn4f-0RQ8D8lTSLkAmkKdQAADqo` created this event.
 
-|------------+----------------------------------------------------------------+-----------------+----------|
-| Property   | Description                                                    | DataType        | Nullable |
-| ---------- | -------------------------------------------------------------- | --------------- | -------- |
-| id         | Id of the transaction Object. When the `type` is `WEB`, this field will contain the requestId of the web request. | String | TRUE |
-| type       | Type of transaction. When the transaction is initiated from a single web request, this value is `WEB`. For jobs, this value is `JOB` | String | TRUE |
-| detail     | Details about the transaction                                  | Map[String → Object] | TRUE |
-|------------+----------------------------------------------------------------+-----------------+----------|
+|------------+---------------------------------------------------------------------------------------------------------+----------------------+----------|
+| Property   | Description                                                                                             | DataType             | Nullable |
+| ---------- | ------------------------------------------------------------------------------------------------------- | -------------------- | -------- |
+| id         | Unique identifier for this transaction.                                                                 | String               | TRUE     |
+| type       | Describes the kind of transaction. `WEB` indicates a web request. `JOB` indicates an asynchronous task. | String               | TRUE     |
+| detail     | Details for this transaction.                                                                           | Map[String → Object] | TRUE     |
+|------------+---------------------------------------------------------------------------------------------------------+----------------------+----------|
 
 ### DebugContext Object
 
@@ -547,11 +550,19 @@ Rate limit violations are sent when a rate limit is exceeded.
 * `user.authentication.sso` doesn't capture whether the SSO attempt was successful or failed because Okta can't collect the subsequent authentication attempt status from the third-party service.
 
 
-## Event ID Correlation
+## Event Correlation
 
-Throughout a user's session many requests (transactions) can occur, such as logging into Okta or opening an application. Within a given request many events may be logged. To illustrate this principle, the table below shows 18 events produced from 13 transactions over 6 different sessions, all performed by one user.
+When looking through the System Log, it is often useful to be able to correlate events to understand the thread of events that happened at a particular time.
 
-| External Session ID       | Transaction ID              | Event ID                             | Event Type                                  | Display Message                   |
+The `LogResponse` object offers two identifiers in this respect:
+  - `authenticationContext.externalSessionId`: identifies events that occurred in the same user session.
+  - `transaction.id`: identifies events that occurred together as part of an operation (for example, a request to Okta's servers).
+
+### Event Correlation Example
+
+The table below shows 18 events produced from 13 transactions over 6 different sessions, all performed by one user. Note that `authenticationContext.externalSessionId` is abbreviated to `sessionId` in this table.
+
+| `sessionId`               | `transaction.id`             | `uuid`                             | `eventType`                                  | `displayMessage`                  |
 |:--------------------------|:----------------------------|:-------------------------------------|:--------------------------------------------|:----------------------------------|
 | trs5JnlvlaIQTOqOj9imLy7lA | WcKPxq1f8QLfFvv3UPHhhgAACGM | f24790d0-d324-47f8-aac5-c27a31ab928d | user.session.access_admin_app               | User accessing Okta administrator app     |
 |                           | WcKPxq1f8QLfFvv3UPHhhgAACGM | ed317758-8776-4240-a540-277c44dcb408 | application.lifecycle.update                | Update application                |
@@ -573,7 +584,7 @@ Throughout a user's session many requests (transactions) can occur, such as logg
 | *null*                    | Wm@-R2s5lEMbNIB03krtvAAACyo | 566671be-ec0b-400d-ad2e-6fc73ed12fb1 | user.session.start                          | User login to Okta                |
 {:.table .table-word-break}
 
-Note that, as evidenced by the `null` `External Session ID` field in the last row, neither `Transaction ID` nor `Event ID` maintain a many-to-one relationship with `External Session ID`. In this particular case, the `null` `External Session ID` field can be explained by a failed user login. Since the login failed, no session was granted back to the user's client.
+As evidenced by the `null` `authenticationContext.externalSessionId` field in the last row, neither `transaction.id` nor `uuid` maintain a many-to-one relationship with `authenticationContext.externalSessionId`. In this particular case, the `null` `authenticationContext.externalSessionId` field can be explained by a failed user login. There was no session granted to the user's client since the login failed.
 
 
 ## Operations


### PR DESCRIPTION
## Description:
System Log API: 
 - Move `authenticationContext.externalSessionId` and `transaction.id` descriptions to "Event Correlation" section.
  - Clarify descriptions.
  - Simplify example verbiage.
  - Replace proper nouns in Event Correlation Example table headers with JSON field paths.

![image](https://user-images.githubusercontent.com/26014539/43815797-3e1fa088-9a86-11e8-8dfc-2e4e44d45ac5.png)
![image](https://user-images.githubusercontent.com/26014539/43815804-46a9c9fe-9a86-11e8-9b71-c467da569852.png)
![image](https://user-images.githubusercontent.com/26014539/43815818-54289952-9a86-11e8-94e3-0815c80c557d.png)

### Resolves:
* [OKTA-177766](https://oktainc.atlassian.net/browse/OKTA-177766)

/cc @analytics-okta

