### PR TITLE
Updating O365 Rate Limit

### DIFF
--- a/_source/_docs/api/getting_started/rate-limits.md
+++ b/_source/_docs/api/getting_started/rate-limits.md
@@ -343,7 +343,7 @@ The following endpoints are used by the Okta home page for authentication and si
 | Okta Home Page Endpoints                 | Per-Minute Limit |
 |:-----------------------------------------|------:|
 | `/app/{app}/{key}/sso/saml`              |   750 |
-| `/app/office365/{key}/sso/wsfed/active`  |  2000 |
+| `/app/office365/{key}/sso/wsfed/active`  |  1000 |
 | `/app/office365/{key}/sso/wsfed/passive` |   250 |
 | `/app/template_saml_2_0/{key}/sso/saml`  |  2500 |
 | `/login/do-login`                        |   200 |


### PR DESCRIPTION
## Description:
- Update to O365 wsfed endpoint rate limit.
- This should go out with the 2019.1.0 update (and be announced in the API change log), though check with @bridgetwent-okta first.

### Resolves:

* [OKTA-201807](https://oktainc.atlassian.net/browse/OKTA-201807)

