### PR TITLE
Update version scheme 2018.49 -> 2018.12.0

### DIFF
--- a/_source/_change-log/2018-49.md
+++ b/_source/_change-log/2018-49.md
@@ -3,18 +3,18 @@ layout: docs_page
 title: Okta API Products Change Log
 ---
 
-## 2018.49
+## 2018.12.0
 
 | Change                                                                                                               | Expected in Preview Orgs | Rollout to Production Orgs Expected to Start |
 | -------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------------------------------------------- |
-| [Bug Fixed in 2018.49](#bug-fixed-in-201849)                                                                       | December 5, 2018         | December 10, 2018                             |
-| [Previously Released Early Access Features 2018.49 Update](#previously-released-early-access-features-201849-update) | Available Now            | Available Now                                |
+| [Bug Fixed in 2018.12.0](#bug-fixed-in-2018120)                                                                       | December 5, 2018         | December 10, 2018                             |
+| [Previously Released Early Access Features 2018.12.0 Update](#previously-released-early-access-features-2018120-update) | Available Now            | Available Now                                |
 
-### Bug Fixed in 2018.49
+### Bug Fixed in 2018.12.0
 
 * Queries to the `/logs` endpoint would return an HTTP 500 error if they contained encoded curly braces (`%7B`or `%7D`).
 
-### Previously Released Early Access Features 2018.49 Update
+### Previously Released Early Access Features 2018.12.0 Update
 
 The following features have already been released as Early Access. To enable them, {{site.contact_support_lc}}.
 


### PR DESCRIPTION
TODO: we need to add a note to this page about the version change so it doesn't look as odd that we have two 2018.12's
the current 2018.12.0 and the original 2018.12