### PR TITLE
Manually replacing apostrophes

### DIFF
--- a/_source/_change-log/2019-02-0.md
+++ b/_source/_change-log/2019-02-0.md
@@ -28,7 +28,7 @@ Use of imported hashed passwords when creating or updating users in the [Users A
 
 ### API Access Management Inline Hook
 
-The [API Access Management Inline Hook](/use_cases/inline_hooks/api_am_hook/api_am_hook/) enables you to integrate your own custom functionality into the process of minting OAuth 2.0 and OpenID Connect tokens. <!--OKTA-206634-->
+The [API Access Management Inline Hook](/use_cases/inline_hooks/api_am_hook/api_am_hook) enables you to integrate your own custom functionality into the process of minting OAuth 2.0 and OpenID Connect tokens. <!--OKTA-206634-->
 
 ### Signature and Digest Algorithms for Template WS-Fed Apps
 

--- a/_source/_data/event-types.json
+++ b/_source/_data/event-types.json
@@ -10959,7 +10959,7 @@
     }, {
       "id" : "oauth2.tokens.transform.error.response",
       "category" : "federation",
-      "description" : "Fired when Okta’s authorization server receives a response from an external service and the response format is valid, but the response contains an error. This can also be used to debug why command response erred. When fired, the event contains information about the error summary. Related events include: oauth2_tokens_transform_response.",
+      "description" : "Fired when Okta's authorization server receives a response from an external service and the response format is valid, but the response contains an error. This can also be used to debug why command response erred. When fired, the event contains information about the error summary. Related events include: oauth2_tokens_transform_response.",
       "info" : {
         "created" : "2019-01-25",
         "release" : "2019.01.3"
@@ -10969,7 +10969,7 @@
     }, {
       "id" : "oauth2.tokens.transform.process",
       "category" : "federation",
-      "description" : "Fired when Okta’s authorization server used the command response for token transform, and the token transform failed. This event fires only when the token transform has failed due to the command response from the external server, for example  that the response contained info to transform an access token and an access token was not requested in the request. This can also be used to debug why a token transformation failed. When fired, this event contains information about the entities involved in the inline hook request and response - including the relevant application, user, authorization server, and policy. This event also contains information about why the token transformation failed. Related events include: oauth2_tokens_transform_response.",
+      "description" : "Fired when Okta's authorization server used the command response for token transform, and the token transform failed. This event fires only when the token transform has failed due to the command response from the external server, for example  that the response contained info to transform an access token and an access token was not requested in the request. This can also be used to debug why a token transformation failed. When fired, this event contains information about the entities involved in the inline hook request and response - including the relevant application, user, authorization server, and policy. This event also contains information about why the token transformation failed. Related events include: oauth2_tokens_transform_response.",
       "info" : {
         "created" : "2019-01-25",
         "release" : "2019.01.3"
@@ -10979,7 +10979,7 @@
     }, {
       "id" : "oauth2.tokens.transform.response",
       "category" : "federation",
-      "description" : "Fired when Okta’s authorization server sends an inline hook to an external service. This event fires when the response is successful or when a response is not received. This can be used to audit the details of the entities involved in the inline hook request and response. When fired, this event contains information about the entities involved in the inline hook request and response - including the relevant application, user, authorization server, and policy.",
+      "description" : "Fired when Okta's authorization server sends an inline hook to an external service. This event fires when the response is successful or when a response is not received. This can be used to audit the details of the entities involved in the inline hook request and response. When fired, this event contains information about the entities involved in the inline hook request and response - including the relevant application, user, authorization server, and policy.",
       "info" : {
         "created" : "2019-01-25",
         "release" : "2019.01.3"


### PR DESCRIPTION
Replacing three occurrences of illegal apostrophe with regular one. This problem will cause Travis tests to file for branches made from weekly. 