### PR TITLE
Describe limit on search-based user queries

### DIFF
--- a/_source/_docs/api/resources/users.md
+++ b/_source/_docs/api/resources/users.md
@@ -1263,11 +1263,11 @@ curl -v -X GET \
 
 > Listing users with search is an {% api_lifecycle ea %} feature and should not be used as a part of any critical flows, like authentication.
 
-Searches for user by the properties specified in the search parameter (case insensitive)
+Searches for users based on the properties specified in the search parameter (case insensitive)
 
 This operation:
 
-* Supports pagination.
+* Supports pagination (to a maximum of 50000 results; see note below).
 * Requires [URL encoding](http://en.wikipedia.org/wiki/Percent-encoding).
 For example, `search=profile.department eq "Engineering"` is encoded as `search=profile.department%20eq%20%22Engineering%22`.
 Examples use cURL-style escaping instead of URL encoding to make them easier to read.
@@ -1286,6 +1286,8 @@ Use an ID lookup for records that you update to ensure your results contain the 
     | `profile.department eq "Engineering"`         | Users that have a `department` of `Engineering` |
     | `profile.occupation eq "Leader"`              | Users that have an `occupation` of `Leader`     |
     | `profile.lastName sw "Sm" `                   | Users whose `lastName` starts with "Sm"         |
+
+> When paginating through a search-based query (see [Pagination](/docs/api/getting_started/design_principles#pagination)), the pages are limited to a total of 50000 results.  If the `limit` parameters of the sequence of pages sum to 50000, attempting to follow the `next` link from the last page will yield an “Invalid search criteria” error.
 
 ##### Search Examples
 


### PR DESCRIPTION
When paginating through the users matching a search-based query, at most 50000 results can be viewed.  The current behavior is a bit rough around the edges (see OKTA-189268) so I describe it as it currently works, where an error is returned if the user tries to follow the "next" link after 50000 results.  We may need to touch up this description after that issue is addressed.

I deliberately avoid mentioning the behavior when fewer than 50000 results have been seen but the "next" link tries to go past 50000.  That cannot arise with the default "limit" of 200 per page (or any other size that evenly divides 50000), and the fix for OKTA-189268 should make it so that pagination always hits 50000 results exactly before yielding an error when requesting the "next" page.

## Description:
- Describe your changes. This will most likely be a copy-paste of your commit
  message(s), which should be descriptive and informative.

### Resolves:
* [Issue #X](#X)
<!-- Required for Okta-generated PRs -->
* [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

