### PR TITLE
Update ExpressJS quickstart with new config format

### DIFF
--- a/_source/quickstart-fragments/nodejs/express-auth-code.md
+++ b/_source/quickstart-fragments/nodejs/express-auth-code.md
@@ -37,7 +37,7 @@ const oidc = new ExpressOIDC({
   issuer: 'https://{yourOktaDomain}/oauth2/default',
   client_id: '{clientId}',
   client_secret: '{clientSecret}',
-  redirect_uri: 'http://localhost:3000/authorization-code/callback',
+  appBaseUrl: 'https://localhost:8080',
   scope: 'openid profile'
 });
 


### PR DESCRIPTION
@manueltanzi-okta @swiftone  to sanity check me here.  It looks like we did not update this quickstart after we refactored the configuration options.