### PR TITLE
set explicit meta tags for facebook and twitter sharing

### DIFF
--- a/_source/_includes/head.html
+++ b/_source/_includes/head.html
@@ -65,6 +65,20 @@
   <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#21313a">
   <meta name="msapplication-config" content="/assets/favicon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
+  {% if page.layout == "blog_post" %}
+  <meta property="og:type"               content="article" />
+  <meta property="og:url"                content="{{ site.external_domain }}{{ page.url }}" />
+  <meta property="og:title"              content="{{ page.title }}" />
+  <meta property="og:description"        content="{{ page.description }}" />
+  {% if page.featured_img %}
+  <meta property="og:image"              content="{{ site.external_domain }}{% asset_path '{{ page.featured_img }}' %}" />
+  {% endif %}
+  <meta property="og:site_name"          content="{{ site.title }}" />
+  <!-- twitter will use the og: tags to show a preview -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@oktadev" />
+  <meta name="twitter:creator" content="@oktadev" />
+  {% endif %}
   <!-- START VWO Tracking -->
   <script type='text/javascript'>
   var _vwo_code=(function(){

--- a/_source/_posts/2018-08-23-symfony-react-php-crud-app.md
+++ b/_source/_posts/2018-08-23-symfony-react-php-crud-app.md
@@ -8,6 +8,7 @@ tweets:
 - "Learn how to use @Symfony and @ReactJS to create a simple CRUD application →"
 - "Create a CRUD application with @Symfony and @ReactJS, and add authentication with Okta! #symfony4"
 - "Look how easy it is to add authentication to a @Symfony app with Okta! #symfony4 #php"
+featured_img: "blog/symfony-react-php-crud-app/movie-list.png"
 ---
 
 Building a modern single-page application can be a daunting task for a sole developer because of the sheer amount of different components you need to get in place – you need a backend API, a dynamic frontend, a decent user interface, and everything has to be secure and scalable. However, with the right tools in place, you can get started quickly without compromising quality or performance. Today I'll show you how to create an app using Symfony 4 as the backend API with a React frontend (and the [React version of Semantic UI](https://react.semantic-ui.com/)) for a hassle-free user interface – I promise you we will write only the bare minimum of HTML, and not a single line of CSS.


### PR DESCRIPTION
This will make our blog posts look a lot better when shared on Twitter, Facebook, Slack and more.

* only sets the tags for pages using the `blog_post` layout
* always sets the title and description tags
* adds new property `featured_img` to explicitly set the featured image for facebook and twitter

Background:

* https://developers.facebook.com/docs/sharing/webmasters
* https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup.html
* https://api.slack.com/docs/message-link-unfurling
