### PR TITLE
Remove links to Events API docs

### DIFF
--- a/_source/_docs/api/resources/events.md
+++ b/_source/_docs/api/resources/events.md
@@ -2,6 +2,7 @@
 layout: docs_page
 title: Events
 category: management
+deprecated: true
 redirect_from: "/docs/api/rest/events.html"
 ---
 

--- a/_source/_includes/sidebar.html
+++ b/_source/_includes/sidebar.html
@@ -110,7 +110,7 @@
         <a href="/docs/api/resources/roles">Manage Okta Resources</a>
         {% if page.id contains "docs/api/resources" %}
           <ul id="Sidebar_Resources" class="Sidebar-hide">
-            {% assign api_references = site.docs | where: 'category', 'management' | sort: 'title' %}
+            {% assign api_references = site.docs | where: 'category', 'management' | where_exp: 'item', 'item.deprecated != true' | sort: 'title' %}
             {% for doc in api_references %}
               {% if doc.beta %}{% continue %}{% endif %}
               <li{% if doc.title == page.title%} class="is-active"{% endif %}><a href="{{ doc.url }}">{{ doc.title }}</a></li>

--- a/_source/_reference/index.html
+++ b/_source/_reference/index.html
@@ -37,7 +37,7 @@ title: API Reference
     <h2>Manage Okta Resources</h2>
     <p>REST endpoints to configure resources such as users, apps, sessions, and factors whenever you need.</p>
     <ul class="list--multicolumn">
-      {% assign api_references = site.docs | where: 'category', 'management' | sort: 'title' %}
+      {% assign api_references = site.docs | where: 'category', 'management' | where_exp: 'item', 'item.deprecated != true' | sort: 'title' %}
       {% for doc in api_references %}
         {% if doc.beta %}{% continue %}{% endif %}
         <li><a href="{{ doc.url }}">{{ doc.title }}</a></li>


### PR DESCRIPTION
## Description:

Removes links to the (deprecated) Events API docs from the API Reference index sidebar.

## Effect

### Before

![image](https://user-images.githubusercontent.com/26014539/49898303-8ab5cb80-fe0d-11e8-8967-24b188b547c5.png)

![image](https://user-images.githubusercontent.com/26014539/49898339-a02af580-fe0d-11e8-9bbf-22cdf068c3cd.png)

### After

![image](https://user-images.githubusercontent.com/26014539/49898364-afaa3e80-fe0d-11e8-9621-55bf5eab76ee.png)

![image](https://user-images.githubusercontent.com/26014539/49898379-bdf85a80-fe0d-11e8-9d08-cab4d7fd3729.png)

### Resolves:

* [OKTA-198911](https://oktainc.atlassian.net/browse/OKTA-198911)

/cc @okta/analytics 