### PR TITLE
Create API Docs for new Role-To-Group assignment APIs

### DIFF
--- a/_source/_docs/api/resources/roles.md
+++ b/_source/_docs/api/resources/roles.md
@@ -14,26 +14,28 @@ Explore the Administrator Roles API:  [![Run in Postman](https://run.pstmn.io/bu
 
 ## Role Assignment Operations
 
-### List Roles Assigned to User
+### List Roles
+
+#### List Roles Assigned to User
 {:.api .api-operation}
 
 {% api_operation get /api/v1/users/${userId}/roles %}
 
 Lists all roles assigned to a user.
 
-#### Request Parameters
+##### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter    | Description                                         | Param Type | DataType | Required |
 |:------------ |:--------------------------------------------------- |:---------- |:-------- |:-------- |
 | userId          | `id` of a user                                        | URL        | String   | TRUE     |
 
-#### Response Parameters
+##### Response Parameters
 {:.api .api-response .api-response-params}
 
 Array of [Role](#role-model)
 
-#### Request Example
+##### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -49,33 +51,127 @@ curl -v -X GET \
 
 ~~~json
 [
-  {
-    "id": "ra1b8aahBZuGJRRa30g4",
-    "label": "Organization Administrator",
-    "type": "ORG_ADMIN",
-    "status": "ACTIVE",
-    "created": "2015-09-06T14:55:11.000Z",
-    "lastUpdated": "2015-09-06T14:55:11.000Z"
-  },
-  {
-    "id": "IFIFAX2BIRGUSTQ",
-    "label": "Application Administrator",
-    "type": "APP_ADMIN",
-    "status": "ACTIVE",
-    "created": "2015-09-06T14:55:11.000Z",
-    "lastUpdated": "2015-09-06T14:55:11.000Z"
-  }
+    {
+        "id": "IFIFAX2BIRGUSTQ",
+        "label": "Application Administrator",
+        "type": "APP_ADMIN",
+        "status": "ACTIVE",
+        "created": "2019-02-06T16:17:40.000Z",
+        "lastUpdated": "2019-02-06T16:17:40.000Z",
+        "assignmentType": "USER",
+        "_links": {
+            "assignee": {
+                "href": "http://{yourOktaDomain}/api/v1/users/00ur32Vg0fvpyHZeQ0g3"
+            }
+        }
+    },
+    {
+        "id": "JBCUYUC7IRCVGS27IFCE2SKO",
+        "label": "Help Desk Administrator",
+        "type": "HELP_DESK_ADMIN",
+        "status": "ACTIVE",
+        "created": "2019-02-06T16:17:40.000Z",
+        "lastUpdated": "2019-02-06T16:17:40.000Z",
+        "assignmentType": "USER",
+        "_links": {
+            "assignee": {
+                "href": "http://{yourOktaDomain}/api/v1/users/00ur32Vg0fvpyHZeQ0g3"
+            }
+        }
+    },
+    {
+        "id": "ra125eqBFpETrMwu80g4",
+        "label": "Organization Administrator",
+        "type": "ORG_ADMIN",
+        "status": "ACTIVE",
+        "created": "2019-02-06T16:17:40.000Z",
+        "lastUpdated": "2019-02-06T16:17:40.000Z",
+        "assignmentType": "USER",
+        "_links": {
+            "assignee": {
+                "href": "http://{yourOktaDomain}/api/v1/users/00ur32Vg0fvpyHZeQ0g3"
+            }
+        }
+    },
+    {
+        "id": "gra25fapn1prGTBKV0g4",
+        "label": "API Access Management Administrator",
+        "type": "API_ACCESS_MANAGEMENT_ADMIN",
+        "status": "ACTIVE",
+        "created": "2019-02-06T16:20:57.000Z",
+        "lastUpdated": "2019-02-06T16:20:57.000Z",
+        "assignmentType": "GROUP",
+        "_links": {
+            "assignee": {
+                "href": "http://{yourOktaDomain}/api/v1/groups/00g1ousb3XCr9Dkr20g4"
+            }
+        }
+    }
 ]
 ~~~
 
-### Assign Role to User
+#### List Roles Assigned to Group
+{:.api .api-operation}
+
+{% api_operation get /api/v1/groups/${groupId}/roles %}
+
+Lists all roles assigned to a group.
+
+##### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter        | Description                                            | Param Type | DataType | Required |
+|:---------------- |:------------------------------------------------------ |:---------- |:-------- |:-------- |
+| groupId          | `id` of a group                                        | URL        | String   | TRUE     |
+
+##### Response Parameters
+{:.api .api-response .api-response-params}
+
+Array of [Role](#role-model)
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles"
+~~~
+
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~json
+[
+    {
+        "id": "IFIFAX2BIRGUSTQ",
+        "label": "Application Administrator",
+        "type": "APP_ADMIN",
+        "status": "ACTIVE",
+        "created": "2019-02-27T14:48:59.000Z",
+        "lastUpdated": "2019-02-27T14:48:59.000Z",
+        "assignmentType": "GROUP",
+        "_links": {
+            "assignee": {
+                "href": "http://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3"
+            }
+        }
+    }
+]
+~~~
+
+### Assign Role
+
+#### Assign Role to User
 {:.api .api-operation}
 
 {% api_operation post /api/v1/users/${userId}/roles %}
 
 Assigns a role to a user.
 
-#### Request Parameters
+##### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description            | Param Type | DataType                  | Required |
@@ -83,12 +179,12 @@ Assigns a role to a user.
 | userId       | `id` of a user           | URL        | String                    | TRUE     |
 | type      | type of role to assign | Body       | [Role Type](#role-types)  | TRUE     |
 
-#### Response Parameters
+##### Response Parameters
 {:.api .api-response .api-response-params}
 
 Assigned [Role](#role-model)
 
-#### Request Example
+##### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -101,7 +197,7 @@ curl -v -X POST \
 }' "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles"
 ~~~
 
-##### Response Example
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~json
@@ -115,14 +211,69 @@ curl -v -X POST \
 }
 ~~~
 
-### Unassign Role from User
+#### Assign Role to Group
+{:.api .api-operation}
+
+{% api_operation post /api/v1/groups/${groupId}/roles %}
+
+Assigns a role to a group.
+
+##### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter     | Description               | Param Type | DataType                  | Required |
+|:--------------|:--------------------------|:-----------|:--------------------------|:---------|
+| groupId       | `id` of a group           | URL        | String                    | TRUE     |
+| type          | type of role to assign    | Body       | [Role Type](#role-types)  | TRUE     |
+
+##### Response Parameters
+{:.api .api-response .api-response-params}
+
+Assigned [Role](#role-model)
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+-d '{
+      "type": "ORG_ADMIN"
+}' "https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles"
+~~~
+
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~json
+{
+    "id": "grasraHPx7i79ajaJ0g3",
+    "label": "Organization Administrator",
+    "type": "ORG_ADMIN",
+    "status": "ACTIVE",
+    "created": "2019-02-27T14:56:55.000Z",
+    "lastUpdated": "2019-02-27T14:56:55.000Z",
+    "assignmentType": "GROUP",
+    "_links": {
+        "assignee": {
+            "href": "http://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3"
+        }
+    }
+}
+~~~
+
+### Unassign Role
+
+#### Unassign Role from User
 {:.api .api-operation}
 
 {% api_operation delete /api/v1/users/${userId}/roles/${roleId} %}
 
 Unassigns a role from a user.
 
-#### Request Parameters
+##### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description  | Param Type | DataType | Required |
@@ -130,14 +281,14 @@ Unassigns a role from a user.
 | userId       | `id` of a user | URL        | String   | TRUE     |
 | roleId       | `id` of a role | URL        | String   | TRUE     |
 
-#### Response Parameters
+##### Response Parameters
 {:.api .api-response .api-response-params}
 
 ~~~ http
 HTTP/1.1 204 No Content
 ~~~
 
-#### Request Example
+##### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -148,7 +299,47 @@ curl -v -X DELETE \
 "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/ra1b8anIk7rx7em7L0g4"
 ~~~
 
-##### Response Example
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+#### Unassign Role from Group
+{:.api .api-operation}
+
+{% api_operation delete /api/v1/groups/${groupId}/roles/${roleId} %}
+
+Unassigns a role from a group.
+
+##### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter     | Description     | Param Type | DataType | Required |
+|:--------------|:----------------|:-----------|:---------|:---------|
+| groupId       | `id` of a group | URL        | String   | TRUE     |
+| roleId        | `id` of a role  | URL        | String   | TRUE     |
+
+##### Response Parameters
+{:.api .api-response .api-response-params}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+##### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X DELETE \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/grasraHPx7i79ajaJ0g3"
+~~~
+
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~ http
@@ -160,13 +351,15 @@ HTTP/1.1 204 No Content
 ### Group Administrator Role Group Targets
 
 #### List Group Targets for Group Administrator Role
+
+##### List Group Targets for Group Administrator Role given to a User
 {:.api .api-operation}
 
 {% api_operation get /api/v1/users/${userId}/roles/${roleId}/targets/groups %}
 
-Lists all group targets for a `USER_ADMIN` role assignment.
+Lists all group targets for a `USER_ADMIN` or `HELP_DESK_ADMIN` role assigned to a user.
 
-##### Request Parameters
+###### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description                                                  | Param Type | DataType | Required |
@@ -178,14 +371,14 @@ Lists all group targets for a `USER_ADMIN` role assignment.
 
 Treat the page cursor as an opaque value: obtain it through the next link relation. See [Pagination](/docs/api/getting_started/design_principles#pagination).
 
-##### Response Parameters
+###### Response Parameters
 {:.api .api-response .api-response-params}
 
 Array of [Groups](groups)
 
 If the role isn't scoped to specific group targets, an empty array `[]` is returned.
 
-##### Request Example
+###### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -196,7 +389,7 @@ curl -v -X GET \
 "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/groups"
 ~~~
 
-##### Response Example
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~json
@@ -234,16 +427,97 @@ curl -v -X GET \
 ]
 ~~~
 
+##### List Group Targets for Group Administrator Role given to a Group
+{:.api .api-operation}
+
+{% api_operation get /api/v1/groups/${groupId}/roles/${roleId}/targets/groups %}
+
+Lists all group targets for a `USER_ADMIN` or `HELP_DESK_ADMIN` role assigned to a group.
+
+###### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter     | Description                                                  | Param Type | DataType | Required |
+|:--------------|:-------------------------------------------------------------|:-----------|:---------|:---------|
+| groupId       | `id` of a group                                              | URL        | String   | TRUE     |
+| roleId        | `id` of a role                                               | URL        | String   | TRUE     |
+| limit         | Specifies the number of results for a page (default is 20)   | Query      | Number   | FALSE    |
+| after         | Specifies the pagination cursor for the next page of targets | Query      | String   | FALSE    |
+
+Treat the page cursor as an opaque value: obtain it through the next link relation. See [Pagination](/docs/api/getting_started/design_principles#pagination).
+
+###### Response Parameters
+{:.api .api-response .api-response-params}
+
+Array of [Groups](groups)
+
+If the role isn't scoped to specific group targets, an empty array `[]` is returned.
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/JBCUYUC7IRCVGS27IFCE2SKO/targets/groups"
+~~~
+
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~json
+[
+    {
+        "id": "00gsrc96agspOaiP40g3",
+        "created": "2019-02-27T15:19:11.000Z",
+        "lastUpdated": "2019-02-27T15:19:11.000Z",
+        "lastMembershipUpdated": "2019-02-27T15:19:11.000Z",
+        "objectClass": [
+            "okta:user_group"
+        ],
+        "type": "OKTA_GROUP",
+        "profile": {
+            "name": "userGroup0",
+            "description": null
+        },
+        "_links": {
+            "logo": [
+                {
+                    "name": "medium",
+                    "href": "http://{yourOktaDomain}/assets/img/logos/groups/okta-medium.d7fb831bc4e7e1a5d8bd35dfaf405d9e.png",
+                    "type": "image/png"
+                },
+                {
+                    "name": "large",
+                    "href": "http://{yourOktaDomain}/assets/img/logos/groups/okta-large.511fcb0de9da185b52589cb14d581c2c.png",
+                    "type": "image/png"
+                }
+            ],
+            "users": {
+                "href": "http://{yourOktaDomain}/api/v1/groups/00gsrc96agspOaiP40g3/users"
+            },
+            "apps": {
+                "href": "http://{yourOktaDomain}/api/v1/groups/00gsrc96agspOaiP40g3/apps"
+            }
+        }
+    }
+]
+~~~
+
 #### Add Group Target to Group Administrator Role
+
+##### Add Group Target to Group Administrator Role given to a User
 {:.api .api-operation}
 
 {% api_operation put /api/v1/users/${userId}/roles/${roleId}/targets/groups/${groupId} %}
 
-Adds a group target for a `USER_ADMIN` role assignment.
+Adds a group target for a `USER_ADMIN` or `HELP_DESK_ADMIN` role assigned to a user.
 
 Adding the first group target changes the scope of the role assignment from applying to all targets to only applying to the specified target.
 
-##### Request Parameters
+###### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description                                   | Param Type | DataType | Required |
@@ -252,14 +526,14 @@ Adding the first group target changes the scope of the role assignment from appl
 | roleId       | `id` of a role                                  | URL        | String   | TRUE     |
 | groupId      | `id` of group target to scope role assignment | URL        | String   | TRUE     |
 
-##### Response Parameters
+###### Response Parameters
 {:.api .api-response .api-response-params}
 
 ~~~ http
 HTTP/1.1 204 No Content
 ~~~
 
-##### Request Example
+###### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -270,7 +544,50 @@ curl -v -X PUT \
 "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/groups/00garkxjAHDYPFcsP0g4"
 ~~~
 
-##### Response Example
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+##### Add Group Target to Group Administrator Role given to a Group
+{:.api .api-operation}
+
+{% api_operation put /api/v1/users/${groupId}/roles/${roleId}/targets/groups/${targetGroupId} %}
+
+Adds a group target for a `USER_ADMIN` or `HELP_DESK_ADMIN` role assigned to a group.
+
+Adding the first group target changes the scope of the role assignment from applying to all targets to only applying to the specified target.
+
+###### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter          | Description                                   | Param Type | DataType | Required |
+|:-------------------|:----------------------------------------------|:-----------|:---------|:---------|
+| groupId            | `id` of an admin group                        | URL        | String   | TRUE     |
+| roleId             | `id` of a role                                | URL        | String   | TRUE     |
+| targetGroupId      | `id` of group target to scope role assignment | URL        | String   | TRUE     |
+
+###### Response Parameters
+{:.api .api-response .api-response-params}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X PUT \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/JBCUYUC7IRCVGS27IFCE2SKO/targets/groups/00gsrhsUaRoUib0XQ0g3"
+~~~
+
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~ http
@@ -278,15 +595,17 @@ HTTP/1.1 204 No Content
 ~~~
 
 #### Remove Group Target from Group Administrator Role
+
+##### Remove Group Target from Group Administrator Role given to a User
 {:.api .api-operation}
 
 {% api_operation delete /api/v1/users/${userId}/roles/${roleId}/targets/groups/${groupId} %}
 
-Removes a group target from a `USER_ADMIN` role assignment.
+Removes a group target from a `USER_ADMIN` or `HELP_DESK_ADMIN` role assigned to a user.
 
-Don't remove the last group target from a role assignment, as this causes an exception.  If you need a role assignment that applies to all groups, the API consumer should delete the `USER_ADMIN` role assignment and recreate it.
+> Note: Don't remove the last group target from a role assignment, as this causes an exception.  If you need a role assignment that applies to all groups, the API consumer should delete the `USER_ADMIN` role assignment and recreate it.
 
-##### Request Parameters
+###### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description                              | Param Type | DataType | Required |
@@ -295,14 +614,14 @@ Don't remove the last group target from a role assignment, as this causes an exc
 | roleId       | `id` of a role                             | URL        | String   | TRUE     |
 | groupId      | `id` of group target for role assignment | URL        | String   | TRUE     |
 
-##### Response Parameters
+###### Response Parameters
 {:.api .api-response .api-response-params}
 
 ~~~ http
 HTTP/1.1 204 No Content
 ~~~
 
-##### Request Example
+###### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -313,7 +632,50 @@ curl -v -X DELETE \
 "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/groups/00garkxjAHDYPFcsP0g4"
 ~~~
 
-##### Response Example
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+##### Remove Group Target from Group Administrator Role given to a Group
+{:.api .api-operation}
+
+{% api_operation delete /api/v1/groups/${groupId}/roles/${roleId}/targets/groups/${targetGroupId} %}
+
+Removes a group target from a `USER_ADMIN` or `HELP_DESK_ADMIN` role assigned to a group.
+
+> Note: Don't remove the last group target from a role assignment, as this causes an exception.  If you need a role assignment that applies to all groups, the API consumer should delete the `USER_ADMIN` role assignment and recreate it.
+
+###### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter     | Description                              | Param Type | DataType | Required |
+|:--------------|:-----------------------------------------|:-----------|:---------|:---------|
+| groupId       | `id` of an admin group                   | URL        | String   | TRUE     |
+| roleId        | `id` of a role                           | URL        | String   | TRUE     |
+| targetGroupId | `id` of group target for role assignment | URL        | String   | TRUE     |
+
+###### Response Parameters
+{:.api .api-response .api-response-params}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X DELETE \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/JBCUYUC7IRCVGS27IFCE2SKO/targets/groups/00gsrhsUaRoUib0XQ0g3"
+~~~
+
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~ http
@@ -323,13 +685,15 @@ HTTP/1.1 204 No Content
 ### App Administrator Role App Targets
 
 #### List App Targets for App Administrator Role
+
+##### List App Targets for App Administrator Role given to a User
 {:.api .api-operation}
 
 {% api_operation get /api/v1/users/${userId}/roles/${roleId}/targets/catalog/apps %}
 
-Lists all app targets for an `APP_ADMIN` role assignment.
+Lists all app targets for an `APP_ADMIN` role assigned to a user.
 
-##### Request Parameters
+###### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description                                                  | Param Type | DataType | Required |
@@ -341,14 +705,14 @@ Lists all app targets for an `APP_ADMIN` role assignment.
 
 Treat the page cursor as an opaque value: obtain it through the next link relation. See [Pagination](/docs/api/getting_started/design_principles#pagination)
 
-##### Response Parameters
+###### Response Parameters
 {:.api .api-response .api-response-params}
 
 Array of Catalog Apps
 
 If the role is not scoped to specific apps in the catalog, an empty array `[]` is returned.
 
-##### Request Example
+###### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -359,7 +723,7 @@ curl -v -X GET \
 "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/catalog/apps"
 ~~~
 
-##### Response Example
+###### Response Example
 {:.api .api-response .api-response-example}
 
 The example shows two applications and two instances. Note the response for instances has an `id` field.
@@ -460,18 +824,102 @@ The example shows two applications and two instances. Note the response for inst
 
 ~~~
 
+##### List App Targets for App Administrator Role given to a Group
+{:.api .api-operation}
+
+{% api_operation get /api/v1/groups/${groupId}/roles/${roleId}/targets/catalog/apps %}
+
+Lists all app targets for an `APP_ADMIN` role assigned to a group.
+
+###### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter | Description                                                  | Param Type | DataType | Required |
+|:----------|:-------------------------------------------------------------|:-----------|:---------|:---------|
+| groupId   | `id` of a group                                              | URL        | String   | TRUE     |
+| roleId    | `id` of a role                                               | URL        | String   | TRUE     |
+| limit     | Specifies the number of results for a page (default is 20)   | Query      | Number   | FALSE    |
+| after     | Specifies the pagination cursor for the next page of targets | Query      | String   | FALSE    |
+
+Treat the page cursor as an opaque value: obtain it through the next link relation. See [Pagination](/docs/api/getting_started/design_principles#pagination)
+
+###### Response Parameters
+{:.api .api-response .api-response-params}
+
+Array of Catalog Apps
+
+If the role is not scoped to specific apps in the catalog, an empty array `[]` is returned.
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X GET \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/IFIFAX2BIRGUSTQ/targets/catalog/apps"
+~~~
+
+###### Response Example
+{:.api .api-response .api-response-example}
+
+The example shows one application and one instance. Note the response for instances has an `id` field.
+
+~~~json
+[
+    {
+        "name": "facebook",
+        "displayName": "Facebook",
+        "description": "Giving people the power to share and make the world more open and connected.",
+        "status": "ACTIVE",
+        "lastUpdated": "2017-07-19T23:37:37.000Z",
+        "category": "SOCIAL",
+        "verificationStatus": "OKTA_VERIFIED",
+        "website": "http://www.facebook.com/",
+        "signOnModes": [
+            "BROWSER_PLUGIN"
+        ],
+        "_links": {
+            "logo": [
+                {
+                    "name": "medium",
+                    "href": "http://{yourOktaDomain}/assets/img/logos/facebook.e8215796628b5eaf687ba414ae245659.png",
+                    "type": "image/png"
+                }
+            ],
+            "self": {
+                "href": "http://{yourOktaDomain}/api/v1/catalog/apps/facebook"
+            }
+        }
+    },
+    {
+        "name": "24 Seven Office 0",
+        "status": "ACTIVE",
+        "id": "0oasrudLtMlzAsTxk0g3",
+        "_links": {
+            "self": {
+                "href": "http://{yourOktaDomain}/api/v1/apps/0oasrudLtMlzAsTxk0g3"
+            }
+        }
+    }
+]
+~~~
+
 #### Add App Target to App Administrator Role
+
+##### Add App Target to App Administrator Role given to a User
 {:.api .api-operation}
 
 {% api_operation put /api/v1/users/${userId}/roles/${roleId}/targets/catalog/apps/${appName} %}
 
-Adds an app target for an `APP_ADMIN` role assignment.
+Adds an app target for an `APP_ADMIN` role assigned to a user.
 
 Adding the first app target changes the scope of the role assignment from applying to all app targets to applying to the specified target.
 
 Adding an app target will override any existing instance targets of the app. For example, if someone was assigned to administer a specific Facebook instance, calling this endpoint with `facebook` for `appName`, would make them administrator for all Facebook instances.
 
-##### Request Parameters
+###### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description                                                | Param Type | DataType | Required |
@@ -480,14 +928,14 @@ Adding an app target will override any existing instance targets of the app. For
 | roleId       | `id` of a role                                               | URL        | String   | TRUE     |
 | appName   | `name` of app target from catalog to scope role assignment | URL        | String   | TRUE     |
 
-##### Response Parameters
+###### Response Parameters
 {:.api .api-response .api-response-params}
 
 ~~~ http
 HTTP/1.1 204 No Content
 ~~~
 
-##### Request Example
+###### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -498,26 +946,72 @@ curl -v -X PUT \
 "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/catalog/apps/amazon_aws"
 ~~~
 
-##### Response Example
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~ http
 HTTP/1.1 204 No Content
 ~~~
 
+##### Add App Target to App Administrator Role given to a Group
+{:.api .api-operation}
+
+{% api_operation put /api/v1/groups/${groupId}/roles/${roleId}/targets/catalog/apps/${appName} %}
+
+Adds an app target for an `APP_ADMIN` role assigned to a group.
+
+Adding the first app target changes the scope of the role assignment from applying to all app targets to applying to the specified target.
+
+Adding an app target will override any existing instance targets of the app. For example, if someone was assigned to administer a specific Facebook instance, calling this endpoint with `facebook` for `appName`, would make them administrator for all Facebook instances.
+
+###### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter | Description                                                | Param Type | DataType | Required |
+|:----------|:-----------------------------------------------------------|:-----------|:---------|:---------|
+| groupId   | `id` of a group                                            | URL        | String   | TRUE     |
+| roleId    | `id` of a role                                             | URL        | String   | TRUE     |
+| appName   | `name` of app target from catalog to scope role assignment | URL        | String   | TRUE     |
+
+###### Response Parameters
+{:.api .api-response .api-response-params}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X PUT \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/IFIFAX2BIRGUSTQ/targets/catalog/apps/amazon_aws"
+~~~
+
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
 
 #### Add App Instance Target to App Administrator Role
+
+##### Add App Instance Target to App Administrator Role given to a User
 {:.api .api-operation}
 
 {% api_operation put /api/v1/users/${userId}/roles/${roleId}/targets/catalog/apps/${appName}/${appInstanceId} %}
 
-Adds an app instance target for an `APP_ADMIN` role assignment
+Adds an app instance target for an `APP_ADMIN` role assigned to a user
 
 Adding the first app or (app instance) target changes the scope of the role assignment from applying to all app targets to applying to the specified target.
 
-App Targets and App Instance Targets cannot be mixed for the same app name. For example, you cannot specify that an administrator has access to mange Salesforce (the entire app type) and specific instances of the Salesforce app; it must be one or the other.
+App Targets and App Instance Targets cannot be mixed for the same app name. For example, you cannot specify that an administrator has access to manage Salesforce (the entire app type) and specific instances of the Salesforce app; it must be one or the other.
 
-##### Request Parameters
+###### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description                                                | Param Type | DataType | Required |
@@ -527,14 +1021,14 @@ App Targets and App Instance Targets cannot be mixed for the same app name. For 
 | appName   | `name` of app target from catalog to scope role assignment | URL        | String   | TRUE     |
 | appInstanceId   | `id` of the app instance target to scope role assignment | URL        | String   | TRUE     |
 
-##### Response Parameters
+###### Response Parameters
 {:.api .api-response .api-response-params}
 
 ~~~ http
 HTTP/1.1 204 No Content
 ~~~
 
-##### Request Example
+###### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -542,10 +1036,56 @@ curl -v -X PUT \
 -H "Accept: application/json" \
 -H "Content-Type: application/json" \
 -H "Authorization: SSWS ${api_token}" \
-"https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/catalog/apps/amazon_aws"
+"https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/catalog/apps/amazon_aws/0oasrudLtMlzAsTxk0g3"
 ~~~
 
-##### Response Example
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+##### Add App Instance Target to App Administrator Role given to a Group
+{:.api .api-operation}
+
+{% api_operation put /api/v1/groups/${groupId}/roles/${roleId}/targets/catalog/apps/${appName}/${appInstanceId} %}
+
+Adds an app instance target for an `APP_ADMIN` role assigned to a group
+
+Adding the first app or (app instance) target changes the scope of the role assignment from applying to all app targets to applying to the specified target.
+
+App Targets and App Instance Targets cannot be mixed for the same app name. For example, you cannot specify that an administrator has access to manage Salesforce (the entire app type) and specific instances of the Salesforce app; it must be one or the other.
+
+###### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter       | Description                                                | Param Type | DataType | Required |
+|:----------------|:-----------------------------------------------------------|:-----------|:---------|:---------|
+| groupId         | `id` of a group                                            | URL        | String   | TRUE     |
+| roleId          | `id` of a role                                             | URL        | String   | TRUE     |
+| appName         | `name` of app target from catalog to scope role assignment | URL        | String   | TRUE     |
+| appInstanceId   | `id` of the app instance target to scope role assignment   | URL        | String   | TRUE     |
+
+###### Response Parameters
+{:.api .api-response .api-response-params}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X PUT \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/IFIFAX2BIRGUSTQ/targets/catalog/apps/facebook/0oassqD8YkfwsJeV60g3"
+~~~
+
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~ http
@@ -553,15 +1093,17 @@ HTTP/1.1 204 No Content
 ~~~
 
 #### Remove App Target from App Administrator Role
+
+##### Remove App Target from App Administrator Role given to a User
 {:.api .api-operation}
 
 {% api_operation delete /api/v1/users/${userId}/roles/${roleId}/targets/catalog/apps/${appName} %}
 
-Removes an app target from an `APP_ADMIN` role assignment
+Removes an app target from an `APP_ADMIN` role assigned to a user
 
 > Note: Don't remove the last app target from a role assignment, as this causes an exception.  If you need a role assignment that applies to all apps, the API consumer should delete the `APP_ADMIN` role assignment and recreate it.
 
-##### Request Parameters
+###### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description                              | Param Type | DataType | Required |
@@ -570,14 +1112,14 @@ Removes an app target from an `APP_ADMIN` role assignment
 | roleId       | `id` of a role                             | URL        | String   | TRUE     |
 | appName   | `name` of app target for role assignment | URL        | String   | TRUE     |
 
-##### Response Parameters
+###### Response Parameters
 {:.api .api-response .api-response-params}
 
 ~~~ http
 HTTP/1.1 204 No Content
 ~~~
 
-##### Request Example
+###### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -588,7 +1130,50 @@ curl -v -X DELETE \
 "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/catalog/apps/amazon_aws"
 ~~~
 
-##### Response Example
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+##### Remove App Target from App Administrator Role given to a Group
+{:.api .api-operation}
+
+{% api_operation delete /api/v1/groups/${groupId}/roles/${roleId}/targets/catalog/apps/${appName} %}
+
+Removes an app target from an `APP_ADMIN` role assigned to a group
+
+> Note: Don't remove the last app target from a role assignment, as this causes an exception.  If you need a role assignment that applies to all apps, the API consumer should delete the `APP_ADMIN` role assignment and recreate it.
+
+###### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter | Description                              | Param Type | DataType | Required |
+|:----------|:-----------------------------------------|:-----------|:---------|:---------|
+| groupId   | `id` of a group                          | URL        | String   | TRUE     |
+| roleId    | `id` of a role                           | URL        | String   | TRUE     |
+| appName   | `name` of app target for role assignment | URL        | String   | TRUE     |
+
+###### Response Parameters
+{:.api .api-response .api-response-params}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X DELETE \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/IFIFAX2BIRGUSTQ/targets/catalog/apps/facebook"
+~~~
+
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~ http
@@ -596,15 +1181,17 @@ HTTP/1.1 204 No Content
 ~~~
 
 #### Remove App Instance Target from App Administrator Role
+
+##### Remove App Instance Target from App Administrator Role given to a User
 {:.api .api-operation}
 
 {% api_operation delete /api/v1/users/${userId}/roles/${roleId}/targets/catalog/apps/${appName}/${appInstanceId} %}
 
-Removes an app instance target from an `APP_ADMIN` role assignment.
+Removes an app instance target from an `APP_ADMIN` role assigned to a user.
 
 > Note: Don't remove the last app target from a role assignment, as this causes an exception.  If you need a role assignment that applies to all apps, the API consumer should delete the `APP_ADMIN` role assignment and recreate it.
 
-##### Request Parameters
+###### Request Parameters
 {:.api .api-request .api-request-params}
 
 | Parameter | Description                              | Param Type | DataType | Required |
@@ -614,14 +1201,14 @@ Removes an app instance target from an `APP_ADMIN` role assignment.
 | appName   | `name` of app target for role assignment | URL        | String   | TRUE     |
 | appInstanceId   | `id` of the app instance target for role assignment | URL        | String   | TRUE     |
 
-##### Response Parameters
+###### Response Parameters
 {:.api .api-response .api-response-params}
 
 ~~~ http
 HTTP/1.1 204 No Content
 ~~~
 
-##### Request Example
+###### Request Example
 {:.api .api-request .api-request-example}
 
 ~~~sh
@@ -632,7 +1219,51 @@ curl -v -X DELETE \
 "https://{yourOktaDomain}/api/v1/users/00u6fud33CXDPBXULRNG/roles/KVJUKUS7IFCE2SKO/targets/catalog/apps/amazon_aws"
 ~~~
 
-##### Response Example
+###### Response Example
+{:.api .api-response .api-response-example}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+##### Remove App Instance Target from App Administrator Role given to a Group
+{:.api .api-operation}
+
+{% api_operation delete /api/v1/groups/${groupId}/roles/${roleId}/targets/catalog/apps/${appName}/${appInstanceId} %}
+
+Removes an app instance target from an `APP_ADMIN` role assigned to a group.
+
+> Note: Don't remove the last app target from a role assignment, as this causes an exception.  If you need a role assignment that applies to all apps, the API consumer should delete the `APP_ADMIN` role assignment and recreate it.
+
+###### Request Parameters
+{:.api .api-request .api-request-params}
+
+| Parameter       | Description                                         | Param Type | DataType | Required |
+|:----------------|:----------------------------------------------------|:-----------|:---------|:---------|
+| groupId         | `id` of a group                                     | URL        | String   | TRUE     |
+| roleId          | `id` of a role                                      | URL        | String   | TRUE     |
+| appName         | `name` of app target for role assignment            | URL        | String   | TRUE     |
+| appInstanceId   | `id` of the app instance target for role assignment | URL        | String   | TRUE     |
+
+###### Response Parameters
+{:.api .api-response .api-response-params}
+
+~~~ http
+HTTP/1.1 204 No Content
+~~~
+
+###### Request Example
+{:.api .api-request .api-request-example}
+
+~~~sh
+curl -v -X DELETE \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-H "Authorization: SSWS ${api_token}" \
+"https://{yourOktaDomain}/api/v1/groups/00gsr2IepS8YhHRFf0g3/roles/IFIFAX2BIRGUSTQ/targets/catalog/apps/facebook/0oassqD8YkfwsJeV60g3"
+~~~
+
+###### Response Example
 {:.api .api-response .api-response-example}
 
 ~~~ http
@@ -641,16 +1272,41 @@ HTTP/1.1 204 No Content
 
 ## Role Model
 
-### Example
+### Examples
 
+#### Sample Role Assigned to the User directly
 ~~~json
 {
-  "id": "ra1b7aguRQ7e5iKYb0g4",
-  "label": "Read-only Administrator",
-  "type": "READ_ONLY_ADMIN",
-  "status": "ACTIVE",
-  "created": "2015-09-04T03:27:16.000Z",
-  "lastUpdated": "2015-09-04T03:27:16.000Z"
+    "id": "ra125eqBFpETrMwu80g4",
+    "label": "Organization Administrator",
+    "type": "ORG_ADMIN",
+    "status": "ACTIVE",
+    "created": "2019-02-06T16:17:40.000Z",
+    "lastUpdated": "2019-02-06T16:17:40.000Z",
+    "assignmentType": "USER",
+    "_links": {
+        "assignee": {
+            "href": "http://{yourOktaDomain}/api/v1/users/00ur32Vg0fvpyHZeQ0g3"
+        }
+    }
+}
+~~~
+
+#### Sample Role Assigned to the User through a Group Membership
+~~~json
+{
+    "id": "gra25fapn1prGTBKV0g4",
+    "label": "API Access Management Administrator",
+    "type": "API_ACCESS_MANAGEMENT_ADMIN",
+    "status": "ACTIVE",
+    "created": "2019-02-06T16:20:57.000Z",
+    "lastUpdated": "2019-02-06T16:20:57.000Z",
+    "assignmentType": "GROUP",
+    "_links": {
+        "assignee": {
+            "href": "http://{yourOktaDomain}/api/v1/groups/00g1ousb3XCr9Dkr20g4"
+        }
+    }
 }
 ~~~
 
@@ -658,16 +1314,17 @@ HTTP/1.1 204 No Content
 
 The role model defines several **read-only** properties:
 
-| Property    | Description                                           | DataType                                                                                                    | Nullable | Unique | Read Only |
-|:------------|:------------------------------------------------------|:------------------------------------------------------------------------------------------------------------|:---------|:-------|:----------|
-| id          | Unique key for the role assignment                    | String                                                                                                      | FALSE    | TRUE   | TRUE      |
-| label       | Display name of role                                  | String                                                                                                      | FALSE    | FALSE  | TRUE      |
-| type        | Type of role                                          | `SUPER_ADMIN`, `ORG_ADMIN`, `API_ACCESS_MANAGEMENT_ADMIN`, `APP_ADMIN`, `USER_ADMIN`, `MOBILE_ADMIN`, `READ_ONLY_ADMIN`, `HELP_DESK_ADMIN` | FALSE    | FALSE  | TRUE      |
-| status      | Status of role assignment                             | `ACTIVE`                                                                                                    | FALSE    | FALSE  | TRUE      |
-| created     | Timestamp when app user was created                   | Date                                                                                                        | FALSE    | FALSE  | TRUE      |
-| lastUpdated | Timestamp when app user was last updated              | Date                                                                                                        | FALSE    | FALSE  | TRUE      |
-| _embedded   | Embedded resources related to the role assignment     | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)                                              | TRUE     | FALSE  | TRUE      |
-| _links      | Discoverable resources related to the role assignment | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)                                              | TRUE     | FALSE  | TRUE      |
+| Property       | Description                                           | DataType                                                                                                    | Nullable | Unique | Read Only |
+|:---------------|:------------------------------------------------------|:------------------------------------------------------------------------------------------------------------|:---------|:-------|:----------|
+| id             | Unique key for the role assignment                    | String                                                                                                      | FALSE    | TRUE   | TRUE      |
+| label          | Display name of role                                  | String                                                                                                      | FALSE    | FALSE  | TRUE      |
+| type           | Type of role                                          | `SUPER_ADMIN`, `ORG_ADMIN`, `API_ACCESS_MANAGEMENT_ADMIN`, `APP_ADMIN`, `USER_ADMIN`, `MOBILE_ADMIN`, `READ_ONLY_ADMIN`, `HELP_DESK_ADMIN` | FALSE    | FALSE  | TRUE      |
+| status         | Status of role assignment                             | `ACTIVE`                                                                                                    | FALSE    | FALSE  | TRUE      |
+| assignmentType | The type of assignment                                | `USER`, `GROUP`                                                                                             | FALSE    | FALSE  | TRUE      |
+| created        | Timestamp when app user was created                   | Date                                                                                                        | FALSE    | FALSE  | TRUE      |
+| lastUpdated    | Timestamp when app user was last updated              | Date                                                                                                        | FALSE    | FALSE  | TRUE      |
+| _embedded      | Embedded resources related to the role assignment     | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)                                              | TRUE     | FALSE  | TRUE      |
+| _links         | Discoverable resources related to the role assignment | [JSON HAL](http://tools.ietf.org/html/draft-kelly-json-hal-06)                                              | TRUE     | FALSE  | TRUE      |
 
 #### Role Types
 
@@ -686,3 +1343,12 @@ Refer to the [product documentation](https://help.okta.com/en/prod/Content/Topic
 | `READ_ONLY_ADMIN` | Read-only Administrator      |                         |
 
 `API_ACCESS MANAGEMENT_ADMIN` is available if the API Access Management feature be enabled. For a description of what the role can do, see [API Access Management Best Practices](/use_cases/api_access_management/#recommended-practices-for-api-access-management).
+
+#### Assignment Types
+
+A role could either be assigned to the user directly or be assigned to a group, of which the user is a member. The `assignee` in `_links` provides more details about the user or the group to which the assignment was made.
+
+| Assignment Type   | Description                                                        |
+|:------------------|:-------------------------------------------------------------------|
+| `USER`            | Role was assigned to the user directly                             |
+| `GROUP`           | Role was assigned to an admin group, of which the user is a member |


### PR DESCRIPTION
## Description:
- Create API Docs for new Role-To-Group assignment APIs
- Fix some gaps in the existing individual role assignment APIs
- Re-structure the Role Assignment section to address both user and group assignments in parallel
- Monolith PR: https://github.com/okta/okta-core/pull/32731
(This depends on https://github.com/okta/okta.github.io/pull/2704)
* I understand we have to wait until FF is GAed before publishing these
(Screenshot: https://okta.box.com/s/yuymwkgvkrsamyyk9p63g9dzqil01rcc)

### Resolves:

* [OKTA-207769](https://oktainc.atlassian.net/browse/OKTA-207769)

cc: @okta/flm @rchild-okta 