### PR TITLE
Remove SAML not supported callout for Idp AppUser operations 

### DIFF
--- a/_source/_docs/api/resources/idps.md
+++ b/_source/_docs/api/resources/idps.md
@@ -3650,7 +3650,7 @@ curl -v -X GET \
 
 {% api_operation GET /api/v1/users/${userId}/idps %}
 
-Lists the IdPs associated with the user. This endpoint doesn't support the SAML2 [Identity Provider Type](#identity-provider-type).
+Lists the IdPs associated with the user.
 
 ##### Request Parameters
 {:.api .api-request .api-request-params}
@@ -3792,7 +3792,7 @@ Content-Type: application/json
 
 {% api_operation GET /api/v1/idps/${idpId}/users/${userId} %}
 
-Fetches a linked [IdP user](#identity-provider-user-model) by ID. This endpoint doesn't support the SAML2 [Identity Provider Type](#identity-provider-type).
+Fetches a linked [IdP user](#identity-provider-user-model) by ID.
 
 ##### Request Parameters
 {:.api .api-request .api-request-params}


### PR DESCRIPTION
## Description:
- Most IdP appuser operations work for all IdP types. 
- Remove callout saying that SAML IdPs are not supported
- One operation (POST /api/v1/idps/{idpId}/users/{userId}) is still not supported, and retains the callout
- https://github.com/okta/okta-core/pull/31352

### Resolves:

* [OKTA-199631](https://oktainc.atlassian.net/browse/OKTA-199631)

###
@larsjohansen-okta @jakubvul 
@federations-okta 

