### PR TITLE
ai_OKTA-192001_Update_SCIM_1.1_Spec_Test_Suite

### DIFF
--- a/_source/_standards/SCIM/SCIMFiles/Okta-SCIM-11-SPEC-Test.json
+++ b/_source/_standards/SCIM/SCIMFiles/Okta-SCIM-11-SPEC-Test.json
@@ -783,7 +783,10 @@
       "auth": {}, 
       "note": "Required Test: Create Okta user with realisitic values", 
       "headers": {
-        "Authorization": "{{auth}}", 
+        "Authorization": "{{auth}}",
+        "Content-Type": [
+          "application/json"
+        ],
         "Accept": [
           "application/json; charset=utf-8"
         ]
@@ -914,7 +917,10 @@
       "auth": {}, 
       "note": "Required Test: Expect failure when recreating user with same values", 
       "headers": {
-        "Authorization": "{{auth}}", 
+        "Authorization": "{{auth}}",
+        "Content-Type": [
+          "application/json"
+        ],
         "Accept": [
           "application/json; charset=utf-8"
         ]

--- a/_source/_standards/SCIM/SCIMFiles/Okta-SCIM-11-SPEC-Test.json
+++ b/_source/_standards/SCIM/SCIMFiles/Okta-SCIM-11-SPEC-Test.json
@@ -1028,3 +1028,4 @@
   ], 
   "description": "Basic tests to see if your SCIM server will work with Okta"
 }
+


### PR DESCRIPTION
Updated test plan according to OKTA-192001

## Description:
- These two tests in SCIM 1.1 Spec Test Suite (https://developer.okta.com/standards/SCIM/SCIMFiles/Okta-SCIM-11-SPEC-Test.json) do not set the Content-Type Header which causes the customer's SCIM application to fail.

1. 'Required Test: Create Okta user with realisitic values'
2. 'Required Test: Expect failure when recreating user with same values'

SCIM 1.1 specs (http://www.simplecloud.info/specs/draft-scim-api-01.html#create-resource) shows examples of POST request where Content-Type header is set.

### Resolves:

* [OKTA-192001](https://oktainc.atlassian.net/browse/OKTA-192001)

### Reviewers:
@balathiruvalluvan-okta 
@ivanvoloshyn-okta 
