### PR TITLE
Adds release filter for event type catalog.

### DIFF
--- a/_source/_assets/css/event-types.scss
+++ b/_source/_assets/css/event-types.scss
@@ -7,12 +7,15 @@
     padding-right: 0 !important;
   }
 
-  #event-type-search {
+  #event-type-filter {
     width: 100%;
     border: 2px solid #d2d2d6;
   }
-  #event-type-search::placeholder {
+  #event-type-filter::placeholder {
     color: #d2d2d6;
+  }
+  #event-type-release {
+    margin-top: 1em;
   }
   #event-type-count {
     font-size: 0.9em;

--- a/_source/_assets/js/event-types.js
+++ b/_source/_assets/js/event-types.js
@@ -1,16 +1,20 @@
 $(document).ready(function () {
   // Elements
-  var $search = $("#event-type-search");
+  var $filter = $("#event-type-filter");
+  var $release = $("#event-type-release");
   var $eventTypes = $(".event-type");
   var $eventTypeCount = $("#event-type-count");
 
   // Enable live search
-  $search.keyup(debounce(search, 100));
+  $filter.keyup(debounce(search, 100));
+  $release.change(search);
 
   // Synchronize url state with search
-  var filter = param("q")
-  if (filter) {
-    $search.val(filter);
+  var filter = param("q");
+  var release = param("release");
+  if (filter || release) {
+    $filter.val(filter);
+    $release.val(release)
     search();
   }
 
@@ -19,13 +23,16 @@ $(document).ready(function () {
    */
   function search() {
     var count = 0;
-    var filter = $search.val().trim();
+    var filter = $filter.val().trim();
+    var release = $release.val().trim();
     var regex = new RegExp(filter, "i");
 
     // Hide or show based on match
     $eventTypes.each(function () {
       var $eventType = $(this);
-      if ($eventType.text().search(regex) < 0) {
+      var text = $eventType.text();
+
+      if (text.indexOf(release) < 0 || text.search(regex) < 0) {
         $eventType.hide();
       } else {
         $eventType.show();
@@ -37,7 +44,7 @@ $(document).ready(function () {
     $eventTypeCount.html("Found <b>" + count + "</b> matches");
 
     // Add to URL
-    push('q', filter)
+    push({q: filter, release: release})
   }
 
   /**
@@ -75,15 +82,14 @@ $(document).ready(function () {
   }
 
   /**
-   * Pushes name value pair to current history
-   * 
-   * @param {string} name
-   * @param {string} value
+   * Pushes name-value pairs into the browser push-state history
+   *
+   * @param {object} params
    */
-  function push(name, value){
+  function push(params){
     // Add to URL if supported
     if (history.pushState) {
-      history.pushState(null, '', '?' + name + '=' + encodeURI(value));
+      history.pushState(null, '', '?' + $.param(params));
     }
   }  
 

--- a/_source/_data/event-types.json
+++ b/_source/_data/event-types.json
@@ -11862,7 +11862,7 @@
       "description" : "MFA enrollment notification email sent. Used to notify admins MFA enrollment notification email has been sent.",
       "info" : {
         "created" : "2018-12-10",
-        "release" : "2019.04.1"
+        "release" : "2019.01.1"
       },
       "tags" : [ "email" ],
       "mappings" : [ "core.user.email.message_sent.mfa_enroll_notification" ]
@@ -11872,7 +11872,7 @@
       "description" : "MFA reset notification email sent. Used to notify admins MFA reset notification email has been sent.",
       "info" : {
         "created" : "2018-12-10",
-        "release" : "2019.04.1"
+        "release" : "2019.01.1"
       },
       "tags" : [ "email" ],
       "mappings" : [ "core.user.email.message_sent.mfa_reset_notification" ]
@@ -12572,7 +12572,7 @@
       "description" : "User reported suspicious activity. This event is used to identify user account suspicious activity.",
       "info" : {
         "created" : "2018-12-07",
-        "release" : "2019.04.1"
+        "release" : "2019.01.1"
       },
       "tags" : [ "user", "webhook-eligible" ],
       "mappings" : [ "core.user.account.report_suspicious_activity_by_enduser" ]

--- a/_source/_docs/api/resources/event-types.md
+++ b/_source/_docs/api/resources/event-types.md
@@ -23,7 +23,14 @@ The relationship between System Log API and Events API event types is generally 
 
 <br>
 {%- assign eventTypes = site.data.event-types.versions[1].eventTypes | sort: "id" -%}
-<input type="text" id="event-type-search" name="filter" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search event types for...">
+{%- assign releases = eventTypes | map: "info" | map: "release" | uniq | sort | reverse -%}
+<input type="text" id="event-type-filter" name="filter" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search event types for...">
+<select id="event-type-release" name="release" markdown="block">
+  <option value="">All Releases</option>
+{%- for release in releases -%}
+  <option value="{{ release }}">{{ release }}</option>
+{%- endfor -%}
+</select>
 <div id="event-type-count">Found <b>{{ eventTypes.size }}</b> matches</div>
 {% for eventType in eventTypes %}
 <div class="event-type" markdown="block">


### PR DESCRIPTION
## Description:

In order to aid users in finding new event types by release, this PR adds a release filter to the [event type catalog page](https://developer.okta.com/docs/api/resources/event-types) to supplement the existing live search.

### Page Context
![image](https://user-images.githubusercontent.com/25536705/52985977-30645880-33c4-11e9-9055-a40d6407d53c.png)

### Control
Unique release numbers, sorted descending with "All Releases" selected by default
![image](https://user-images.githubusercontent.com/25536705/52986016-4bcf6380-33c4-11e9-8338-1c891e07f4ef.png)

### Deep Linking
Respects URL params and syncs as you change:

![image](https://user-images.githubusercontent.com/25536705/52986065-7caf9880-33c4-11e9-8375-a995632e646b.png)

### Dependencies
Note that there is no dependency on a Monolith release

### Resolves:

* [OKTA-210257](https://oktainc.atlassian.net/browse/OKTA-210257)

