### PR TITLE
[OKTA-190429] Policy API: Correcting name of type value

### DIFF
--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -185,10 +185,6 @@ HTTP 200:
 
 {% api_operation post /api/v1/policies %}
 
-#### Request Parameters
-
-The policy ID described in the [Policy Object](#PolicyObject) is required.
-
 ##### Request Example
 {:.api .api-request .api-request-example}
 
@@ -734,7 +730,7 @@ The Rules model defines several attributes:
 Parameter | Description | Data Type | Required | Default
 | --- | --- | --- | ---
 id | Identifier of the rule | String | No | Assigned
-type | Rule type. Valid values: `OKTA_SIGN_ON` or `PASSWORD` or `MFA_ENROLL` | String (Enum) | Yes |
+type | Rule type. Valid values: `SIGN_ON` or `PASSWORD` or `MFA_ENROLL` | String (Enum) | Yes |
 status | Status of the rule: `ACTIVE` or `INACTIVE` | String (Enum) | No | ACTIVE
 priority | Priority of the rule | Integer | No | Last / Lowest Priority
 system | This is set to 'true' on system rules, which cannot be deleted. | Boolean | No | false


### PR DESCRIPTION
## Description:
- Policy API: Correcting name of type value

One of the values that the 'type' attribute of the Rules object can be set to is SIGN_ON, but the documentation previously gave the value as OKTA_SIGN_ON.

(Note that, confusingly, the Policy object does have 'OKTA_SIGN_ON' as one the values that its 'type' attribute can be set to.)

As a a side issue, I have removed a sentence that said you need to supply Policy ID as a required parameter when calling the  ‘Create a Policy’ API. This didn't makes sense: a Policy you are just creating would not have an ID yet.

### Resolves:

* [OKTA-190429] (https://oktainc.atlassian.net/browse/OKTA-190429)

