### PR TITLE
Document that authorization_code grant type is now allowed for browser clients

### DIFF
--- a/_source/_docs/api/resources/apps.md
+++ b/_source/_docs/api/resources/apps.md
@@ -1029,7 +1029,7 @@ Adds an OAuth 2.0 client application. This application is only available to the 
     | ----------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------- |
     | `web`             | `authorization_code`, `implicit`, `refresh_token`             | Must have at least `authorization_code`                                           |
     | `native`          | `authorization_code`, `implicit`, `password`, `refresh_token` | Must have at least `authorization_code`                                           |
-    | `browser`         | `implicit`                                                    |                                                                                   |
+    | `browser`         | `authorization_code`, `implicit`                              |                                                                                   |
     | `service`         | `client_credentials`                                          | Works with OAuth 2.0 flow (not OpenID Connect)                                    |
 
 * The `grant_types` and `response_types` values described above are partially orthogonal, as they refer to arguments passed to different

--- a/_source/_docs/api/resources/oauth-clients.md
+++ b/_source/_docs/api/resources/oauth-clients.md
@@ -229,11 +229,10 @@ Response body:
             "https://httpbin.org/get"
         ],
         "response_types": [
-            "id_token",
-            "token"
+            "code"
         ],
         "grant_types": [
-            "implicit"
+            "authorization_code"
         ],
         "token_endpoint_auth_method": "none",
         "application_type": "browser"
@@ -739,7 +738,7 @@ Property Details
     | :---------------- | :------------------------------------------------------------------------- | :--------------------------------------------- |
     | `web`             | `authorization_code`, `implicit`, `refresh_token`, `client_credentials`(*) | Must have at least `authorization_code`        |
     | `native`          | `authorization_code`, `implicit`, `password`, `refresh_token`              | Must have at least `authorization_code`        |
-    | `browser`         | `implicit`                                                                 |                                                |
+    | `browser`         | `authorization_code`, `implicit`                                           |                                                |
     | `service`         | `client_credentials`                                                       | Works with OAuth 2.0 flow (not OpenID Connect) |
 
     (*) `client_credentials` with a `web` application type allows you to use one `client_id` for an application that needs to make user-specific calls and back-end calls for data.


### PR DESCRIPTION

## Description:
- authorization_code is now a permitted grant type for browser clients
- Scheduled for, 2019.03.2 for preview, 2019.04 for production

### Resolves:

* [OKTA-197273](https://oktainc.atlassian.net/browse/OKTA-197273)

### Primary Reviewer:
@jakubvul 
@federations-okta 

![image](https://user-images.githubusercontent.com/14223650/54395089-0113d500-466c-11e9-92f8-c641dea6bf2c.png)
![image](https://user-images.githubusercontent.com/14223650/54395127-1c7ee000-466c-11e9-8f96-22bb669765f4.png)
![image](https://user-images.githubusercontent.com/14223650/54395140-299bcf00-466c-11e9-8e5b-7977ce3f9a00.png)
