### PR TITLE
Adds version lock for bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
   chrome: stable
   sauce_connect: true
 before_install:
-- gem update bundler
+- gem install bundler -v '< 2'
 - bundle install
 - nvm install $(cat .nvmrc)
 script: "./scripts/travis.sh"


### PR DESCRIPTION
## Description:
Bundler 2.0 causing issues for us. 
- https://travis-ci.community/t/bundle-is-not-installed-for-ruby-2-3/1641/6
- https://status.rubygems.org/incidents/dh3cd8fjd5qw


