### PR TITLE
Name Change of API AM Inline Hook to Token Inline Hook in RN

### DIFF
--- a/_source/_change-log/2019-02-0.md
+++ b/_source/_change-log/2019-02-0.md
@@ -11,7 +11,7 @@ title: Okta API Products Change Log
 |-----------------------------------------------------------------------------------------------------------------------|--------------------------|----------------------------------------------|
 | [Imported Hashed User Passwords Generally Available](#imported-hashed-user-passwords-generally-available)                                                     | February 6, 2019         |                                              |
 | [Inline Hooks](#inline-hooks)                                                                                         | February 6, 2019         | February 19                                  |
-| [API Access Management Inline Hook](#api-access-management-inline-hook)                                               | February 6, 2019         | February 19                                  |
+| [Token Inline Hook](#token-inline-hook)                                               | February 6, 2019         | February 19                                  |
 | [Signature and Digest Algorithms for Template WS-FED Apps](#signature-and-digest-algorithms-for-template-ws-fed-apps) | February 6, 2019         | February 19                                  |
 | [Google Integration Updated](#google-integration-updated) | February 6, 2019         | February 19                                  |
 | [High Capacity Rate Limits](#high-capacity-rate-limits) | February 6, 2019         | February 19                                  |
@@ -26,9 +26,9 @@ Use of imported hashed passwords when creating or updating users in the [Users A
 
 [Inline Hooks](/use_cases/inline_hooks/) enable you to integrate your own custom functionality into Okta process flows. The framework to support them is now in Early Access (EA). <!--OKTA-205011-->
 
-### API Access Management Inline Hook
+### Token Inline Hook
 
-The [API Access Management Inline Hook](/use_cases/inline_hooks/api_am_hook/api_am_hook) enables you to integrate your own custom functionality into the process of minting OAuth 2.0 and OpenID Connect tokens. <!--OKTA-206634-->
+The [Token Inline Hook](/use_cases/inline_hooks/api_am_hook/api_am_hook) enables you to integrate your own custom functionality into the process of minting OAuth 2.0 and OpenID Connect tokens. <!--OKTA-206634-->
 
 ### Signature and Digest Algorithms for Template WS-Fed Apps
 


### PR DESCRIPTION
Name of the hook was changed after release. This is to change the name used in the change log.