### PR TITLE
Removed beta tag for Okta MFA Policy

### DIFF
--- a/_source/_docs/api/resources/policy.md
+++ b/_source/_docs/api/resources/policy.md
@@ -1102,8 +1102,6 @@ The following conditions may be applied to the rules associated with Okta Sign O
 ## Multifactor (MFA) Enrollment Policy
 {: #OktaMFAPolicy }
 
-> The MFA Policy API is a {% api_lifecycle beta %} release.
-
 Multifactor (MFA) Enrollment Policy controls which MFA methods are available for a user, as well as when a user may enroll in a particular factor.
 
 #### Policy Settings Example


### PR DESCRIPTION
## Description:
- Okta MFA enroll policy is in GA. 
- Doc incorrectly says it is BETA.
- https://developer.okta.com/docs/api/resources/policy#OktaMFAPolicy

### Resolves:

* [OKTA-213366](https://oktainc.atlassian.net/browse/OKTA-213366)

