### PR TITLE
Update authn.md to add resend link explanation for verify and email API's 

### DIFF
--- a/_source/_docs/api/resources/authn.md
+++ b/_source/_docs/api/resources/authn.md
@@ -4185,6 +4185,22 @@ curl -v -X POST \
 }
 ~~~
 
+##### Resend Push Notification 
+
+Use the `resend` link to send another push notification if user doesn't receive the push notification challenge or it has been expired.
+
+###### Request Example for Resend Push Notification 
+
+~~~bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-d '{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb"
+}' "https://{yourOktaDomain}/api/v1/authn/factors/opfh52xcuft3J4uZc0g3/verify/resend"
+~~~
+
+
 ##### Response Example (Approved)
 {:.api .api-response .api-response-example}
 
@@ -4285,6 +4301,21 @@ curl -v -X POST \
 }
 ~~~
 
+##### Resend Push Notification in case of Rejection
+
+Use the `resend` link to send another push notification if notification gets rejected.
+
+###### Request Example for Resend Push Notification in case of Rejection
+
+~~~bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-d '{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb"
+}' "https://{yourOktaDomain}/api/v1/authn/factors/opfh52xcuft3J4uZc0g3/verify/resend"
+~~~
+
 ##### Response Example (Timeout)
 {:.api .api-response .api-response-example}
 
@@ -4358,6 +4389,21 @@ curl -v -X POST \
     ]
   }
 }
+~~~
+
+##### Resend Push Notification in case of Timeout
+
+Use the `resend` link to send another push notification if notification gets timed out.
+
+###### Request Example for Resend Push Notification in case of Timeout
+
+~~~bash
+curl -v -X POST \
+-H "Accept: application/json" \
+-H "Content-Type: application/json" \
+-d '{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb"
+}' "https://{yourOktaDomain}/api/v1/authn/factors/opfh52xcuft3J4uZc0g3/verify/resend"
 ~~~
 
 #### Verify Duo Factor

--- a/_source/_docs/api/resources/authn.md
+++ b/_source/_docs/api/resources/authn.md
@@ -4185,22 +4185,6 @@ curl -v -X POST \
 }
 ~~~
 
-##### Resend Push Notification 
-
-Use the `resend` link to send another push notification if user doesn't receive the push notification challenge or it has been expired.
-
-###### Request Example for Resend Push Notification 
-
-~~~bash
-curl -v -X POST \
--H "Accept: application/json" \
--H "Content-Type: application/json" \
--d '{
-  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb"
-}' "https://{yourOktaDomain}/api/v1/authn/factors/opfh52xcuft3J4uZc0g3/verify/resend"
-~~~
-
-
 ##### Response Example (Approved)
 {:.api .api-response .api-response-example}
 
@@ -4301,21 +4285,6 @@ curl -v -X POST \
 }
 ~~~
 
-##### Resend Push Notification in case of Rejection
-
-Use the `resend` link to send another push notification if notification gets rejected.
-
-###### Request Example for Resend Push Notification in case of Rejection
-
-~~~bash
-curl -v -X POST \
--H "Accept: application/json" \
--H "Content-Type: application/json" \
--d '{
-  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb"
-}' "https://{yourOktaDomain}/api/v1/authn/factors/opfh52xcuft3J4uZc0g3/verify/resend"
-~~~
-
 ##### Response Example (Timeout)
 {:.api .api-response .api-response-example}
 
@@ -4391,11 +4360,11 @@ curl -v -X POST \
 }
 ~~~
 
-##### Resend Push Notification in case of Timeout
+##### Resend Push Notification
 
-Use the `resend` link to send another push notification if notification gets timed out.
+Use the `resend` link to send another push notification if user doesn't receive the push notification challenge or it has been expired, timed out or rejected.
 
-###### Request Example for Resend Push Notification in case of Timeout
+###### Request Example for Resend Push Notification
 
 ~~~bash
 curl -v -X POST \


### PR DESCRIPTION
## Description:
This ticket is to document /api/v1/authn/factors/<factorIdOrFactorType>/verify/resend for Email and Verify Push (in addition to SMS and Call). Currently, the resend link shows up in some response examples, but they are not explained.


### Resolves:

* [OKTA-213500](https://oktainc.atlassian.net/browse/OKTA-213500)

