### PR TITLE
fix regexp

### DIFF
--- a/scripts/find-missing-slashes.js
+++ b/scripts/find-missing-slashes.js
@@ -13,7 +13,7 @@ const fs = require('fs');
 const readdir = require('recursive-readdir');
 const chalk = require('chalk');
 
-const linkExpr = '<(?:a|area|base|link)[^>]*href\s*=\s*"([^"]+)"';
+const linkExpr = '<(?:a|area|base|link)[^>]*href\\s*=\\s*"([^"]+)"';
 const globalLinkRe = new RegExp(linkExpr, 'g');
 const localLinkRe = new RegExp(linkExpr);
 const linkExtRe = new RegExp('/[^/]+\\.[a-z]+$');


### PR DESCRIPTION
## Description:
when you create a string with a backslash `'\s'` ,it changes it to `'s'`. i assume the intention was to have a regex with `/\s/`, so you need to start with a string  with an escaped backslash: `'\\s'`
