### PR TITLE
[OKTA-159463] Changing description of state property in postMessage Data Model

### DIFF
--- a/_source/_docs/api/resources/oidc.md
+++ b/_source/_docs/api/resources/oidc.md
@@ -143,13 +143,13 @@ Use the postMessage() data model to help you when working with the `okta_post_me
 
 `message`:
 
-| Parameter         | Description                                                                                    | DataType |
-|:------------------|:-----------------------------------------------------------------------------------------------|:---------|
-| access_token      | An [access token](#access-token). This is returned if the `response_type` included `token`.    | String   |
-| error             | The error code, if something went wrong.                                                       | String   |
-| error_description | Additional error information (if any).                                                         | String   |
-| id_token          | An [ID token](#id-token). This is returned if the `response_type` included `id_token`.         | String   |
-| state             | See information on the `state` parameter in [Parameter Details](#parameter-details). | String   |
+| Parameter         | Description                                                                                 | DataType |
+|:------------------|:--------------------------------------------------------------------------------------------|:---------|
+| access_token      | An [access token](#access-token). This is returned if the `response_type` included `token`. | String   |
+| error             | The error code, if something went wrong.                                                    | String   |
+| error_description | Additional error information (if any).                                                      | String   |
+| id_token          | An [ID token](#id-token). This is returned if the `response_type` included `id_token`.      | String   |
+| state             | The unmodified `state` value from the request.                                              | String   |
 
 `targetOrigin`:
 


### PR DESCRIPTION
## Description:
- For clarity, changing the description of the state property, as used in the postMessage() data model. New description: The unmodified `state` value from the request.  

### Resolves:

* [OKTA-159463](https://oktainc.atlassian.net/browse/OKTA-159463)

