### PR TITLE
Document limit of 20 groups for user creation

### DIFF
--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -137,7 +137,7 @@ curl -v -X POST \
 
 Creates a user without a [password](#password-object)
 
-When the user is activated, an email is sent to the user with an activation token that the can be used to complete the activation process.
+When the user is activated, an email is sent to the user with an activation token that can be used to complete the activation process.
 This flow is useful if migrating users from an existing user store.
 
 ##### Request Example
@@ -498,7 +498,7 @@ curl -v -X POST \
 
 Creates a user that is immediately added to the specified groups upon creation
 
-Use this in conjunction with other create operations for a Group Administrator that is scoped to only create users in specified groups.
+Use this in conjunction with other create operations for a Group Administrator that is scoped to create users only in specified groups.  The request may specify up to 20 group ids.  (This limit applies only when creating a user.  The user may later be added to more groups.)
 
 ##### Request Example
 {:.api .api-request .api-request-example}


### PR DESCRIPTION
## Description:
- Document limit of 20 groups for user creation.
- Also took the opportunity to fix a minor typo elsewhere.

### Resolves:
* [Issue #184773](#184773)
<!-- Required for Okta-generated PRs -->
* [OKTA-184773](https://oktainc.atlassian.net/browse/OKTA-184773)

