### PR TITLE
Update operations table, fixes #2500

### DIFF
--- a/_source/_docs/api/resources/system_log.md
+++ b/_source/_docs/api/resources/system_log.md
@@ -615,7 +615,7 @@ The table below summarizes the supported query parameters:
 | `until`     | Filters the upper time bound of the log events `published` property | The [Internet Date/Time Format profile of ISO 8601](https://tools.ietf.org/html/rfc3339#page-8). An example: `2017-05-03T16:22:18Z` | Current time |
 | `after`     | Used to retrieve the next page of results. Okta returns a link in the HTTP Header (`rel=next`) that includes the after query parameter. | Opaque token           |                         |
 | `filter`    | [Filter Expression](#expression-filter) that filters the results                                      | [SCIM Filter expression](/docs/api/getting_started/design_principles#filtering) |  |
-| `q`         | Filters the log events results by one or more exact [keywords](#keyword-filter)                       | URL encoded string                                       |                         |
+| `q`         | Filters the log events results by one or more exact [keywords](#keyword-filter)                       | URL encoded string. Max length: 40 chars (before encoding)                                      |                         |
 | `sortOrder` | The order of the returned events sorted by `published`                                                | `ASCENDING` or `DESCENDING`                              | `ASCENDING`             |
 | `limit`     | Sets the number of results returned in the response                                                   | Integer between 0 and 1000                                | 100                     |
 |-------------+-------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------|


### PR DESCRIPTION
Include information about limitation for query parameter `q`.

## Description:
Update operations table, fixes #2500.

Include information about limitation for query parameter `q`.

### Resolves:
_No Okta ticket opened_