### PR TITLE
Fix a Role-To-Group endpoint doc pointing to users instead

### DIFF
--- a/_source/_docs/api/resources/roles.md
+++ b/_source/_docs/api/resources/roles.md
@@ -554,7 +554,7 @@ HTTP/1.1 204 No Content
 ##### Add Group Target to Group Administrator Role given to a Group
 {:.api .api-operation}
 
-{% api_operation put /api/v1/users/${groupId}/roles/${roleId}/targets/groups/${targetGroupId} %}
+{% api_operation put /api/v1/groups/${groupId}/roles/${roleId}/targets/groups/${targetGroupId} %}
 
 Adds a group target for a `USER_ADMIN` or `HELP_DESK_ADMIN` role assigned to a group.
 


### PR DESCRIPTION
## Description:
- Fix a Role-To-Group endpoint doc pointing to users instead
- Is this PR related to a Monolith release? Yes, 2019.03.0

### Resolves:

* [OKTA-213746](https://oktainc.atlassian.net/browse/OKTA-213746)

